### PR TITLE
Display device name in system tray tooltip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.11.4 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.11.5 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -69,14 +69,14 @@ Platform.SystemTrayIcon {
             return baseTooltip;
         }
 
-        var batteryText = "\n\n";
+        var batteryText = "\n" + "🎧" + HeadsetControlBridge.deviceName + "\n";
 
         if (HeadsetControlBridge.batteryStatus === "BATTERY_CHARGING") {
             batteryText += "⚡︎"
-        } else {
-            batteryText += "🔋";
-            batteryText += HeadsetControlBridge.batteryLevel + "%";
         }
+
+        batteryText += "🔋";
+            batteryText += HeadsetControlBridge.batteryLevel + "%";
 
         return baseTooltip + batteryText;
     }


### PR DESCRIPTION
Updates the system tray battery text to include the name of the connected headset, providing clearer context for the displayed status.
