### PR TITLE
Updates project ownership and CI dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Get version from CMake
@@ -66,7 +66,7 @@ jobs:
           $folder = "build/QontrolPanel"
           Compress-Archive -Path $folder -DestinationPath $zipFile
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: QontrolPanel_win64_msvc2022
           path: build/QontrolPanel_win64_msvc2022.zip
@@ -90,7 +90,7 @@ jobs:
           $env:Path += ";${env:ProgramFiles(x86)}\Inno Setup 6"
           iscc.exe tools/installer.iss
       - name: Upload Installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: QontrolPanel_Installer
           path: tools/Output/QontrolPanel_Installer.exe

--- a/.github/workflows/compile_translations.yml
+++ b/.github/workflows/compile_translations.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -29,7 +29,7 @@ jobs:
           cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       workflow_run_id:
-        description: 'Build workflow run ID (optional - will use latest successful run if not provided)'
+        description: "Build workflow run ID (optional - will use latest successful run if not provided)"
         required: false
 
 jobs:
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get version from CMake
         id: cmake_version
         uses: DarwinInnovation/cmake-project-version-action@v1.0
 
       - name: Download Windows artifact
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@v20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build.yml
@@ -28,7 +28,7 @@ jobs:
           if_no_artifact_found: fail
 
       - name: Download Windows Installer
-        uses: dawidd6/action-download-artifact@v9
+        uses: dawidd6/action-download-artifact@v20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           VERSION="${{ steps.cmake_version.outputs.version }}"
           echo "Creating release for version: $VERSION"
-          
+
           git tag $VERSION
           git push origin $VERSION
           echo "new_tag=$VERSION" >> $GITHUB_ENV
@@ -71,8 +71,8 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: QontrolPanel_Installer.exe 
-          asset_name: QontrolPanel_Installer.exe  
+          asset_path: QontrolPanel_Installer.exe
+          asset_name: QontrolPanel_Installer.exe
           asset_content_type: application/vnd.microsoft.portable-executable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to publish (e.g., 1.10.4)'
+        description: "Release tag to publish (e.g., 1.10.4)"
         required: true
 jobs:
   publish:
@@ -14,7 +14,7 @@ jobs:
       - name: Publish to WinGet
         uses: vedantmgoyal9/winget-releaser@v2
         with:
-          identifier: Odizinne.QontrolPanel
+          identifier: ChrisLauinger77.QontrolPanel
           release-tag: ${{ inputs.release_tag || github.event.release.tag_name }}
           installers-regex: 'QontrolPanel_Installer\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.11.2 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.12.0 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)
@@ -201,7 +201,7 @@ set_source_files_properties(${QML_SINGLETONS}
 )
 
 qt_add_qml_module(QontrolPanel
-    URI Odizinne.QontrolPanel
+    URI ChrisLauinger77.QontrolPanel
     VERSION 1.0
     QML_FILES ${QML_FILES} ${QML_SINGLETONS}
 )

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # QontrolPanel
 
-[![Version](https://img.shields.io/github/v/release/odizinne/qontrolpanel)]()
-[![Github All Releases](https://img.shields.io/github/downloads/odizinne/qontrolpanel/total.svg)]()
-[![license](https://img.shields.io/github/license/odizinne/qontrolpanel)]()
+[![Version](https://img.shields.io/github/v/release/ChrisLauinger77/qontrolpanel)]()
+[![Github All Releases](https://img.shields.io/github/downloads/ChrisLauinger77/qontrolpanel/total.svg)]()
+[![license](https://img.shields.io/github/license/ChrisLauinger77/qontrolpanel)]()
 
 QontrolPanel is an enhanced audio panel for Windows.  
-It provide output and input volume / device / mute control as well as application volume mixer.  
+It provide output and input volume / device / mute control as well as application volume mixer.
 
 ![image](.assets/screenshot.png)
 
 If you like my work, please consider supporting me:
 
-<a href="https://ko-fi.com/odizinne" target="_blank">
+<a href="https://ko-fi.com/ChrisLauinger77" target="_blank">
   <img src="https://cdn.prod.website-files.com/5c14e387dab576fe667689cf/670f5a01cf2da94a032117b9_support_me_on_kofi_red-p-500.png" alt="Support me on Ko-fi" width="25%">
-</a>  
+</a>
 
 ## Usage
 
@@ -28,11 +28,11 @@ Translators should have a look [here](.github/TRANSLATIONS.md).
 
 ### Winget
 
-`winget install Odizinne.QontrolPanel`
+`winget install ChrisLauinger77.QontrolPanel`
 
 ### Manual
 
-Download latest version [here](https://github.com/Odizinne/QontrolPanel/releases/latest).  
+Download latest version [here](https://github.com/ChrisLauinger77/QontrolPanel/releases/latest).  
 Use the provided installer or download the archive, extract it, and run `bin/QontrolPanel.exe`.
 
 ## Build the project
@@ -40,6 +40,7 @@ Use the provided installer or download the archive, extract it, and run `bin/Qon
 See [here](.github/BUILDING.md).
 
 ## Credits
+
 - Used OCEAN sound effects from KDE
 - Used icons from FlatIcon and VeryIcon
 - Application icon from [Yogi Aprelliyanto](https://www.flaticon.com/authors/yogi-aprelliyanto)

--- a/i18n_compiled/translation_progress.json
+++ b/i18n_compiled/translation_progress.json
@@ -7,12 +7,12 @@
   "en": {
     "percentage": 100,
     "last_updated": "2026-04-07 15:19:25 ",
-    "contributor": "Odizinne"
+    "contributor": "ChrisLauinger77"
   },
   "fr": {
     "percentage": 90,
     "last_updated": "2025-12-20 11:47:12 +0100",
-    "contributor": "Odizinne"
+    "contributor": "ChrisLauinger77"
   },
   "ko": {
     "percentage": 100,
@@ -32,7 +32,7 @@
   "pl": {
     "percentage": 89,
     "last_updated": "2026-04-06 18:48:41 +0200",
-    "contributor": "Odizinne"
+    "contributor": "ChrisLauinger77"
   },
   "de": {
     "percentage": 99,

--- a/qml/ChatMixNotification.qml
+++ b/qml/ChatMixNotification.qml
@@ -3,7 +3,7 @@ import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Controls.impl
 import QtQuick.Window
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ApplicationWindow {
     id: notificationWindow

--- a/qml/Common/ApplicationsListView.qml
+++ b/qml/Common/ApplicationsListView.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Rectangle {
     id: root

--- a/qml/Common/Card.qml
+++ b/qml/Common/Card.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 import QtQuick.Controls.impl
 
 Rectangle {

--- a/qml/Common/CustomScrollView.qml
+++ b/qml/Common/CustomScrollView.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ScrollView {
     id: control

--- a/qml/Common/DevicesListView.qml
+++ b/qml/Common/DevicesListView.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Rectangle {
     id: root

--- a/qml/Common/ProgressSlider.qml
+++ b/qml/Common/ProgressSlider.qml
@@ -5,7 +5,7 @@ import QtQuick
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Controls.FluentWinUI3.impl as Impl
 import QtQuick.Templates as T
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 NFSlider {
     id: control

--- a/qml/ConfirmPowerActionDialog.qml
+++ b/qml/ConfirmPowerActionDialog.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Dialog {
     id: dialog

--- a/qml/DonatePopup.qml
+++ b/qml/DonatePopup.qml
@@ -1,6 +1,6 @@
 import QtQuick.Controls.FluentWinUI3
 import QtQuick
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 Dialog {
     id: donatePopup
     modal: true
@@ -24,7 +24,7 @@ Dialog {
             highlighted: true
             DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
             onClicked: {
-                Qt.openUrlExternally("https://ko-fi.com/odizinne")
+                Qt.openUrlExternally("https://ko-fi.com/ChrisLauinger77")
                 donatePopup.close()
             }
         }

--- a/qml/ExecutableRenameContextMenu.qml
+++ b/qml/ExecutableRenameContextMenu.qml
@@ -1,5 +1,5 @@
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Menu {
     id: executableRenameContextMenu

--- a/qml/ExecutableRenameDialog.qml
+++ b/qml/ExecutableRenameDialog.qml
@@ -1,7 +1,7 @@
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Layouts
 import QtQuick
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Dialog {
     id: executableRenameDialog

--- a/qml/IntroWindow.qml
+++ b/qml/IntroWindow.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ApplicationWindow {
     id: introWindow

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Controls.impl
 import QtQuick.Window
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 import Qt.labs.platform as Platform
 
 ApplicationWindow {

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     id: mediaLayout

--- a/qml/MediaOverlay.qml
+++ b/qml/MediaOverlay.qml
@@ -3,7 +3,7 @@ import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Controls.impl
 import QtQuick.Window
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ApplicationWindow {
     id: mediaOverlayWindow

--- a/qml/PanelFooter.qml
+++ b/qml/PanelFooter.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Controls.impl
 import QtQuick.Layouts
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Rectangle {
     id: footer

--- a/qml/PowerConfirmationWindow.qml
+++ b/qml/PowerConfirmationWindow.qml
@@ -1,5 +1,5 @@
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 import QtQuick
 
 ApplicationWindow {

--- a/qml/PowerMenu.qml
+++ b/qml/PowerMenu.qml
@@ -1,5 +1,5 @@
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Menu {
     id: powerMenu

--- a/qml/SettingsPane/AppearancePane.qml
+++ b/qml/SettingsPane/AppearancePane.qml
@@ -1,7 +1,7 @@
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Layouts
 import QtQuick
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/CommAppsPane.qml
+++ b/qml/SettingsPane/CommAppsPane.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     id: lyt

--- a/qml/SettingsPane/ComponentsPane.qml
+++ b/qml/SettingsPane/ComponentsPane.qml
@@ -2,7 +2,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/ConsolePane.qml
+++ b/qml/SettingsPane/ConsolePane.qml
@@ -2,7 +2,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     id: logViewer

--- a/qml/SettingsPane/DebugPane.qml
+++ b/qml/SettingsPane/DebugPane.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/DeviceRenamingPane.qml
+++ b/qml/SettingsPane/DeviceRenamingPane.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/GeneralPane.qml
+++ b/qml/SettingsPane/GeneralPane.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/LanguagePane.qml
+++ b/qml/SettingsPane/LanguagePane.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/MediaOverlayPane.qml
+++ b/qml/SettingsPane/MediaOverlayPane.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3

--- a/qml/SettingsPane/ShortcutsPane.qml
+++ b/qml/SettingsPane/ShortcutsPane.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     id: lyt

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -3,7 +3,7 @@ pragma ComponentBehavior: Bound
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Layouts
 import QtQuick
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 ApplicationWindow {
     id: root

--- a/qml/Singletons/Constants.qml
+++ b/qml/Singletons/Constants.qml
@@ -1,7 +1,7 @@
 pragma Singleton
 import QtQuick
 import QtQuick.Controls.FluentWinUI3
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Item {
     id: constants

--- a/qml/Singletons/Context.qml
+++ b/qml/Singletons/Context.qml
@@ -1,7 +1,7 @@
 pragma Singleton
 
 import QtQuick
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 QtObject {
     signal easterEggRequested()

--- a/qml/Singletons/LogBridge.qml
+++ b/qml/Singletons/LogBridge.qml
@@ -1,6 +1,6 @@
 pragma Singleton
 import QtQuick
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Item {
     id: logBridge

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import Qt.labs.platform as Platform
-import Odizinne.QontrolPanel
+import ChrisLauinger77.QontrolPanel
 
 Platform.SystemTrayIcon {
     id: systemTray

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
 
     QApplication a(argc, argv);
     a.setQuitOnLastWindowClosed(false);
-    a.setOrganizationName("Odizinne");
+    a.setOrganizationName("ChrisLauinger77");
     a.setApplicationName("QontrolPanel");
     qRegisterMetaType<LogManager::LogType>("LogType");
     LOG_INFO("Core", "Starting application");

--- a/src/panelengine.cpp
+++ b/src/panelengine.cpp
@@ -56,7 +56,7 @@ void PanelEngine::initializeQMLEngine()
     }
 
     engine = new QQmlApplicationEngine(this);
-    engine->loadFromModule("Odizinne.QontrolPanel", "Main");
+    engine->loadFromModule("ChrisLauinger77.QontrolPanel", "Main");
 
     if (!engine->rootObjects().isEmpty()) {
         panelWindow = qobject_cast<QWindow*>(engine->rootObjects().constFirst());

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -81,7 +81,7 @@ void Updater::checkForUpdates()
     // Clear previous release notes
     setReleaseNotes("");
 
-    QString urlString = "https://api.github.com/repos/Odizinne/QontrolPanel/releases/latest";
+    QString urlString = "https://api.github.com/repos/ChrisLauinger77/QontrolPanel/releases/latest";
     QUrl url{urlString};
     QNetworkRequest request{url};
     request.setHeader(QNetworkRequest::UserAgentHeader, "QontrolPanel-Updater");

--- a/src/usersettings.cpp
+++ b/src/usersettings.cpp
@@ -26,13 +26,13 @@ UserSettings* UserSettings::instance()
 
 void UserSettings::saveValue(const QString &key, const QVariant &value)
 {
-    QSettings settings("Odizinne", "QontrolPanel");
+    QSettings settings("ChrisLauinger77", "QontrolPanel");
     settings.setValue(key, value);
 }
 
 void UserSettings::initProperties()
 {
-    QSettings settings("Odizinne", "QontrolPanel");
+    QSettings settings("ChrisLauinger77", "QontrolPanel");
 
     m_enableDeviceManager = settings.value("enableDeviceManager", true).toBool();
     m_enableApplicationMixer = settings.value("enableApplicationMixer", true).toBool();

--- a/src/windows_metadata.rc.in
+++ b/src/windows_metadata.rc.in
@@ -17,7 +17,7 @@ BEGIN
             VALUE "FileVersion", "@PROJECT_VERSION@"
             VALUE "ProductName", "@PROJECT_NAME@"
             VALUE "ProductVersion", "@PROJECT_VERSION@"
-            VALUE "LegalCopyright", "© 2025 Odizinne"
+            VALUE "LegalCopyright", "© 2025 ChrisLauinger77"
         END
     END
     BLOCK "VarFileInfo"

--- a/tools/analyze_translations.py
+++ b/tools/analyze_translations.py
@@ -299,11 +299,11 @@ def main():
             translation_progress[language_code] = {
                 'percentage': 100,
                 'last_updated': current_date,
-                'contributor': 'Odizinne'
+                'contributor': 'ChrisLauinger77'
             }
             print(f"  {language_code}: 100% (English - source language)", flush=True)
             print(f"    Last updated: {current_date}", flush=True)
-            print(f"    Contributor: Odizinne", flush=True)
+            print(f"    Contributor: ChrisLauinger77", flush=True)
             continue
 
         stats = analyze_ts_file(ts_file)

--- a/tools/installer.iss
+++ b/tools/installer.iss
@@ -7,8 +7,8 @@
 #define                BuildVersion
 #define TempVersion    GetVersionComponents(AppSourceDir + "bin\" + AppExeName, MajorVersion, MinorVersion, RevisionVersion, BuildVersion)
 #define AppVersion     str(MajorVersion) + "." + str(MinorVersion) + "." + str(RevisionVersion)
-#define AppPublisher  "Odizinne"
-#define AppURL        "https://github.com/Odizinne/QontrolPanel"
+#define AppPublisher  "ChrisLauinger77"
+#define AppURL        "https://github.com/ChrisLauinger77/QontrolPanel"
 #define AppIcon       "..\Resources\icons\icon.ico"
 #define CurrentYear   GetDateTimeString('yyyy','','')
 


### PR DESCRIPTION
Updates project references to reflect new ownership:
- Migrates internal QML module URIs, application organization name, and copyright information.
- Adjusts external links in the README, updater, and installer scripts to the new repository and publisher.
- Changes the WinGet package identifier to align with the new ownership.

Increments the project version to 1.12.0.

Upgrades GitHub Actions to their latest major versions:
- Enhances workflow stability, security, and leverages new features across build, translation, and release pipelines.