### PR TITLE
Add test mode for HeadsetControl simulation

### DIFF
--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -674,6 +674,54 @@ You can enable it in the General tab.</source>
         <source>Charging</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Enable test mode below to simulate a supported headset and validate the HeadsetControl UI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl test mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Simulate a supported headset for testing. This stays enabled until the app closes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Test headset profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which synthetic headset scenario HeadsetControl should simulate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1 - Error conditions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2 - Charging battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>3 - Basic battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>4 - Battery unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>5 - Timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>6 - Full battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>7 - Low battery</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>IntroWindow</name>

--- a/include/headsetcontrolbridge.h
+++ b/include/headsetcontrolbridge.h
@@ -17,6 +17,8 @@ class HeadsetControlBridge : public QObject
     Q_PROPERTY(QString batteryStatus READ batteryStatus NOTIFY batteryStatusChanged)
     Q_PROPERTY(int batteryLevel READ batteryLevel NOTIFY batteryLevelChanged)
     Q_PROPERTY(bool anyDeviceFound READ anyDeviceFound NOTIFY anyDeviceFoundChanged)
+    Q_PROPERTY(bool testModeEnabled READ testModeEnabled NOTIFY testModeEnabledChanged)
+    Q_PROPERTY(int testProfile READ testProfile NOTIFY testProfileChanged)
 
 public:
     explicit HeadsetControlBridge(QObject *parent = nullptr);
@@ -29,6 +31,8 @@ public:
     Q_INVOKABLE void setLights(bool enabled);
     Q_INVOKABLE void setSidetone(int value);
     Q_INVOKABLE void setFetchRate(int seconds);
+    Q_INVOKABLE void setTestModeEnabled(bool enabled);
+    Q_INVOKABLE void setTestProfile(int profile);
 
     bool hasSidetoneCapability() const;
     bool hasLightsCapability() const;
@@ -36,6 +40,8 @@ public:
     QString batteryStatus() const;
     int batteryLevel() const;
     bool anyDeviceFound() const;
+    bool testModeEnabled() const;
+    int testProfile() const;
 
 signals:
     void capabilitiesChanged();
@@ -43,6 +49,8 @@ signals:
     void batteryStatusChanged();
     void batteryLevelChanged();
     void anyDeviceFoundChanged();
+    void testModeEnabledChanged();
+    void testProfileChanged();
     void lowHeadsetBattery();
 
 private slots:
@@ -51,6 +59,8 @@ private slots:
     void onMonitorBatteryStatusChanged();
     void onMonitorBatteryLevelChanged();
     void onMonitorAnyDeviceFoundChanged();
+    void onMonitorTestModeEnabledChanged();
+    void onMonitorTestProfileChanged();
 
 private:
     static HeadsetControlBridge* m_instance;

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -38,6 +38,8 @@ public:
     QString batteryStatus() const { return m_batteryStatus; }
     int batteryLevel() const { return m_batteryLevel; }
     bool anyDeviceFound() const { return m_anyDeviceFound; }
+    bool testModeEnabled() const { return m_testModeEnabled; }
+    int testProfile() const { return m_testProfile; }
 
 public slots:
     void startMonitoring();
@@ -45,6 +47,8 @@ public slots:
     void setLights(bool enabled);
     void setSidetone(int value);
     void setFetchInterval(int intervalMs);
+    void setTestModeEnabled(bool enabled);
+    void setTestProfile(int profile);
 
 signals:
     void headsetDataUpdated(const QList<HeadsetControlDevice>& devices);
@@ -54,11 +58,14 @@ signals:
     void batteryStatusChanged();
     void batteryLevelChanged();
     void anyDeviceFoundChanged();
+    void testModeEnabledChanged();
+    void testProfileChanged();
 
 private slots:
     void fetchHeadsetInfo();
 
 private:
+    void applyTestDeviceConfiguration();
     void updateDeviceCache();
     void updateCapabilities();
     QString batteryStatusToString(battery_status status) const;
@@ -78,4 +85,6 @@ private:
     int m_batteryLevel;
     bool m_anyDeviceFound;
     bool m_isFetching;
+    bool m_testModeEnabled;
+    int m_testProfile;
 };

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -7,6 +7,15 @@ import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
     spacing: 3
+    readonly property var testProfiles: [
+        qsTr("1 - Error conditions"),
+        qsTr("2 - Charging battery"),
+        qsTr("3 - Basic battery"),
+        qsTr("4 - Battery unavailable"),
+        qsTr("5 - Timeout"),
+        qsTr("6 - Full battery"),
+        qsTr("7 - Low battery")
+    ]
 
     Label {
         text: HeadsetControlBridge.deviceName
@@ -34,6 +43,41 @@ ColumnLayout {
             ColumnLayout {
                 width: parent.width
                 spacing: 3
+
+                Card {
+                    Layout.fillWidth: true
+                    visible: !HeadsetControlBridge.anyDeviceFound && UserSettings.headsetcontrolMonitoring && !HeadsetControlBridge.testModeEnabled
+                    title: qsTr("No compatible device found.")
+                    description: qsTr("Enable test mode below to simulate a supported headset and validate the HeadsetControl UI.")
+                }
+
+                Card {
+                    Layout.fillWidth: true
+                    visible: UserSettings.headsetcontrolMonitoring && (!HeadsetControlBridge.anyDeviceFound || HeadsetControlBridge.testModeEnabled)
+                    title: qsTr("HeadsetControl test mode")
+                    description: qsTr("Simulate a supported headset for testing. This stays enabled until the app closes.")
+
+                    additionalControl: LabeledSwitch {
+                        checked: HeadsetControlBridge.testModeEnabled
+                        onClicked: HeadsetControlBridge.setTestModeEnabled(checked)
+                    }
+                }
+
+                Card {
+                    Layout.fillWidth: true
+                    visible: UserSettings.headsetcontrolMonitoring && (!HeadsetControlBridge.anyDeviceFound || HeadsetControlBridge.testModeEnabled)
+                    title: qsTr("Test headset profile")
+                    description: qsTr("Choose which synthetic headset scenario HeadsetControl should simulate.")
+                    enabled: HeadsetControlBridge.testModeEnabled
+
+                    additionalControl: CustomComboBox {
+                        Layout.preferredHeight: 35
+                        model: testProfiles
+                        currentIndex: Math.max(0, HeadsetControlBridge.testProfile - 1)
+                        enabled: HeadsetControlBridge.testModeEnabled
+                        onActivated: HeadsetControlBridge.setTestProfile(currentIndex + 1)
+                    }
+                }
 
                 Card {
                     Layout.fillWidth: true
@@ -129,8 +173,8 @@ ColumnLayout {
         Label {
             anchors.centerIn: parent
             opacity: 0.5
-            text: UserSettings.headsetcontrolMonitoring ? qsTr("No compatible device found.") : qsTr("HeadsetControl monitoring is disabled\nYou can enable it in the General tab.")
-            visible: !HeadsetControlBridge.anyDeviceFound || !UserSettings.headsetcontrolMonitoring
+            text: qsTr("HeadsetControl monitoring is disabled\nYou can enable it in the General tab.")
+            visible: !UserSettings.headsetcontrolMonitoring
             horizontalAlignment: Text.AlignHCenter
         }
     }

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -10,6 +10,10 @@ HeadsetControlBridge::HeadsetControlBridge(QObject *parent)
     : QObject(parent)
 {
     m_instance = this;
+    connect(UserSettings::instance(), &UserSettings::headsetcontrolMonitoringChanged,
+            this, [this]() {
+                setMonitoringEnabled(UserSettings::instance()->headsetcontrolMonitoring());
+            });
     QTimer::singleShot(100, this, &HeadsetControlBridge::connectToMonitor);
 }
 
@@ -53,6 +57,10 @@ void HeadsetControlBridge::connectToMonitor()
                 this, &HeadsetControlBridge::onMonitorBatteryLevelChanged);
         connect(monitor, &HeadsetControlMonitor::anyDeviceFoundChanged,
                 this, &HeadsetControlBridge::onMonitorAnyDeviceFoundChanged);
+        connect(monitor, &HeadsetControlMonitor::testModeEnabledChanged,
+            this, &HeadsetControlBridge::onMonitorTestModeEnabledChanged);
+        connect(monitor, &HeadsetControlMonitor::testProfileChanged,
+            this, &HeadsetControlBridge::onMonitorTestProfileChanged);
 
         int fetchRateSeconds = UserSettings::instance()->headsetcontrolFetchRate();
         int fetchRateMs = fetchRateSeconds * 1000;
@@ -68,6 +76,8 @@ void HeadsetControlBridge::connectToMonitor()
         emit batteryStatusChanged();
         emit batteryLevelChanged();
         emit anyDeviceFoundChanged();
+        emit testModeEnabledChanged();
+        emit testProfileChanged();
     } else {
         QTimer::singleShot(200, this, &HeadsetControlBridge::connectToMonitor);
     }
@@ -149,6 +159,18 @@ bool HeadsetControlBridge::anyDeviceFound() const
     return monitor ? monitor->anyDeviceFound() : false;
 }
 
+bool HeadsetControlBridge::testModeEnabled() const
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    return monitor ? monitor->testModeEnabled() : false;
+}
+
+int HeadsetControlBridge::testProfile() const
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    return monitor ? monitor->testProfile() : 1;
+}
+
 void HeadsetControlBridge::onMonitorCapabilitiesChanged()
 {
     emit capabilitiesChanged();
@@ -185,6 +207,16 @@ void HeadsetControlBridge::onMonitorAnyDeviceFoundChanged()
     emit anyDeviceFoundChanged();
 }
 
+void HeadsetControlBridge::onMonitorTestModeEnabledChanged()
+{
+    emit testModeEnabledChanged();
+}
+
+void HeadsetControlBridge::onMonitorTestProfileChanged()
+{
+    emit testProfileChanged();
+}
+
 void HeadsetControlBridge::setFetchRate(int seconds)
 {
     HeadsetControlMonitor* monitor = findMonitor();
@@ -192,5 +224,23 @@ void HeadsetControlBridge::setFetchRate(int seconds)
         int intervalMs = seconds * 1000;
         QMetaObject::invokeMethod(monitor, "setFetchInterval", Qt::QueuedConnection,
                                   Q_ARG(int, intervalMs));
+    }
+}
+
+void HeadsetControlBridge::setTestModeEnabled(bool enabled)
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        QMetaObject::invokeMethod(monitor, "setTestModeEnabled", Qt::QueuedConnection,
+                                  Q_ARG(bool, enabled));
+    }
+}
+
+void HeadsetControlBridge::setTestProfile(int profile)
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        QMetaObject::invokeMethod(monitor, "setTestProfile", Qt::QueuedConnection,
+                                  Q_ARG(int, profile));
     }
 }

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -14,6 +14,8 @@ HeadsetControlMonitor::HeadsetControlMonitor(QObject *parent)
     , m_batteryLevel(-1)
     , m_anyDeviceFound(false)
     , m_isFetching(false)
+    , m_testModeEnabled(false)
+    , m_testProfile(1)
 {
     LOG_INFO("HeadsetControlManager",
                                     QString("HeadsetControlMonitor initialized - Library version: %1")
@@ -44,6 +46,7 @@ void HeadsetControlMonitor::startMonitoring()
                                     QString("Starting headset monitoring (fetch interval: %1ms)").arg(m_fetchIntervalMs));
 
     m_isMonitoring = true;
+    applyTestDeviceConfiguration();
     m_fetchTimer->start();
     fetchHeadsetInfo();
 
@@ -161,6 +164,8 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
     m_isFetching = true;
 
     try {
+        applyTestDeviceConfiguration();
+
         // Discover headsets
         m_headsets = headsetcontrol::discover();
 
@@ -185,6 +190,7 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
                 emit anyDeviceFoundChanged();
             }
             emit headsetDataUpdated(m_cachedDevices);
+            m_isFetching = false;
             return;
         }
 
@@ -362,4 +368,43 @@ void HeadsetControlMonitor::setFetchInterval(int intervalMs)
 
     LOG_INFO("HeadsetControlManager",
                                     QString("Fetch interval updated to %1ms").arg(m_fetchIntervalMs));
+}
+
+void HeadsetControlMonitor::setTestModeEnabled(bool enabled)
+{
+    if (m_testModeEnabled == enabled) {
+        return;
+    }
+
+    m_testModeEnabled = enabled;
+    applyTestDeviceConfiguration();
+    emit testModeEnabledChanged();
+
+    if (m_isMonitoring) {
+        fetchHeadsetInfo();
+    }
+}
+
+void HeadsetControlMonitor::setTestProfile(int profile)
+{
+    int sanitizedProfile = qBound(1, profile, 7);
+    if (m_testProfile == sanitizedProfile) {
+        return;
+    }
+
+    m_testProfile = sanitizedProfile;
+    applyTestDeviceConfiguration();
+    emit testProfileChanged();
+
+    if (m_testModeEnabled && m_isMonitoring) {
+        fetchHeadsetInfo();
+    }
+}
+
+void HeadsetControlMonitor::applyTestDeviceConfiguration()
+{
+    headsetcontrol::enableTestDevice(m_testModeEnabled);
+    if (m_testModeEnabled) {
+        headsetcontrol::setTestProfile(m_testProfile);
+    }
 }


### PR DESCRIPTION
Introduces a test mode in the settings pane that allows for simulating various headset states, such as specific battery levels and error conditions. This enables developers to validate UI behavior and status reporting without requiring physical hardware.
