### PR TITLE
Improves Headset Monitoring & Battery Status

### DIFF
--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -18,7 +18,7 @@ struct HeadsetControlDevice {
     int batteryLevel;       // -1 - 100
     QStringList capabilities;
 
-    HeadsetControlDevice() : batteryLevel(0) {}
+    HeadsetControlDevice() : batteryLevel(-1) {}
 };
 Q_DECLARE_METATYPE(HeadsetControlDevice)
 

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -8,6 +8,7 @@ import ChrisLauinger77.QontrolPanel
 ColumnLayout {
     spacing: 3
     readonly property var testProfiles: [
+        qsTr("0 - Default"),
         qsTr("1 - Error conditions"),
         qsTr("2 - Charging battery"),
         qsTr("3 - Basic battery"),

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -8,7 +8,6 @@ import ChrisLauinger77.QontrolPanel
 ColumnLayout {
     spacing: 3
     readonly property var testProfiles: [
-        qsTr("0 - Default"),
         qsTr("1 - Error conditions"),
         qsTr("2 - Charging battery"),
         qsTr("3 - Basic battery"),

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -156,8 +156,8 @@ ColumnLayout {
                     Layout.fillWidth: true
                     title: qsTr("Fetch rate (seconds)")
                     additionalControl: SpinBox {
-                        from: 5
-                        to: 60
+                        from: 10
+                        to: 600
                         value: UserSettings.headsetcontrolFetchRate
                         editable: true
                         stepSize: 5

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -204,6 +204,10 @@ void HeadsetControlBridge::onMonitorBatteryLevelChanged()
 
 void HeadsetControlBridge::onMonitorAnyDeviceFoundChanged()
 {
+    if (!anyDeviceFound()) {
+        m_lowBatteryNotificationSent = false;
+    }
+
     emit anyDeviceFoundChanged();
 }
 

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -70,8 +70,8 @@ void HeadsetControlMonitor::stopMonitoring()
     m_hasSidetoneCapability = false;
     m_hasLightsCapability = false;
     m_deviceName = "";
-    m_batteryStatus = "";
-    m_batteryLevel = 0;
+    m_batteryStatus = "BATTERY_UNAVAILABLE";
+    m_batteryLevel = -1;
     bool wasDeviceFound = m_anyDeviceFound;
     m_anyDeviceFound = false;
 
@@ -177,8 +177,8 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
             m_hasSidetoneCapability = false;
             m_hasLightsCapability = false;
             m_deviceName = "";
-            m_batteryStatus = "";
-            m_batteryLevel = 0;
+            m_batteryStatus = "BATTERY_UNAVAILABLE";
+            m_batteryLevel = -1;
             bool wasDeviceFound = m_anyDeviceFound;
             m_anyDeviceFound = false;
 


### PR DESCRIPTION
Enhances battery status reporting by initializing battery level to -1 and status to "BATTERY_UNAVAILABLE" when a device is disconnected or not found. This provides clearer indication when battery information is unavailable.

Resets low battery notifications upon headset disconnection, preventing stale alerts.

Adjusts the configurable fetch rate for headset monitoring, expanding the range from 5-60 seconds to 10-600 seconds for greater flexibility.