### PR TITLE
Adds configurable power dialog timeout and UI improvements

### DIFF
--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -651,6 +651,18 @@ Wenn Sie meine Arbeit unterstützen möchten, freue ich mich über jeden Beitrag
         <translation>QSS wird beim Start Ihres Computers gestartet</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation>Zeige einen Bestätigungsdialog an, wenn eine Energieaktion aus dem Taskleistenmenü ausgewählt wird</translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation>Zeitlimit für die Bestätigung der Stromversorgung (Sekunden)</translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation>Zeit, bevor der Bestätigungsdialog für die Energieaktion die ausgewählte Aktion automatisch auslöst</translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation>Empfindlichkeit des Schiebereglers</translation>
     </message>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -651,6 +651,18 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS will boot up when your computer starts</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation>Slider wheel sensivity</translation>
     </message>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -669,6 +669,18 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
         <translation>Lancer au démarrage</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -651,6 +651,18 @@ Se vuoi supportare il mio lavoro, qualsiasi contributo sarebbe molto apprezzato!
         <translation>QSS verrà eseguito ad avvio del sistema</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation>Sensibilità rotella scorrimento</translation>
     </message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -651,6 +651,18 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>コンピューターの起動時に QSS を起動します</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -651,6 +651,18 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>컴퓨터가 시작되면 QSS가 부팅됩니다</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation>슬라이더 휠 감도</translation>
     </message>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -655,6 +655,18 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
         <translation>Pokaż potwierdzenie akcji zasilania</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -652,6 +652,18 @@ Se você quiser apoiar meu trabalho, qualquer contribuição será muito bem-vin
         <translation>QSS será iniciado quando o computador for ligado</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation>Sensibilidade da roda do mouse no controle deslizante</translation>
     </message>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -650,6 +650,18 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS запустится при включении компьютера</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -650,6 +650,18 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS se bo zagnal ob zagonu računalnika</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation>Občutljivost drsnega kolesa</translation>
     </message>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -650,6 +650,18 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS 将随系统启动时自动启动</translation>
     </message>
     <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Slider wheel sensivity</source>
         <translation type="unfinished"></translation>
     </message>

--- a/include/usersettings.h
+++ b/include/usersettings.h
@@ -51,6 +51,7 @@ class UserSettings : public QObject
 
     Q_PROPERTY(bool enablePowerMenu READ enablePowerMenu WRITE setEnablePowerMenu NOTIFY enablePowerMenuChanged)
     Q_PROPERTY(bool showPowerDialogConfirmation READ showPowerDialogConfirmation WRITE setShowPowerDialogConfirmation NOTIFY showPowerDialogConfirmationChanged)
+    Q_PROPERTY(int powerDialogTimeout READ powerDialogTimeout WRITE setPowerDialogTimeout NOTIFY powerDialogTimeoutChanged)
 
     Q_PROPERTY(int ddcciBrightness READ ddcciBrightness WRITE setDdcciBrightness NOTIFY ddcciBrightnessChanged)
     Q_PROPERTY(bool displayBatteryFooter READ displayBatteryFooter WRITE setDisplayBatteryFooter NOTIFY displayBatteryFooterChanged)
@@ -110,6 +111,7 @@ public:
 
     bool enablePowerMenu() const { return m_enablePowerMenu; }
     bool showPowerDialogConfirmation() const { return m_showPowerDialogConfirmation; }
+    int powerDialogTimeout() const { return m_powerDialogTimeout; }
 
     int ddcciBrightness() const { return m_ddcciBrightness; }
     bool displayBatteryFooter() const { return m_displayBatteryFooter; }
@@ -165,6 +167,7 @@ public:
 
     void setEnablePowerMenu(bool value);
     void setShowPowerDialogConfirmation(bool value);
+    void setPowerDialogTimeout(int value);
 
     void setDdcciBrightness(int value);
     void setDisplayBatteryFooter(bool value);
@@ -220,6 +223,7 @@ signals:
 
     void enablePowerMenuChanged();
     void showPowerDialogConfirmationChanged();
+    void powerDialogTimeoutChanged();
 
     void ddcciBrightnessChanged();
     void displayBatteryFooterChanged();
@@ -281,6 +285,7 @@ private:
 
     bool m_enablePowerMenu;
     bool m_showPowerDialogConfirmation;
+    int m_powerDialogTimeout;
 
     int m_ddcciBrightness;
     bool m_displayBatteryFooter;

--- a/qml/PowerConfirmationWindow.qml
+++ b/qml/PowerConfirmationWindow.qml
@@ -27,6 +27,7 @@ ApplicationWindow {
     ConfirmPowerActionDialog {
         id: powerActionDialog
         anchors.centerIn: parent
+        countdownSeconds: UserSettings.powerDialogTimeout
         onRequestClose: powerConfirmationWindow.hide()
     }
 

--- a/qml/SettingsPane/GeneralPane.qml
+++ b/qml/SettingsPane/GeneralPane.qml
@@ -34,6 +34,7 @@ ColumnLayout {
             Card {
                 Layout.fillWidth: true
                 title: qsTr("Show power action confirmation")
+                description: qsTr("Show a confirmation dialog when selecting a power action from the system tray menu")
                 additionalControl: LabeledSwitch {
                     checked: UserSettings.showPowerDialogConfirmation
                     onClicked: UserSettings.showPowerDialogConfirmation = checked
@@ -41,8 +42,10 @@ ColumnLayout {
             }
 
             Card {
+                enabled: UserSettings.showPowerDialogConfirmation
                 Layout.fillWidth: true
-                title: qsTr("Power action confirmation timeout")
+                title: qsTr("Power action confirmation timeout (seconds)")
+                description: qsTr("Time before the power action confirmation dialog automatically triggers the selected action")
                 additionalControl: SpinBox {
                     from: 1
                     to: 120

--- a/qml/SettingsPane/GeneralPane.qml
+++ b/qml/SettingsPane/GeneralPane.qml
@@ -42,6 +42,17 @@ ColumnLayout {
 
             Card {
                 Layout.fillWidth: true
+                title: qsTr("Power action confirmation timeout")
+                additionalControl: SpinBox {
+                    from: 1
+                    to: 120
+                    value: UserSettings.powerDialogTimeout
+                    onValueChanged: UserSettings.powerDialogTimeout = value
+                }
+            }
+
+            Card {
+                Layout.fillWidth: true
                 title: qsTr("Slider wheel sensivity")
                 additionalControl: SpinBox {
                     from: 1

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -150,19 +150,30 @@ ColumnLayout {
                     Layout.fillWidth: true
                     title: qsTr("Microphone Sidetone")
                     description: qsTr("Adjust your voice feedback level")
-                    additionalControl: NFSlider {
-                        from: 0
-                        to: 128
-                        value: UserSettings.headsetcontrolSidetone
-                        onPressedChanged: {
-                            if (!pressed) {
+                    additionalControl: RowLayout {
+                        spacing: 12
+
+                        NFSlider {
+                            id: sidetoneSlider
+                            from: 0
+                            to: 128
+                            value: UserSettings.headsetcontrolSidetone
+                            Layout.preferredWidth: 180
+                            onPressedChanged: {
+                                if (!pressed) {
+                                    UserSettings.headsetcontrolSidetone = Math.round(value)
+                                    HeadsetControlBridge.setSidetone(Math.round(value))
+                                }
+                            }
+                            onWheelChanged: {
                                 UserSettings.headsetcontrolSidetone = Math.round(value)
                                 HeadsetControlBridge.setSidetone(Math.round(value))
                             }
                         }
-                        onWheelChanged: {
-                            UserSettings.headsetcontrolSidetone = Math.round(value)
-                            HeadsetControlBridge.setSidetone(Math.round(value))
+
+                        Label {
+                            text: Math.round(sidetoneSlider.value).toString()
+                            opacity: 0.7
                         }
                     }
                 }

--- a/src/usersettings.cpp
+++ b/src/usersettings.cpp
@@ -75,6 +75,7 @@ void UserSettings::initProperties()
 
     m_enablePowerMenu = settings.value("enablePowerMenu", true).toBool();
     m_showPowerDialogConfirmation = settings.value("showPowerDialogConfirmation", true).toBool();
+    m_powerDialogTimeout = settings.value("powerDialogTimeout", 30).toInt();
 
     m_ddcciBrightness = settings.value("ddcciBrightness", 100).toInt();
     m_displayBatteryFooter = settings.value("displayBatteryFooter", true).toBool();
@@ -411,6 +412,15 @@ void UserSettings::setShowPowerDialogConfirmation(bool value)
         m_showPowerDialogConfirmation = value;
         saveValue("showPowerDialogConfirmation", value);
         emit showPowerDialogConfirmationChanged();
+    }
+}
+
+void UserSettings::setPowerDialogTimeout(int value)
+{
+    if (m_powerDialogTimeout != value) {
+        m_powerDialogTimeout = value;
+        saveValue("powerDialogTimeout", value);
+        emit powerDialogTimeoutChanged();
     }
 }
 


### PR DESCRIPTION
Introduces a user-configurable timeout for the power action confirmation dialog and enhances clarity in the settings UI.

### Key Changes:
*   **Power Action Confirmation Timeout:** Allows users to set the duration (1-120 seconds, default 30) before the power action confirmation dialog automatically triggers the selected action. This setting is accessible in the General settings pane and is only enabled if the confirmation dialog is active.
*   **Improved UI Feedback:** Displays the current numerical value alongside the "Microphone Sidetone" slider in the Headset Control settings, providing immediate visual feedback to the user.
*   **Enhanced Setting Descriptions:** Adds clear descriptions to relevant settings cards to better explain their purpose.