### PR TITLE
Adds Headset Rotate-to-Mute Feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.12.0 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.12.1 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -693,6 +693,14 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
         <translation>Wählen Sie aus, welches Szenario für synthetische Headsets HeadsetControl simulieren soll.</translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation>ChatMix</translation>
     </message>
@@ -707,6 +715,14 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>RGB-Beleuchtung an Ihrem Headset ein- und ausschalten</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -727,10 +743,6 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     <message>
         <source>Device battery</source>
         <translation>Gerätebatterie</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>Laden</translation>
     </message>
 </context>
 <context>
@@ -1116,6 +1128,10 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     <message>
         <source>Exit</source>
         <translation>Beenden</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -694,11 +694,11 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktueller Akkustand des angeschlossenen Headsets</translation>
     </message>
     <message>
         <source>(Charging)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Laden)</translation>
     </message>
     <message>
         <source>ChatMix</source>
@@ -718,11 +718,11 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     </message>
     <message>
         <source>Headset Rotate-to-Mute</source>
-        <translation type="unfinished"></translation>
+        <translation>Headset: Durch Drehen stummschalten</translation>
     </message>
     <message>
         <source>Toggle rotate-to-mute feature on your headset</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktivieren Sie die Funktion „Durch Drehen stummschalten“ an Ihrem Headset</translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -1131,7 +1131,7 @@ Sie können sie auf der Registerkarte „Allgemein“ aktivieren.</translation>
     </message>
     <message>
         <source>ChatMix</source>
-        <translation type="unfinished">ChatMix</translation>
+        <translation>ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -645,6 +645,14 @@ You can enable it in the General tab.</translation>
         <translation>Headset Lighting</translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -659,6 +667,14 @@ You can enable it in the General tab.</translation>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>Toggle RGB lights on your headset</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -679,10 +695,6 @@ You can enable it in the General tab.</translation>
     <message>
         <source>Device battery</source>
         <translation>Device battery</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>Charging</translation>
     </message>
     <message>
         <source>Enable test mode below to simulate a supported headset and validate the HeadsetControl UI.</source>
@@ -1116,6 +1128,10 @@ You can enable it in the General tab.</translation>
     <message>
         <source>Exit</source>
         <translation>Exit</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -697,6 +697,14 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -707,6 +715,14 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
     <message>
         <source>Headset Lighting</source>
         <translation>Éclairage du casque</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust your voice feedback level</source>
@@ -730,10 +746,6 @@ Vous pouvez l&apos;activer dans l&apos;onglet Général.</translation>
     <message>
         <source>Device battery</source>
         <translation>Batterie du périphérique</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>Chargement</translation>
     </message>
 </context>
 <context>
@@ -1132,6 +1144,10 @@ Vous pouvez l&apos;activer dans l&apos;onglet Général.</translation>
     <message>
         <source>QontrolPanel settings</source>
         <translation>Paramètres de QontrolPanel</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -693,6 +693,14 @@ Puoi abilitarlo nella scheda Generale.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -707,6 +715,14 @@ Puoi abilitarlo nella scheda Generale.</translation>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>Attiva luci RGB dell&apos;auricolare</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -727,10 +743,6 @@ Puoi abilitarlo nella scheda Generale.</translation>
     <message>
         <source>Device battery</source>
         <translation>Batteria dispositivo</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>In carica</translation>
     </message>
 </context>
 <context>
@@ -1116,6 +1128,10 @@ Puoi abilitarlo nella scheda Generale.</translation>
     <message>
         <source>Exit</source>
         <translation>Esci da QuickSoundSwitcher</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -692,6 +692,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -706,6 +714,14 @@ You can enable it in the General tab.</source>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>ヘッドセットの RGB ライトを切り替えます</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -726,10 +742,6 @@ You can enable it in the General tab.</source>
     <message>
         <source>Device battery</source>
         <translation>デバイスのバッテリー</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>充電中</translation>
     </message>
 </context>
 <context>
@@ -1115,6 +1127,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Exit</source>
         <translation>終了</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -693,6 +693,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">채팅 믹스</translation>
     </message>
@@ -707,6 +715,14 @@ You can enable it in the General tab.</source>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>헤드셋의 RGB 조명 전환</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -727,10 +743,6 @@ You can enable it in the General tab.</source>
     <message>
         <source>Device battery</source>
         <translation>장치 배터리</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>충전 중</translation>
     </message>
 </context>
 <context>
@@ -1116,6 +1128,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Exit</source>
         <translation>종료</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">채팅 믹스</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -635,10 +635,6 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
         <translation>Bateria urządzenia</translation>
     </message>
     <message>
-        <source>Charging</source>
-        <translation>Ładowanie</translation>
-    </message>
-    <message>
         <source>Show battery status in panel footer</source>
         <translation>Pokaż stan baterii w stopce panelu</translation>
     </message>
@@ -719,11 +715,27 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1128,6 +1140,10 @@ Można ją włączyć w zakładce Ogólne.</translation>
     <message>
         <source>Exit</source>
         <translation>Wyjście</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
 </context>
 <context>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -693,6 +693,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -707,6 +715,14 @@ You can enable it in the General tab.</source>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>Alternar as luzes RGB do headset</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -727,10 +743,6 @@ You can enable it in the General tab.</source>
     <message>
         <source>Device battery</source>
         <translation>Bateria do dispositivo</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>Carregando</translation>
     </message>
 </context>
 <context>
@@ -1116,6 +1128,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Exit</source>
         <translation>Sair</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -691,6 +691,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -704,6 +712,14 @@ You can enable it in the General tab.</source>
     </message>
     <message>
         <source>Toggle RGB lights on your headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -724,10 +740,6 @@ You can enable it in the General tab.</source>
     </message>
     <message>
         <source>Device battery</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Charging</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1114,6 +1126,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Exit</source>
         <translation type="unfinished">Выход</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -691,6 +691,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -705,6 +713,14 @@ You can enable it in the General tab.</source>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>Vklop/izklop RGB luči na slušalkah</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -725,10 +741,6 @@ You can enable it in the General tab.</source>
     <message>
         <source>Device battery</source>
         <translation>Baterija naprave</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>Polnjenje</translation>
     </message>
 </context>
 <context>
@@ -1114,6 +1126,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Exit</source>
         <translation>Izhod</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -691,6 +691,14 @@ You can enable it in the General tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Charging)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>
@@ -705,6 +713,14 @@ You can enable it in the General tab.</source>
     <message>
         <source>Toggle RGB lights on your headset</source>
         <translation>开关耳机上的 RGB 灯光</translation>
+    </message>
+    <message>
+        <source>Headset Rotate-to-Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Microphone Sidetone</source>
@@ -725,10 +741,6 @@ You can enable it in the General tab.</source>
     <message>
         <source>Device battery</source>
         <translation>设备电量</translation>
-    </message>
-    <message>
-        <source>Charging</source>
-        <translation>充电中...</translation>
     </message>
 </context>
 <context>
@@ -1114,6 +1126,10 @@ You can enable it in the General tab.</source>
     <message>
         <source>Exit</source>
         <translation>退出</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
         <source>Windows sound settings (Legacy)</source>

--- a/include/headsetcontrolbridge.h
+++ b/include/headsetcontrolbridge.h
@@ -13,6 +13,7 @@ class HeadsetControlBridge : public QObject
 
     Q_PROPERTY(bool hasSidetoneCapability READ hasSidetoneCapability NOTIFY capabilitiesChanged)
     Q_PROPERTY(bool hasLightsCapability READ hasLightsCapability NOTIFY capabilitiesChanged)
+    Q_PROPERTY(bool hasRotateToMuteCapability READ hasRotateToMuteCapability NOTIFY capabilitiesChanged)
     Q_PROPERTY(bool hasChatMixCapability READ hasChatMixCapability NOTIFY capabilitiesChanged)
     Q_PROPERTY(QString deviceName READ deviceName NOTIFY deviceNameChanged)
     Q_PROPERTY(QString batteryStatus READ batteryStatus NOTIFY batteryStatusChanged)
@@ -31,6 +32,7 @@ public:
 
     Q_INVOKABLE void setMonitoringEnabled(bool enabled);
     Q_INVOKABLE void setLights(bool enabled);
+    Q_INVOKABLE void setRotateToMute(bool enabled);
     Q_INVOKABLE void setSidetone(int value);
     Q_INVOKABLE void setFetchRate(int seconds);
     Q_INVOKABLE void setTestModeEnabled(bool enabled);
@@ -38,6 +40,7 @@ public:
 
     bool hasSidetoneCapability() const;
     bool hasLightsCapability() const;
+    bool hasRotateToMuteCapability() const;
     bool hasChatMixCapability() const;
     QString deviceName() const;
     QString batteryStatus() const;

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -35,6 +35,7 @@ public:
 
     bool hasSidetoneCapability() const { return m_hasSidetoneCapability; }
     bool hasLightsCapability() const { return m_hasLightsCapability; }
+    bool hasRotateToMuteCapability() const { return m_hasRotateToMuteCapability; }
     bool hasChatMixCapability() const { return m_hasChatMixCapability; }
     QString deviceName() const { return m_deviceName; }
     QString batteryStatus() const { return m_batteryStatus; }
@@ -48,6 +49,7 @@ public slots:
     void startMonitoring();
     void stopMonitoring();
     void setLights(bool enabled);
+    void setRotateToMute(bool enabled);
     void setSidetone(int value);
     void setFetchInterval(int intervalMs);
     void setTestModeEnabled(bool enabled);
@@ -84,6 +86,7 @@ private:
 
     bool m_hasSidetoneCapability;
     bool m_hasLightsCapability;
+    bool m_hasRotateToMuteCapability;
     bool m_hasChatMixCapability;
     QString m_deviceName;
     QString m_batteryStatus;

--- a/include/usersettings.h
+++ b/include/usersettings.h
@@ -43,6 +43,7 @@ class UserSettings : public QObject
     Q_PROPERTY(bool autoFetchForAppUpdates READ autoFetchForAppUpdates WRITE setAutoFetchForAppUpdates NOTIFY autoFetchForAppUpdatesChanged)
     Q_PROPERTY(bool headsetcontrolMonitoring READ headsetcontrolMonitoring WRITE setHeadsetcontrolMonitoring NOTIFY headsetcontrolMonitoringChanged)
     Q_PROPERTY(bool headsetcontrolLights READ headsetcontrolLights WRITE setHeadsetcontrolLights NOTIFY headsetcontrolLightsChanged)
+    Q_PROPERTY(bool headsetcontrolRotateToMute READ headsetcontrolRotateToMute WRITE setHeadsetcontrolRotateToMute NOTIFY headsetcontrolRotateToMuteChanged)
     Q_PROPERTY(int headsetcontrolSidetone READ headsetcontrolSidetone WRITE setHeadsetcontrolSidetone NOTIFY headsetcontrolSidetoneChanged)
     Q_PROPERTY(bool allowBrightnessControl READ allowBrightnessControl WRITE setAllowBrightnessControl NOTIFY allowBrightnessControlChanged)
     Q_PROPERTY(bool avoidApplicationsOverflow READ avoidApplicationsOverflow WRITE setAvoidApplicationsOverflow NOTIFY avoidApplicationsOverflowChanged)
@@ -101,6 +102,7 @@ public:
     bool autoFetchForAppUpdates() const { return m_autoFetchForAppUpdates; }
     bool headsetcontrolMonitoring() const { return m_headsetcontrolMonitoring; }
     bool headsetcontrolLights() const { return m_headsetcontrolLights; }
+    bool headsetcontrolRotateToMute() const { return m_headsetcontrolRotateToMute; }
     int headsetcontrolSidetone() const { return m_headsetcontrolSidetone; }
     bool allowBrightnessControl() const { return m_allowBrightnessControl; }
     bool avoidApplicationsOverflow() const { return m_avoidApplicationsOverflow; }
@@ -155,6 +157,7 @@ public:
     void setAutoFetchForAppUpdates(bool value);
     void setHeadsetcontrolMonitoring(bool value);
     void setHeadsetcontrolLights(bool value);
+    void setHeadsetcontrolRotateToMute(bool value);
     void setHeadsetcontrolSidetone(int value);
     void setAllowBrightnessControl(bool value);
     void setAvoidApplicationsOverflow(bool value);
@@ -209,6 +212,7 @@ signals:
     void autoFetchForAppUpdatesChanged();
     void headsetcontrolMonitoringChanged();
     void headsetcontrolLightsChanged();
+    void headsetcontrolRotateToMuteChanged();
     void headsetcontrolSidetoneChanged();
     void allowBrightnessControlChanged();
     void avoidApplicationsOverflowChanged();
@@ -269,6 +273,7 @@ private:
     bool m_autoFetchForAppUpdates;
     bool m_headsetcontrolMonitoring;
     bool m_headsetcontrolLights;
+    bool m_headsetcontrolRotateToMute;
     int m_headsetcontrolSidetone;
     bool m_allowBrightnessControl;
     bool m_avoidApplicationsOverflow;

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -83,8 +83,10 @@ ColumnLayout {
                     Layout.fillWidth: true
                     title: qsTr("Device battery")
                     visible: HeadsetControlBridge.batteryStatus !== "BATTERY_UNAVAILABLE" && HeadsetControlBridge.anyDeviceFound
+                    description: qsTr("Current battery level of the connected headset") +
+                                 (HeadsetControlBridge.batteryStatus === "BATTERY_CHARGING" ? "\n" + "⚡︎" + qsTr("(Charging)") : "")
                     additionalControl: Label {
-                        text: HeadsetControlBridge.batteryStatus === "BATTERY_CHARGING" ? qsTr("Charging") : HeadsetControlBridge.batteryLevel + "%"
+                        text: "🔋" + HeadsetControlBridge.batteryLevel + "%"
                     }
                 }
 

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -130,6 +130,22 @@ ColumnLayout {
 
                 Card {
                     visible: HeadsetControlBridge.anyDeviceFound
+                    enabled: HeadsetControlBridge.hasRotateToMuteCapability
+                    Layout.fillWidth: true
+                    title: qsTr("Headset Rotate-to-Mute")
+                    description: qsTr("Toggle rotate-to-mute feature on your headset")
+
+                    additionalControl: LabeledSwitch {
+                        checked: UserSettings.headsetcontrolRotateToMute
+                        onClicked:{
+                            UserSettings.headsetcontrolRotateToMute = checked
+                            HeadsetControlBridge.setRotateToMute(checked)
+                        }
+                    }
+                }
+
+                Card {
+                    visible: HeadsetControlBridge.anyDeviceFound
                     enabled: HeadsetControlBridge.hasSidetoneCapability
                     Layout.fillWidth: true
                     title: qsTr("Microphone Sidetone")
@@ -150,6 +166,7 @@ ColumnLayout {
                         }
                     }
                 }
+
                 Card {
                     visible: HeadsetControlBridge.anyDeviceFound
                     Layout.fillWidth: true

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -77,6 +77,9 @@ Platform.SystemTrayIcon {
 
         batteryText += "🔋";
             batteryText += HeadsetControlBridge.batteryLevel + "%";
+        if (HeadsetControlBridge.hasChatMixCapability) {
+            batteryText += "\n" + "🎤" + qsTr("ChatMix") + ": " + HeadsetControlBridge.chatMix;
+        }
 
         return baseTooltip + batteryText;
     }

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -78,7 +78,7 @@ Platform.SystemTrayIcon {
         batteryText += "🔋";
             batteryText += HeadsetControlBridge.batteryLevel + "%";
         if (HeadsetControlBridge.hasChatMixCapability) {
-            batteryText += "\n" + "🎤" + qsTr("ChatMix") + ": " + HeadsetControlBridge.chatMix;
+            batteryText += " " + "🎤" + qsTr("ChatMix") + ": " + HeadsetControlBridge.chatMix;
         }
 
         return baseTooltip + batteryText;

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -117,6 +117,15 @@ void HeadsetControlBridge::setLights(bool enabled)
     }
 }
 
+void HeadsetControlBridge::setRotateToMute(bool enabled)
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        QMetaObject::invokeMethod(monitor, "setRotateToMute", Qt::QueuedConnection,
+                                  Q_ARG(bool, enabled));
+    }
+}
+
 void HeadsetControlBridge::setSidetone(int value)
 {
     HeadsetControlMonitor* monitor = findMonitor();
@@ -136,6 +145,12 @@ bool HeadsetControlBridge::hasLightsCapability() const
 {
     HeadsetControlMonitor* monitor = findMonitor();
     return monitor ? monitor->hasLightsCapability() : false;
+}
+
+bool HeadsetControlBridge::hasRotateToMuteCapability() const
+{
+    HeadsetControlMonitor* monitor = findMonitor();
+    return monitor ? monitor->hasRotateToMuteCapability() : false;
 }
 
 bool HeadsetControlBridge::hasChatMixCapability() const

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -9,6 +9,7 @@ HeadsetControlMonitor::HeadsetControlMonitor(QObject *parent)
     , m_fetchIntervalMs(30000)
     , m_hasSidetoneCapability(false)
     , m_hasLightsCapability(false)
+    , m_hasRotateToMuteCapability(false)
     , m_hasChatMixCapability(false)
     , m_deviceName("")
     , m_batteryStatus("BATTERY_UNAVAILABLE")
@@ -71,6 +72,7 @@ void HeadsetControlMonitor::stopMonitoring()
     m_headsets.clear();
     m_hasSidetoneCapability = false;
     m_hasLightsCapability = false;
+    m_hasRotateToMuteCapability = false;
     m_hasChatMixCapability = false;
     m_deviceName = "";
     m_batteryStatus = "BATTERY_UNAVAILABLE";
@@ -129,6 +131,35 @@ void HeadsetControlMonitor::setLights(bool enabled)
     }
 }
 
+void HeadsetControlMonitor::setRotateToMute(bool enabled)
+{
+    if (!m_hasRotateToMuteCapability) {
+        LOG_WARN("HeadsetControlManager",
+                                         "Cannot set rotate-to-mute - device does not support rotate-to-mute capability");
+        return;
+    }
+
+    if (m_headsets.empty()) {
+        LOG_WARN("HeadsetControlManager",
+                                         "Cannot set rotate-to-mute - no device connected");
+        return;
+    }
+
+    LOG_INFO("HeadsetControlManager",
+                                    QString("Setting rotate-to-mute: %1").arg(enabled ? "ON" : "OFF"));
+
+    headsetcontrol::Headset& headset = m_headsets[0];
+    headsetcontrol::Result<headsetcontrol::RotateToMuteResult> result = headset.setRotateToMute(enabled);
+
+    if (!result) {
+        LOG_CRITICAL("HeadsetControlManager",
+                                             QString("Failed to set rotate-to-mute: %1").arg(QString::fromStdString(result.error().fullMessage())));
+    } else {
+        LOG_INFO("HeadsetControlManager",
+                                        "Rotate-to-mute set successfully");
+    }
+}
+
 void HeadsetControlMonitor::setSidetone(int value)
 {
     if (!m_hasSidetoneCapability) {
@@ -181,6 +212,7 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
             m_cachedDevices.clear();
             m_hasSidetoneCapability = false;
             m_hasLightsCapability = false;
+            m_hasRotateToMuteCapability = false;
             m_hasChatMixCapability = false;
             m_deviceName = "";
             m_batteryStatus = "BATTERY_UNAVAILABLE";
@@ -306,6 +338,7 @@ void HeadsetControlMonitor::updateCapabilities()
 {
     bool newSidetoneCapability = false;
     bool newLightsCapability = false;
+    bool newRotateToMuteCapability = false;
     bool newChatMixCapability = false;
     QString newDeviceName = "";
     bool newAnyDeviceFound = !m_cachedDevices.isEmpty();
@@ -317,6 +350,7 @@ void HeadsetControlMonitor::updateCapabilities()
 
         newSidetoneCapability = headset.supports(CAP_SIDETONE);
         newLightsCapability = headset.supports(CAP_LIGHTS);
+        newRotateToMuteCapability = headset.supports(CAP_ROTATE_TO_MUTE);
         newChatMixCapability = headset.supports(CAP_CHATMIX_STATUS);
 
         LOG_INFO("HeadsetControlManager",
@@ -326,9 +360,11 @@ void HeadsetControlMonitor::updateCapabilities()
 
     if (newSidetoneCapability != m_hasSidetoneCapability ||
         newLightsCapability != m_hasLightsCapability ||
+        newRotateToMuteCapability != m_hasRotateToMuteCapability ||
         newChatMixCapability != m_hasChatMixCapability) {
         m_hasSidetoneCapability = newSidetoneCapability;
         m_hasLightsCapability = newLightsCapability;
+        m_hasRotateToMuteCapability = newRotateToMuteCapability;
         m_hasChatMixCapability = newChatMixCapability;
         emit capabilitiesChanged();
     }
@@ -351,6 +387,12 @@ void HeadsetControlMonitor::updateCapabilities()
                 LOG_INFO("HeadsetControlManager",
                                                 QString("Applying saved lights setting: %1").arg(lightsEnabled ? "ON" : "OFF"));
                 setLights(lightsEnabled);
+            }
+            if (newRotateToMuteCapability) {
+                bool rotateToMuteEnabled = UserSettings::instance()->headsetcontrolRotateToMute();
+                LOG_INFO("HeadsetControlManager",
+                                                QString("Applying saved rotate-to-mute setting: %1").arg(rotateToMuteEnabled ? "ON" : "OFF"));
+                setRotateToMute(rotateToMuteEnabled);
             }
             if (newSidetoneCapability) {
                 int sidetoneValue = UserSettings::instance()->headsetcontrolSidetone();

--- a/src/usersettings.cpp
+++ b/src/usersettings.cpp
@@ -67,6 +67,7 @@ void UserSettings::initProperties()
     m_autoFetchForAppUpdates = settings.value("autoFetchForAppUpdates", false).toBool();
     m_headsetcontrolMonitoring = settings.value("headsetcontrolMonitoring", true).toBool();
     m_headsetcontrolLights = settings.value("headsetcontrolLights", true).toBool();
+    m_headsetcontrolRotateToMute = settings.value("headsetcontrolRotateToMute", true).toBool();
     m_headsetcontrolSidetone = settings.value("headsetcontrolSidetone", 0).toInt();
     m_allowBrightnessControl = settings.value("allowBrightnessControl", true).toBool();
     m_avoidApplicationsOverflow = settings.value("avoidApplicationsOverflow", false).toBool();
@@ -347,6 +348,15 @@ void UserSettings::setHeadsetcontrolLights(bool value)
         m_headsetcontrolLights = value;
         saveValue("headsetcontrolLights", value);
         emit headsetcontrolLightsChanged();
+    }
+}
+
+void UserSettings::setHeadsetcontrolRotateToMute(bool value)
+{
+    if (m_headsetcontrolRotateToMute != value) {
+        m_headsetcontrolRotateToMute = value;
+        saveValue("headsetcontrolRotateToMute", value);
+        emit headsetcontrolRotateToMuteChanged();
     }
 }
 


### PR DESCRIPTION
### Summary
Introduces support for the headset rotate-to-mute feature, allowing users to toggle this capability for supported devices. This pull request also enhances the battery display in the settings pane and adds ChatMix status to the system tray tooltip for a more informative user experience.

### What's new?
*   **Headset Rotate-to-Mute:** Provides a new setting and control to enable or disable the rotate-to-mute functionality on compatible headsets. This setting is persistent and will be applied automatically when a device is connected.

### Bug fixes?
No explicit bug fixes are included in this change.

### Changes for the user
*   Users can now manage the "Headset Rotate-to-Mute" feature through a dedicated toggle in the Headset Control settings pane.
*   The headset battery display in the settings pane now includes a more descriptive text, a charging indicator (⚡︎), and an updated battery emoji (🔋) for improved clarity.
*   The system tray tooltip now displays the current ChatMix status for headsets that support this capability, providing quick access to relevant information.

### Under the hood
*   Added `hasRotateToMuteCapability` and `setRotateToMute` properties and methods to `HeadsetControlBridge` for QML integration.
*   Implemented core logic for `setRotateToMute` within `HeadsetControlMonitor`, including capability detection and interaction with the underlying headset control library.
*   Integrated a new `headsetcontrolRotateToMute` setting into `UserSettings` to persist user preferences across sessions.
*   Updated `HeadsetControlPane.qml` and `SystemTray.qml` to expose the new rotate-to-mute control and incorporate the enhanced battery and ChatMix status displays.
