### PR TITLE
Adds ChatMix status and refines build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
       - "i18n/**"
       - "i18n_compiled/**"
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 env:
   QT_VERSION: "6.10.1"
   VCPKG_ROOT: "C:/vcpkg"
@@ -73,11 +76,13 @@ jobs:
           cmake --build . --config Release
           cmake --install . --config Release
       - name: Remove obsolete entries from changed TS files
+        id: translation_updates
         shell: pwsh
         run: |
           $changedFiles = git diff --name-only -- i18n/*.ts
           if (-not $changedFiles) {
               Write-Host "No translation source changes detected"
+              "has_changes=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
               exit 0
           }
 
@@ -89,7 +94,10 @@ jobs:
               }
           }
 
+          "has_changes=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Create pull request for translation source updates
+        if: steps.translation_updates.outputs.has_changes == 'true' && github.ref_name == 'main'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -108,6 +116,21 @@ jobs:
             - removal of obsolete translation entries in changed files
           add-paths: |
             i18n
+      - name: Commit translation source updates to current branch
+        if: steps.translation_updates.outputs.has_changes == 'true' && github.ref_name != 'main' && github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add i18n
+
+          if (git diff --cached --quiet) {
+              Write-Host "No translation source changes staged"
+              exit 0
+          }
+
+          git commit -m "Update translation source files [skip ci]"
+          git push origin HEAD:${{ github.ref_name }}
       - name: Rename release folder
         shell: pwsh
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref || github.ref }}
           submodules: recursive
       - name: Update HeadsetControl submodule to latest master
         shell: pwsh
@@ -117,7 +118,7 @@ jobs:
           add-paths: |
             i18n
       - name: Commit translation source updates to current branch
-        if: steps.translation_updates.outputs.has_changes == 'true' && github.ref_name != 'main' && github.event_name != 'pull_request'
+        if: steps.translation_updates.outputs.has_changes == 'true' && github.event_name == 'push' && github.ref_name != 'main'
         shell: pwsh
         run: |
           git config user.name "GitHub Action"
@@ -131,6 +132,21 @@ jobs:
 
           git commit -m "Update translation source files [skip ci]"
           git push origin HEAD:${{ github.ref_name }}
+      - name: Commit translation source updates to PR branch
+        if: steps.translation_updates.outputs.has_changes == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'main' && github.event.pull_request.head.repo.full_name == github.repository
+        shell: pwsh
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add i18n
+
+          if (git diff --cached --quiet) {
+              Write-Host "No translation source changes staged"
+              exit 0
+          }
+
+          git commit -m "Update translation source files [skip ci]"
+              git push origin HEAD:${{ github.event.pull_request.head.ref }}
       - name: Rename release folder
         shell: pwsh
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.11.5 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.12.0 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -693,6 +693,14 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
         <translation>Wählen Sie aus, welches Szenario für synthetische Headsets HeadsetControl simulieren soll.</translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show battery status in panel footer</source>
         <translation>Batteriestatus in der Fußzeile des Fensters anzeigen</translation>
     </message>

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -694,11 +694,11 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     </message>
     <message>
         <source>ChatMix</source>
-        <translation type="unfinished">ChatMix</translation>
+        <translation>ChatMix</translation>
     </message>
     <message>
         <source>ChatMix value of the connected headset</source>
-        <translation type="unfinished"></translation>
+        <translation>ChatMix-Wert des angeschlossenen Headsets</translation>
     </message>
     <message>
         <source>Show battery status in panel footer</source>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -645,6 +645,14 @@ You can enable it in the General tab.</translation>
         <translation>Headset Lighting</translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show battery status in panel footer</source>
         <translation>Show battery status in panel footer</translation>
     </message>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -697,6 +697,14 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Headset Lighting</source>
         <translation>Éclairage du casque</translation>
     </message>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -693,6 +693,14 @@ Puoi abilitarlo nella scheda Generale.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show battery status in panel footer</source>
         <translation>Visualizza stato batteria nel piè di pagina pannello</translation>
     </message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -692,6 +692,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show battery status in panel footer</source>
         <translation>パネルのフッターにバッテリーの状態を表示します</translation>
     </message>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -693,6 +693,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">채팅 믹스</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show battery status in panel footer</source>
         <translation>패널 하단에 배터리 상태 표시</translation>
     </message>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -719,6 +719,14 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>HeadsetControl monitoring is disabled
 You can enable it in the General tab.</source>
         <translation>Monitorowanie HeadsetControl jest wyłączone

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -691,6 +691,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show battery status in panel footer</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -691,6 +691,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Show battery status in panel footer</source>
         <translation type="unfinished"></translation>
     </message>

--- a/include/headsetcontrolbridge.h
+++ b/include/headsetcontrolbridge.h
@@ -13,9 +13,11 @@ class HeadsetControlBridge : public QObject
 
     Q_PROPERTY(bool hasSidetoneCapability READ hasSidetoneCapability NOTIFY capabilitiesChanged)
     Q_PROPERTY(bool hasLightsCapability READ hasLightsCapability NOTIFY capabilitiesChanged)
+    Q_PROPERTY(bool hasChatMixCapability READ hasChatMixCapability NOTIFY capabilitiesChanged)
     Q_PROPERTY(QString deviceName READ deviceName NOTIFY deviceNameChanged)
     Q_PROPERTY(QString batteryStatus READ batteryStatus NOTIFY batteryStatusChanged)
     Q_PROPERTY(int batteryLevel READ batteryLevel NOTIFY batteryLevelChanged)
+    Q_PROPERTY(int chatMix READ chatMix NOTIFY chatMixChanged)
     Q_PROPERTY(bool anyDeviceFound READ anyDeviceFound NOTIFY anyDeviceFoundChanged)
     Q_PROPERTY(bool testModeEnabled READ testModeEnabled NOTIFY testModeEnabledChanged)
     Q_PROPERTY(int testProfile READ testProfile NOTIFY testProfileChanged)
@@ -36,9 +38,11 @@ public:
 
     bool hasSidetoneCapability() const;
     bool hasLightsCapability() const;
+    bool hasChatMixCapability() const;
     QString deviceName() const;
     QString batteryStatus() const;
     int batteryLevel() const;
+    int chatMix() const;
     bool anyDeviceFound() const;
     bool testModeEnabled() const;
     int testProfile() const;
@@ -48,6 +52,7 @@ signals:
     void deviceNameChanged();
     void batteryStatusChanged();
     void batteryLevelChanged();
+    void chatMixChanged();
     void anyDeviceFoundChanged();
     void testModeEnabledChanged();
     void testProfileChanged();
@@ -58,6 +63,7 @@ private slots:
     void onMonitorDeviceNameChanged();
     void onMonitorBatteryStatusChanged();
     void onMonitorBatteryLevelChanged();
+    void onMonitorChatMixChanged();
     void onMonitorAnyDeviceFoundChanged();
     void onMonitorTestModeEnabledChanged();
     void onMonitorTestProfileChanged();

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -16,9 +16,10 @@ struct HeadsetControlDevice {
     QString productId;
     QString batteryStatus;  // "BATTERY_AVAILABLE", "BATTERY_CHARGING", "BATTERY_UNAVAILABLE"
     int batteryLevel;       // -1 - 100
+    int chatMix;            // -1 when unavailable, otherwise 0 - 128
     QStringList capabilities;
 
-    HeadsetControlDevice() : batteryLevel(-1) {}
+    HeadsetControlDevice() : batteryLevel(-1), chatMix(-1) {}
 };
 Q_DECLARE_METATYPE(HeadsetControlDevice)
 
@@ -34,9 +35,11 @@ public:
 
     bool hasSidetoneCapability() const { return m_hasSidetoneCapability; }
     bool hasLightsCapability() const { return m_hasLightsCapability; }
+    bool hasChatMixCapability() const { return m_hasChatMixCapability; }
     QString deviceName() const { return m_deviceName; }
     QString batteryStatus() const { return m_batteryStatus; }
     int batteryLevel() const { return m_batteryLevel; }
+    int chatMix() const { return m_chatMix; }
     bool anyDeviceFound() const { return m_anyDeviceFound; }
     bool testModeEnabled() const { return m_testModeEnabled; }
     int testProfile() const { return m_testProfile; }
@@ -57,6 +60,7 @@ signals:
     void deviceNameChanged();
     void batteryStatusChanged();
     void batteryLevelChanged();
+    void chatMixChanged();
     void anyDeviceFoundChanged();
     void testModeEnabledChanged();
     void testProfileChanged();
@@ -80,9 +84,11 @@ private:
 
     bool m_hasSidetoneCapability;
     bool m_hasLightsCapability;
+    bool m_hasChatMixCapability;
     QString m_deviceName;
     QString m_batteryStatus;
     int m_batteryLevel;
+    int m_chatMix;
     bool m_anyDeviceFound;
     bool m_isFetching;
     bool m_testModeEnabled;

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -89,6 +89,15 @@ ColumnLayout {
                 }
 
                 Card {
+                    Layout.fillWidth: true
+                    title: qsTr("ChatMix")
+                    visible: HeadsetControlBridge.anyDeviceFound && HeadsetControlBridge.hasChatMixCapability
+                    additionalControl: Label {
+                        text:  qsTr("ChatMix value of the connected headset is ") + HeadsetControlBridge.chatMix
+                    }
+                }
+
+                Card {
                     visible: HeadsetControlBridge.anyDeviceFound
                     Layout.fillWidth: true
                     title: qsTr("Show battery status in panel footer")

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -92,8 +92,9 @@ ColumnLayout {
                     Layout.fillWidth: true
                     title: qsTr("ChatMix")
                     visible: HeadsetControlBridge.anyDeviceFound && HeadsetControlBridge.hasChatMixCapability
+                    description: qsTr("ChatMix value of the connected headset")
                     additionalControl: Label {
-                        text:  qsTr("ChatMix value of the connected headset is ") + HeadsetControlBridge.chatMix
+                        text:  HeadsetControlBridge.chatMix
                     }
                 }
 

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -55,6 +55,8 @@ void HeadsetControlBridge::connectToMonitor()
                 this, &HeadsetControlBridge::onMonitorBatteryStatusChanged);
         connect(monitor, &HeadsetControlMonitor::batteryLevelChanged,
                 this, &HeadsetControlBridge::onMonitorBatteryLevelChanged);
+        connect(monitor, &HeadsetControlMonitor::chatMixChanged,
+            this, &HeadsetControlBridge::onMonitorChatMixChanged);
         connect(monitor, &HeadsetControlMonitor::anyDeviceFoundChanged,
                 this, &HeadsetControlBridge::onMonitorAnyDeviceFoundChanged);
         connect(monitor, &HeadsetControlMonitor::testModeEnabledChanged,
@@ -75,6 +77,7 @@ void HeadsetControlBridge::connectToMonitor()
         emit deviceNameChanged();
         emit batteryStatusChanged();
         emit batteryLevelChanged();
+        emit chatMixChanged();
         emit anyDeviceFoundChanged();
         emit testModeEnabledChanged();
         emit testProfileChanged();
@@ -135,6 +138,12 @@ bool HeadsetControlBridge::hasLightsCapability() const
     return monitor ? monitor->hasLightsCapability() : false;
 }
 
+bool HeadsetControlBridge::hasChatMixCapability() const
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    return monitor ? monitor->hasChatMixCapability() : false;
+}
+
 QString HeadsetControlBridge::deviceName() const
 {
     HeadsetControlMonitor* monitor = findMonitor();
@@ -151,6 +160,12 @@ int HeadsetControlBridge::batteryLevel() const
 {
     HeadsetControlMonitor* monitor = findMonitor();
     return monitor ? monitor->batteryLevel() : -1;
+}
+
+int HeadsetControlBridge::chatMix() const
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    return monitor ? monitor->chatMix() : -1;
 }
 
 bool HeadsetControlBridge::anyDeviceFound() const
@@ -200,6 +215,11 @@ void HeadsetControlBridge::onMonitorBatteryLevelChanged()
     }
 
     emit batteryLevelChanged();
+}
+
+void HeadsetControlBridge::onMonitorChatMixChanged()
+{
+    emit chatMixChanged();
 }
 
 void HeadsetControlBridge::onMonitorAnyDeviceFoundChanged()

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -9,9 +9,11 @@ HeadsetControlMonitor::HeadsetControlMonitor(QObject *parent)
     , m_fetchIntervalMs(30000)
     , m_hasSidetoneCapability(false)
     , m_hasLightsCapability(false)
+    , m_hasChatMixCapability(false)
     , m_deviceName("")
     , m_batteryStatus("BATTERY_UNAVAILABLE")
     , m_batteryLevel(-1)
+    , m_chatMix(-1)
     , m_anyDeviceFound(false)
     , m_isFetching(false)
     , m_testModeEnabled(false)
@@ -69,9 +71,11 @@ void HeadsetControlMonitor::stopMonitoring()
     m_headsets.clear();
     m_hasSidetoneCapability = false;
     m_hasLightsCapability = false;
+    m_hasChatMixCapability = false;
     m_deviceName = "";
     m_batteryStatus = "BATTERY_UNAVAILABLE";
     m_batteryLevel = -1;
+    m_chatMix = -1;
     bool wasDeviceFound = m_anyDeviceFound;
     m_anyDeviceFound = false;
 
@@ -79,6 +83,7 @@ void HeadsetControlMonitor::stopMonitoring()
     emit deviceNameChanged();
     emit batteryStatusChanged();
     emit batteryLevelChanged();
+    emit chatMixChanged();
     if (wasDeviceFound) {
         emit anyDeviceFoundChanged();
     }
@@ -176,9 +181,11 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
             m_cachedDevices.clear();
             m_hasSidetoneCapability = false;
             m_hasLightsCapability = false;
+            m_hasChatMixCapability = false;
             m_deviceName = "";
             m_batteryStatus = "BATTERY_UNAVAILABLE";
             m_batteryLevel = -1;
+            m_chatMix = -1;
             bool wasDeviceFound = m_anyDeviceFound;
             m_anyDeviceFound = false;
 
@@ -186,6 +193,7 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
             emit deviceNameChanged();
             emit batteryStatusChanged();
             emit batteryLevelChanged();
+            emit chatMixChanged();
             if (wasDeviceFound) {
                 emit anyDeviceFoundChanged();
             }
@@ -246,6 +254,24 @@ void HeadsetControlMonitor::updateDeviceCache()
             device.batteryLevel = -1;
         }
 
+        if (headset.supports(CAP_CHATMIX_STATUS)) {
+            headsetcontrol::Result<headsetcontrol::ChatmixResult> chatMixResult = headset.getChatmix();
+            if (chatMixResult) {
+                device.chatMix = chatMixResult->level;
+
+                LOG_INFO("HeadsetControlManager",
+                                                QString("Device %1: ChatMix %2")
+                                                    .arg(device.deviceName).arg(device.chatMix));
+            } else {
+                device.chatMix = -1;
+                LOG_WARN("HeadsetControlManager",
+                                                 QString("Failed to read ChatMix: %1")
+                                                     .arg(QString::fromStdString(chatMixResult.error().fullMessage())));
+            }
+        } else {
+            device.chatMix = -1;
+        }
+
         LOG_INFO("HeadsetControlManager",
                                         QString("Found headset device: %1 with %2 capabilities")
                                             .arg(device.deviceName).arg(device.capabilities.size()));
@@ -267,6 +293,10 @@ void HeadsetControlMonitor::updateDeviceCache()
             m_batteryLevel = primaryDevice.batteryLevel;
             emit batteryLevelChanged();
         }
+        if (primaryDevice.chatMix != m_chatMix) {
+            m_chatMix = primaryDevice.chatMix;
+            emit chatMixChanged();
+        }
     }
 
     emit headsetDataUpdated(m_cachedDevices);
@@ -276,6 +306,7 @@ void HeadsetControlMonitor::updateCapabilities()
 {
     bool newSidetoneCapability = false;
     bool newLightsCapability = false;
+    bool newChatMixCapability = false;
     QString newDeviceName = "";
     bool newAnyDeviceFound = !m_cachedDevices.isEmpty();
     bool wasDeviceFound = m_anyDeviceFound;
@@ -286,6 +317,7 @@ void HeadsetControlMonitor::updateCapabilities()
 
         newSidetoneCapability = headset.supports(CAP_SIDETONE);
         newLightsCapability = headset.supports(CAP_LIGHTS);
+        newChatMixCapability = headset.supports(CAP_CHATMIX_STATUS);
 
         LOG_INFO("HeadsetControlManager",
                                         QString("Device capabilities: %1")
@@ -293,9 +325,11 @@ void HeadsetControlMonitor::updateCapabilities()
     }
 
     if (newSidetoneCapability != m_hasSidetoneCapability ||
-        newLightsCapability != m_hasLightsCapability) {
+        newLightsCapability != m_hasLightsCapability ||
+        newChatMixCapability != m_hasChatMixCapability) {
         m_hasSidetoneCapability = newSidetoneCapability;
         m_hasLightsCapability = newLightsCapability;
+        m_hasChatMixCapability = newChatMixCapability;
         emit capabilitiesChanged();
     }
 


### PR DESCRIPTION
Implements monitoring and display for headset ChatMix functionality, providing users with visibility into this status for compatible devices.

Also refines the GitHub Actions build workflow for translation file updates:
- Automatically commits translation changes directly to non-`main` branches, such as `dev`.
- Creates a pull request for translation changes only when building on the `main` branch.
- Updates workflow permissions to enable these actions.

Increments the project version to `1.12.0` to reflect the new features.