### PR TITLE
Adds default settings page and tray double-click

### DIFF
--- a/cmake/languages.cmake
+++ b/cmake/languages.cmake
@@ -1,18 +1,18 @@
 # Define all supported languages in one place
 # Format: "code|English name|native name"
 set(SUPPORTED_LANGUAGES
-    "de|German|deutsch"
     "en|English|english"
-    "es|Spanish|español"
     "fr|French|français"
+    "de|German|deutsch"
     "it|Italian|italiano"
-    "ja|Japanese|日本語"
     "ko|Korean|한국어"
-    "pl|Polish|polski"
-    "pt_BR|Portuguese (Brazil)|português (Brasil)"
     "ru|Russian|pусский"
-    "sl|Slovenian|slovenščina"
     "zh_CN|Chinese (Simplified)|简体中文"
+    "pl|Polish|polski"
+    "ja|Japanese|日本語"
+    "pt_BR|Portuguese (Brazil)|português (Brasil)"
+    "sl|Slovenian|slovenščina"
+    "es|Spanish|español"
 )
 
 # Function to extract language codes only

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -647,10 +647,6 @@ Wenn Sie meine Arbeit unterstützen möchten, freue ich mich über jeden Beitrag
         <translation>Beim Systemstart ausführen</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS wird beim Start Ihres Computers gestartet</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -741,6 +737,10 @@ Wenn Sie meine Arbeit unterstützen möchten, freue ich mich über jeden Beitrag
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>DDC/CI-Helligkeitsaktualisierungsrate</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -651,6 +651,62 @@ Wenn Sie meine Arbeit unterstützen möchten, freue ich mich über jeden Beitrag
         <translation>QSS wird beim Start Ihres Computers gestartet</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Allgemein</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">Komponenten</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Erscheinungsbild</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Medien-Overlay</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Tastenkombinationen</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished">App-Tastenkombinationen</translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">HeadsetControl</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">Umbenennung</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Sprache</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Updates</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Debug</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation>Zeige einen Bestätigungsdialog an, wenn eine Energieaktion aus dem Taskleistenmenü ausgewählt wird</translation>
     </message>
@@ -752,10 +808,6 @@ Wenn Sie meine Arbeit unterstützen möchten, freue ich mich über jeden Beitrag
     <message>
         <source>Current battery level of the connected headset</source>
         <translation>Aktueller Akkustand des angeschlossenen Headsets</translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
-        <translation>(Laden)</translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -810,6 +810,10 @@ Wenn Sie meine Arbeit unterstützen möchten, freue ich mich über jeden Beitrag
         <translation>Aktueller Akkustand des angeschlossenen Headsets</translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation>ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -647,10 +647,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>Run at system startup</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS will boot up when your computer starts</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -741,6 +737,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>DDC/CI brightness update rate</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -651,6 +651,62 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS will boot up when your computer starts</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">General</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">Components</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Appearance</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Media Overlay</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Shortcuts</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">HeadsetControl</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">Renaming</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Language</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Updates</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Debug</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -703,10 +759,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -874,6 +874,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>7 - Low battery</translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>HeadsetControl monitoring is disabled
 You can enable it in the Components tab.</source>
         <translation type="unfinished"></translation>

--- a/i18n/QontrolPanel_es.ts
+++ b/i18n/QontrolPanel_es.ts
@@ -874,6 +874,10 @@ Si quieres apoyar mi trabajo, cualquier contribución será muy apreciada.</tran
         <translation type="unfinished">7 - Batería baja</translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>HeadsetControl monitoring is disabled
 You can enable it in the Components tab.</source>
         <translation type="unfinished">La supervisión de HeadsetControl está desactivada

--- a/i18n/QontrolPanel_es.ts
+++ b/i18n/QontrolPanel_es.ts
@@ -1,1263 +1,1315 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS[]>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="es">
-  <context>
+<context>
     <name>AppHotkeysPane</name>
     <message>
-      <source>App Volume Hotkeys</source>
-      <translation type="unfinished">Atajos de volumen de aplicaciones</translation>
+        <source>App Volume Hotkeys</source>
+        <translation type="unfinished">Atajos de volumen de aplicaciones</translation>
     </message>
     <message>
-      <source>Per-application volume shortcuts</source>
-      <translation type="unfinished">Atajos de volumen por aplicación</translation>
+        <source>Per-application volume shortcuts</source>
+        <translation type="unfinished">Atajos de volumen por aplicación</translation>
     </message>
     <message>
-      <source>Assign global hotkeys to control volume of specific applications</source>
-      <translation type="unfinished">Asigna atajos globales para controlar el volumen de aplicaciones específicas</translation>
+        <source>Assign global hotkeys to control volume of specific applications</source>
+        <translation type="unfinished">Asigna atajos globales para controlar el volumen de aplicaciones específicas</translation>
     </message>
     <message>
-      <source>Add</source>
-      <translation type="unfinished">Añadir</translation>
+        <source>Add</source>
+        <translation type="unfinished">Añadir</translation>
     </message>
     <message>
-      <source>Step</source>
-      <translation type="unfinished">Paso</translation>
+        <source>Step</source>
+        <translation type="unfinished">Paso</translation>
     </message>
     <message>
-      <source>Remove</source>
-      <translation type="unfinished">Eliminar</translation>
+        <source>Remove</source>
+        <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-      <source>Add App Volume Hotkey</source>
-      <translation type="unfinished">Añadir atajo de volumen de aplicación</translation>
+        <source>Add App Volume Hotkey</source>
+        <translation type="unfinished">Añadir atajo de volumen de aplicación</translation>
     </message>
     <message>
-      <source>Application</source>
-      <translation type="unfinished">Aplicación</translation>
+        <source>Application</source>
+        <translation type="unfinished">Aplicación</translation>
     </message>
     <message>
-      <source>Volume Up Shortcut</source>
-      <translation type="unfinished">Atajo para subir el volumen</translation>
+        <source>Volume Up Shortcut</source>
+        <translation type="unfinished">Atajo para subir el volumen</translation>
     </message>
     <message>
-      <source>Click to set...</source>
-      <translation type="unfinished">Haz clic para asignar...</translation>
+        <source>Click to set...</source>
+        <translation type="unfinished">Haz clic para asignar...</translation>
     </message>
     <message>
-      <source>Volume Down Shortcut</source>
-      <translation type="unfinished">Atajo para bajar el volumen</translation>
+        <source>Volume Down Shortcut</source>
+        <translation type="unfinished">Atajo para bajar el volumen</translation>
     </message>
     <message>
-      <source>Volume Step Size</source>
-      <translation type="unfinished">Tamaño del paso de volumen</translation>
+        <source>Volume Step Size</source>
+        <translation type="unfinished">Tamaño del paso de volumen</translation>
     </message>
     <message>
-      <source>Cancel</source>
-      <translation type="unfinished">Cancelar</translation>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>AppearancePane</name>
     <message>
-      <source>Appearance &amp; Position</source>
-      <translation type="unfinished">Apariencia y posición</translation>
+        <source>Appearance &amp; Position</source>
+        <translation type="unfinished">Apariencia y posición</translation>
     </message>
     <message>
-      <source>Panel position</source>
-      <translation type="unfinished">Posición del panel</translation>
+        <source>Panel position</source>
+        <translation type="unfinished">Posición del panel</translation>
     </message>
     <message>
-      <source>Top</source>
-      <translation type="unfinished">Arriba</translation>
+        <source>Top</source>
+        <translation type="unfinished">Arriba</translation>
     </message>
     <message>
-      <source>Bottom</source>
-      <translation type="unfinished">Abajo</translation>
+        <source>Bottom</source>
+        <translation type="unfinished">Abajo</translation>
     </message>
     <message>
-      <source>Left</source>
-      <translation type="unfinished">Izquierda</translation>
+        <source>Left</source>
+        <translation type="unfinished">Izquierda</translation>
     </message>
     <message>
-      <source>Right</source>
-      <translation type="unfinished">Derecha</translation>
+        <source>Right</source>
+        <translation type="unfinished">Derecha</translation>
     </message>
     <message>
-      <source>Taskbar offset</source>
-      <translation type="unfinished">Desplazamiento de la barra de tareas</translation>
+        <source>Taskbar offset</source>
+        <translation type="unfinished">Desplazamiento de la barra de tareas</translation>
     </message>
     <message>
-      <source>Panel X margin</source>
-      <translation type="unfinished">Margen X del panel</translation>
+        <source>Panel X margin</source>
+        <translation type="unfinished">Margen X del panel</translation>
     </message>
     <message>
-      <source>Control panel X axis margin</source>
-      <translation type="unfinished">Margen del eje X del panel de control</translation>
+        <source>Control panel X axis margin</source>
+        <translation type="unfinished">Margen del eje X del panel de control</translation>
     </message>
     <message>
-      <source>Panel Y margin</source>
-      <translation type="unfinished">Margen Y del panel</translation>
+        <source>Panel Y margin</source>
+        <translation type="unfinished">Margen Y del panel</translation>
     </message>
     <message>
-      <source>Control panel Y axis margin</source>
-      <translation type="unfinished">Margen del eje Y del panel de control</translation>
+        <source>Control panel Y axis margin</source>
+        <translation type="unfinished">Margen del eje Y del panel de control</translation>
     </message>
     <message>
-      <source>Show audio level</source>
-      <translation type="unfinished">Mostrar nivel de audio</translation>
+        <source>Show audio level</source>
+        <translation type="unfinished">Mostrar nivel de audio</translation>
     </message>
     <message>
-      <source>Display audio level value in slider</source>
-      <translation type="unfinished">Mostrar el valor del nivel de audio en el control deslizante</translation>
+        <source>Display audio level value in slider</source>
+        <translation type="unfinished">Mostrar el valor del nivel de audio en el control deslizante</translation>
     </message>
     <message>
-      <source>Tray icon theme</source>
-      <translation type="unfinished">Tema del icono de la bandeja</translation>
+        <source>Tray icon theme</source>
+        <translation type="unfinished">Tema del icono de la bandeja</translation>
     </message>
     <message>
-      <source>Panel theme</source>
-      <translation type="unfinished">Tema del panel</translation>
+        <source>Panel theme</source>
+        <translation type="unfinished">Tema del panel</translation>
     </message>
     <message>
-      <source>Choose the appearance of the system tray icon</source>
-      <translation type="unfinished">Elige la apariencia del icono de la bandeja del sistema</translation>
+        <source>Choose the appearance of the system tray icon</source>
+        <translation type="unfinished">Elige la apariencia del icono de la bandeja del sistema</translation>
     </message>
     <message>
-      <source>Auto</source>
-      <translation type="unfinished">Automático</translation>
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
     </message>
     <message>
-      <source>Dark</source>
-      <translation type="unfinished">Oscuro</translation>
+        <source>Dark</source>
+        <translation type="unfinished">Oscuro</translation>
     </message>
     <message>
-      <source>Light</source>
-      <translation type="unfinished">Claro</translation>
+        <source>Light</source>
+        <translation type="unfinished">Claro</translation>
     </message>
     <message>
-      <source>Windows taskbar size (Only set if using W11 and taskbar is not at screen bottom)</source>
-      <translation type="unfinished">Tamaño de la barra de tareas de Windows (configúralo solo si usas W11 y la barra de tareas no está en la parte inferior de la pantalla)</translation>
+        <source>Windows taskbar size (Only set if using W11 and taskbar is not at screen bottom)</source>
+        <translation type="unfinished">Tamaño de la barra de tareas de Windows (configúralo solo si usas W11 y la barra de tareas no está en la parte inferior de la pantalla)</translation>
     </message>
     <message>
-      <source>Choose the color of the system tray icon</source>
-      <translation type="unfinished">Elige el color del icono de la bandeja del sistema</translation>
+        <source>Choose the color of the system tray icon</source>
+        <translation type="unfinished">Elige el color del icono de la bandeja del sistema</translation>
     </message>
     <message>
-      <source>Tray icon style</source>
-      <translation type="unfinished">Estilo del icono de la bandeja</translation>
+        <source>Tray icon style</source>
+        <translation type="unfinished">Estilo del icono de la bandeja</translation>
     </message>
     <message>
-      <source>Normal</source>
-      <translation type="unfinished">Normal</translation>
+        <source>Normal</source>
+        <translation type="unfinished">Normal</translation>
     </message>
     <message>
-      <source>Filled</source>
-      <translation type="unfinished">Relleno</translation>
+        <source>Filled</source>
+        <translation type="unfinished">Relleno</translation>
     </message>
     <message>
-      <source>Battery</source>
-      <translation type="unfinished">Batería</translation>
+        <source>Battery</source>
+        <translation type="unfinished">Batería</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ApplicationsListView</name>
     <message>
-      <source>System sounds</source>
-      <translation type="unfinished">Sonidos del sistema</translation>
+        <source>System sounds</source>
+        <translation type="unfinished">Sonidos del sistema</translation>
     </message>
     <message>
-      <source>Rename Application</source>
-      <translation type="unfinished">Cambiar nombre de la aplicación</translation>
+        <source>Rename Application</source>
+        <translation type="unfinished">Cambiar nombre de la aplicación</translation>
     </message>
     <message>
-      <source>Reset to Original Name</source>
-      <translation type="unfinished">Restablecer nombre original</translation>
+        <source>Reset to Original Name</source>
+        <translation type="unfinished">Restablecer nombre original</translation>
     </message>
     <message>
-      <source>Original name: </source>
-      <translation type="unfinished">Nombre original: </translation>
+        <source>Original name: </source>
+        <translation type="unfinished">Nombre original: </translation>
     </message>
     <message>
-      <source>Stream index: </source>
-      <translation type="unfinished">Índice de flujo: </translation>
+        <source>Stream index: </source>
+        <translation type="unfinished">Índice de flujo: </translation>
     </message>
     <message>
-      <source>Custom name:</source>
-      <translation type="unfinished">Nombre personalizado:</translation>
+        <source>Custom name:</source>
+        <translation type="unfinished">Nombre personalizado:</translation>
     </message>
     <message>
-      <source>Cancel</source>
-      <translation type="unfinished">Cancelar</translation>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-      <source>Save</source>
-      <translation type="unfinished">Guardar</translation>
+        <source>Save</source>
+        <translation type="unfinished">Guardar</translation>
     </message>
     <message>
-      <source>Unlock</source>
-      <translation type="unfinished">Desbloquear</translation>
+        <source>Unlock</source>
+        <translation type="unfinished">Desbloquear</translation>
     </message>
     <message>
-      <source>Lock</source>
-      <translation type="unfinished">Bloquear</translation>
+        <source>Lock</source>
+        <translation type="unfinished">Bloquear</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>AudioWorker</name>
     <message>
-      <source>System sounds</source>
-      <translation type="unfinished">Sonidos del sistema</translation>
+        <source>System sounds</source>
+        <translation type="unfinished">Sonidos del sistema</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ChatMixNotification</name>
     <message>
-      <source>Microphone Muted</source>
-      <translation type="unfinished">Micrófono silenciado</translation>
+        <source>Microphone Muted</source>
+        <translation type="unfinished">Micrófono silenciado</translation>
     </message>
     <message>
-      <source>Microphone Unmuted</source>
-      <translation type="unfinished">Micrófono reactivado</translation>
+        <source>Microphone Unmuted</source>
+        <translation type="unfinished">Micrófono reactivado</translation>
     </message>
     <message>
-      <source>ChatMix Enabled</source>
-      <translation type="unfinished">ChatMix activado</translation>
+        <source>ChatMix Enabled</source>
+        <translation type="unfinished">ChatMix activado</translation>
     </message>
     <message>
-      <source>ChatMix Disabled</source>
-      <translation type="unfinished">ChatMix desactivado</translation>
+        <source>ChatMix Disabled</source>
+        <translation type="unfinished">ChatMix desactivado</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>CommAppsPane</name>
     <message>
-      <source>Communication Apps</source>
-      <translation type="unfinished">Aplicaciones de comunicación</translation>
+        <source>Communication Apps</source>
+        <translation type="unfinished">Aplicaciones de comunicación</translation>
     </message>
     <message>
-      <source>Enable ChatMix</source>
-      <translation type="unfinished">Activar ChatMix</translation>
+        <source>Enable ChatMix</source>
+        <translation type="unfinished">Activar ChatMix</translation>
     </message>
     <message>
-      <source>Control communication apps separately from other applications</source>
-      <translation type="unfinished">Controla las aplicaciones de comunicación por separado del resto de aplicaciones</translation>
+        <source>Control communication apps separately from other applications</source>
+        <translation type="unfinished">Controla las aplicaciones de comunicación por separado del resto de aplicaciones</translation>
     </message>
     <message>
-      <source>Restored volume</source>
-      <translation type="unfinished">Volumen restaurado</translation>
+        <source>Restored volume</source>
+        <translation type="unfinished">Volumen restaurado</translation>
     </message>
     <message>
-      <source>The volume to set for applications when ChatMix is disabled</source>
-      <translation type="unfinished">El volumen que se establecerá para las aplicaciones cuando ChatMix esté desactivado</translation>
+        <source>The volume to set for applications when ChatMix is disabled</source>
+        <translation type="unfinished">El volumen que se establecerá para las aplicaciones cuando ChatMix esté desactivado</translation>
     </message>
     <message>
-      <source>Communication Applications</source>
-      <translation type="unfinished">Aplicaciones de comunicación</translation>
+        <source>Communication Applications</source>
+        <translation type="unfinished">Aplicaciones de comunicación</translation>
     </message>
     <message>
-      <source>Discord</source>
-      <translation type="unfinished">Discord</translation>
+        <source>Discord</source>
+        <translation type="unfinished">Discord</translation>
     </message>
     <message>
-      <source>Add App</source>
-      <translation type="unfinished">Añadir aplicación</translation>
+        <source>Add App</source>
+        <translation type="unfinished">Añadir aplicación</translation>
     </message>
     <message>
-      <source>ChatMix volume</source>
-      <translation type="unfinished">Volumen de ChatMix</translation>
+        <source>ChatMix volume</source>
+        <translation type="unfinished">Volumen de ChatMix</translation>
     </message>
     <message>
-      <source>Add application names that should be treated as communication apps</source>
-      <translation type="unfinished">Añade nombres de aplicaciones que deban tratarse como aplicaciones de comunicación</translation>
+        <source>Add application names that should be treated as communication apps</source>
+        <translation type="unfinished">Añade nombres de aplicaciones que deban tratarse como aplicaciones de comunicación</translation>
     </message>
     <message>
-      <source>Remove</source>
-      <translation type="unfinished">Eliminar</translation>
+        <source>Remove</source>
+        <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-      <source>Enable ChatMix Warning</source>
-      <translation type="unfinished">Aviso de activación de ChatMix</translation>
+        <source>Enable ChatMix Warning</source>
+        <translation type="unfinished">Aviso de activación de ChatMix</translation>
     </message>
     <message>
-      <source>Activating ChatMix will initially set all non communication application volumes to 50%. This might cause loud audio output.</source>
-      <translation type="unfinished">Al activar ChatMix, inicialmente se establecerá el volumen de todas las aplicaciones que no sean de comunicación en un 50 %. Esto podría provocar un audio muy alto.</translation>
+        <source>Activating ChatMix will initially set all non communication application volumes to 50%. This might cause loud audio output.</source>
+        <translation type="unfinished">Al activar ChatMix, inicialmente se establecerá el volumen de todas las aplicaciones que no sean de comunicación en un 50 %. Esto podría provocar un audio muy alto.</translation>
     </message>
     <message>
-      <source>It is recommended to lower your master volume before proceeding to avoid sudden loud sounds.</source>
-      <translation type="unfinished">Se recomienda bajar el volumen maestro antes de continuar para evitar sonidos repentinos muy altos.</translation>
+        <source>It is recommended to lower your master volume before proceeding to avoid sudden loud sounds.</source>
+        <translation type="unfinished">Se recomienda bajar el volumen maestro antes de continuar para evitar sonidos repentinos muy altos.</translation>
     </message>
     <message>
-      <source>Activate</source>
-      <translation type="unfinished">Activar</translation>
+        <source>Activate</source>
+        <translation type="unfinished">Activar</translation>
     </message>
     <message>
-      <source>Add Communication App</source>
-      <translation type="unfinished">Añadir aplicación de comunicación</translation>
+        <source>Add Communication App</source>
+        <translation type="unfinished">Añadir aplicación de comunicación</translation>
     </message>
     <message>
-      <source>Enter application name (e.g., Discord)</source>
-      <translation type="unfinished">Introduce el nombre de la aplicación (p. ej., Discord)</translation>
+        <source>Enter application name (e.g., Discord)</source>
+        <translation type="unfinished">Introduce el nombre de la aplicación (p. ej., Discord)</translation>
     </message>
     <message>
-      <source>Cancel</source>
-      <translation type="unfinished">Cancelar</translation>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-      <source>Add</source>
-      <translation type="unfinished">Añadir</translation>
+        <source>Add</source>
+        <translation type="unfinished">Añadir</translation>
     </message>
     <message>
-      <source>The volume to set for non communication applications when ChatMix is enabled</source>
-      <translation type="unfinished">El volumen que se establecerá para las aplicaciones que no son de comunicación cuando ChatMix esté activado</translation>
+        <source>The volume to set for non communication applications when ChatMix is enabled</source>
+        <translation type="unfinished">El volumen que se establecerá para las aplicaciones que no son de comunicación cuando ChatMix esté activado</translation>
     </message>
     <message>
-      <source>Activate ChatMix</source>
-      <translation type="unfinished">Activar ChatMix</translation>
+        <source>Activate ChatMix</source>
+        <translation type="unfinished">Activar ChatMix</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ComponentsPane</name>
     <message>
-      <source>Components</source>
-      <translation type="unfinished">Componentes</translation>
+        <source>Components</source>
+        <translation type="unfinished">Componentes</translation>
     </message>
     <message>
-      <source>Enable power menu</source>
-      <translation type="unfinished">Activar menú de energía</translation>
+        <source>Enable power menu</source>
+        <translation type="unfinished">Activar menú de energía</translation>
     </message>
     <message>
-      <source>Show power button in the panel footer</source>
-      <translation type="unfinished">Mostrar el botón de encendido en el pie del panel</translation>
+        <source>Show power button in the panel footer</source>
+        <translation type="unfinished">Mostrar el botón de encendido en el pie del panel</translation>
     </message>
     <message>
-      <source>Enable brightness control</source>
-      <translation type="unfinished">Activar control de brillo</translation>
+        <source>Enable brightness control</source>
+        <translation type="unfinished">Activar control de brillo</translation>
     </message>
     <message>
-      <source>Enable HeadsetControl integration</source>
-      <translation type="unfinished">Activar integración con HeadsetControl</translation>
+        <source>Enable HeadsetControl integration</source>
+        <translation type="unfinished">Activar integración con HeadsetControl</translation>
     </message>
     <message>
-      <source>Monitor battery using HeadsetControl for supported devices</source>
-      <translation type="unfinished">Supervisar la batería mediante HeadsetControl en dispositivos compatibles</translation>
+        <source>Monitor battery using HeadsetControl for supported devices</source>
+        <translation type="unfinished">Supervisar la batería mediante HeadsetControl en dispositivos compatibles</translation>
     </message>
     <message>
-      <source>Enable audio device manager</source>
-      <translation type="unfinished">Activar administrador de dispositivos de audio</translation>
+        <source>Enable audio device manager</source>
+        <translation type="unfinished">Activar administrador de dispositivos de audio</translation>
     </message>
     <message>
-      <source>Display audio device manager in panel</source>
-      <translation type="unfinished">Mostrar el administrador de dispositivos de audio en el panel</translation>
+        <source>Display audio device manager in panel</source>
+        <translation type="unfinished">Mostrar el administrador de dispositivos de audio en el panel</translation>
     </message>
     <message>
-      <source>Enable application volume mixer</source>
-      <translation type="unfinished">Activar mezclador de volumen por aplicación</translation>
+        <source>Enable application volume mixer</source>
+        <translation type="unfinished">Activar mezclador de volumen por aplicación</translation>
     </message>
     <message>
-      <source>Display application volume mixer in panel</source>
-      <translation type="unfinished">Mostrar el mezclador de volumen por aplicación en el panel</translation>
+        <source>Display application volume mixer in panel</source>
+        <translation type="unfinished">Mostrar el mezclador de volumen por aplicación en el panel</translation>
     </message>
     <message>
-      <source>Show brightness control in panel</source>
-      <translation type="unfinished">Mostrar el control de brillo en el panel</translation>
+        <source>Show brightness control in panel</source>
+        <translation type="unfinished">Mostrar el control de brillo en el panel</translation>
     </message>
     <message>
-      <source>Enable media session manager</source>
-      <translation type="unfinished">Activar administrador de sesiones multimedia</translation>
+        <source>Enable media session manager</source>
+        <translation type="unfinished">Activar administrador de sesiones multimedia</translation>
     </message>
     <message>
-      <source>Display currently playing media from Windows known sources</source>
-      <translation type="unfinished">Mostrar el contenido multimedia que se está reproduciendo desde fuentes conocidas de Windows</translation>
+        <source>Display currently playing media from Windows known sources</source>
+        <translation type="unfinished">Mostrar el contenido multimedia que se está reproduciendo desde fuentes conocidas de Windows</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ConfirmPowerActionDialog</name>
     <message>
-      <source>System will hibernate in %1 seconds</source>
-      <translation type="unfinished">El sistema hibernará en %1 segundos</translation>
+        <source>System will hibernate in %1 seconds</source>
+        <translation type="unfinished">El sistema hibernará en %1 segundos</translation>
     </message>
     <message>
-      <source>System will restart in %1 seconds</source>
-      <translation type="unfinished">El sistema se reiniciará en %1 segundos</translation>
+        <source>System will restart in %1 seconds</source>
+        <translation type="unfinished">El sistema se reiniciará en %1 segundos</translation>
     </message>
     <message>
-      <source>System will shutdown in %1 seconds</source>
-      <translation type="unfinished">El sistema se apagará en %1 segundos</translation>
+        <source>System will shutdown in %1 seconds</source>
+        <translation type="unfinished">El sistema se apagará en %1 segundos</translation>
     </message>
     <message>
-      <source>You will be signed out in %1 seconds</source>
-      <translation type="unfinished">La sesión se cerrará en %1 segundos</translation>
+        <source>You will be signed out in %1 seconds</source>
+        <translation type="unfinished">La sesión se cerrará en %1 segundos</translation>
     </message>
     <message>
-      <source>Hibernate</source>
-      <translation type="unfinished">Hibernar</translation>
+        <source>Hibernate</source>
+        <translation type="unfinished">Hibernar</translation>
     </message>
     <message>
-      <source>Restart</source>
-      <translation type="unfinished">Reiniciar</translation>
+        <source>Restart</source>
+        <translation type="unfinished">Reiniciar</translation>
     </message>
     <message>
-      <source>Shutdown</source>
-      <translation type="unfinished">Apagar</translation>
+        <source>Shutdown</source>
+        <translation type="unfinished">Apagar</translation>
     </message>
     <message>
-      <source>Sign Out</source>
-      <translation type="unfinished">Cerrar sesión</translation>
+        <source>Sign Out</source>
+        <translation type="unfinished">Cerrar sesión</translation>
     </message>
     <message>
-      <source>Restart to UEFI</source>
-      <translation type="unfinished">Reiniciar en UEFI</translation>
+        <source>Restart to UEFI</source>
+        <translation type="unfinished">Reiniciar en UEFI</translation>
     </message>
     <message>
-      <source>System will restart to UEFI in %1 seconds</source>
-      <translation type="unfinished">El sistema se reiniciará en UEFI en %1 segundos</translation>
+        <source>System will restart to UEFI in %1 seconds</source>
+        <translation type="unfinished">El sistema se reiniciará en UEFI en %1 segundos</translation>
     </message>
     <message>
-      <source>OK</source>
-      <translation type="unfinished">Aceptar</translation>
+        <source>OK</source>
+        <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-      <source>Cancel</source>
-      <translation type="unfinished">Cancelar</translation>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-      <source>Action</source>
-      <translation type="unfinished">Acción</translation>
+        <source>Action</source>
+        <translation type="unfinished">Acción</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ConsolePane</name>
     <message>
-      <source>Console output</source>
-      <translation type="unfinished">Salida de consola</translation>
+        <source>Console output</source>
+        <translation type="unfinished">Salida de consola</translation>
     </message>
     <message>
-      <source>Filter by:</source>
-      <translation type="unfinished">Filtrar por:</translation>
+        <source>Filter by:</source>
+        <translation type="unfinished">Filtrar por:</translation>
     </message>
     <message>
-      <source>Auto-scroll</source>
-      <translation type="unfinished">Desplazamiento automático</translation>
+        <source>Auto-scroll</source>
+        <translation type="unfinished">Desplazamiento automático</translation>
     </message>
     <message>
-      <source>Copy All</source>
-      <translation type="unfinished">Copiar todo</translation>
+        <source>Copy All</source>
+        <translation type="unfinished">Copiar todo</translation>
     </message>
     <message>
-      <source>Clear</source>
-      <translation type="unfinished">Limpiar</translation>
+        <source>Clear</source>
+        <translation type="unfinished">Limpiar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DebugPane</name>
     <message>
-      <source>Debug and information</source>
-      <translation type="unfinished">Depuración e información</translation>
+        <source>Debug and information</source>
+        <translation type="unfinished">Depuración e información</translation>
     </message>
     <message>
-      <source>Application version</source>
-      <translation type="unfinished">Versión de la aplicación</translation>
+        <source>Application version</source>
+        <translation type="unfinished">Versión de la aplicación</translation>
     </message>
     <message>
-      <source>QT version</source>
-      <translation type="unfinished">Versión de QT</translation>
+        <source>QT version</source>
+        <translation type="unfinished">Versión de QT</translation>
     </message>
     <message>
-      <source>Commit</source>
-      <translation type="unfinished">Commit</translation>
+        <source>Commit</source>
+        <translation type="unfinished">Commit</translation>
     </message>
     <message>
-      <source>Build date</source>
-      <translation type="unfinished">Fecha de compilación</translation>
+        <source>Build date</source>
+        <translation type="unfinished">Fecha de compilación</translation>
     </message>
     <message>
-      <source>Application Updates</source>
-      <translation type="unfinished">Actualizaciones de la aplicación</translation>
+        <source>Application Updates</source>
+        <translation type="unfinished">Actualizaciones de la aplicación</translation>
     </message>
     <message>
-      <source>Version %1 is available</source>
-      <translation type="unfinished">La versión %1 está disponible</translation>
+        <source>Version %1 is available</source>
+        <translation type="unfinished">La versión %1 está disponible</translation>
     </message>
     <message>
-      <source>Checking...</source>
-      <translation type="unfinished">Comprobando...</translation>
+        <source>Checking...</source>
+        <translation type="unfinished">Comprobando...</translation>
     </message>
     <message>
-      <source>Downloading...</source>
-      <translation type="unfinished">Descargando...</translation>
+        <source>Downloading...</source>
+        <translation type="unfinished">Descargando...</translation>
     </message>
     <message>
-      <source>Check for Updates</source>
-      <translation type="unfinished">Buscar actualizaciones</translation>
+        <source>Check for Updates</source>
+        <translation type="unfinished">Buscar actualizaciones</translation>
     </message>
     <message>
-      <source>Download and Install</source>
-      <translation type="unfinished">Descargar e instalar</translation>
+        <source>Download and Install</source>
+        <translation type="unfinished">Descargar e instalar</translation>
     </message>
     <message>
-      <source>Release notes</source>
-      <translation type="unfinished">Notas de la versión</translation>
+        <source>Release notes</source>
+        <translation type="unfinished">Notas de la versión</translation>
     </message>
     <message>
-      <source>View what's new in version %1</source>
-      <translation type="unfinished">Ver las novedades de la versión %1</translation>
+        <source>View what&apos;s new in version %1</source>
+        <translation type="unfinished">Ver las novedades de la versión %1</translation>
     </message>
     <message>
-      <source>Show</source>
-      <translation type="unfinished">Mostrar</translation>
+        <source>Show</source>
+        <translation type="unfinished">Mostrar</translation>
     </message>
     <message>
-      <source>No release notes available</source>
-      <translation type="unfinished">No hay notas de versión disponibles</translation>
+        <source>No release notes available</source>
+        <translation type="unfinished">No hay notas de versión disponibles</translation>
     </message>
     <message>
-      <source>Version %1</source>
-      <translation type="unfinished">Versión %1</translation>
+        <source>Version %1</source>
+        <translation type="unfinished">Versión %1</translation>
     </message>
     <message>
-      <source>Auto check for app updates</source>
-      <translation type="unfinished">Comprobar automáticamente actualizaciones de la aplicación</translation>
+        <source>Auto check for app updates</source>
+        <translation type="unfinished">Comprobar automáticamente actualizaciones de la aplicación</translation>
     </message>
     <message>
-      <source>Check for application updates at startup and every 4 hours</source>
-      <translation type="unfinished">Buscar actualizaciones de la aplicación al iniciar y cada 4 horas</translation>
+        <source>Check for application updates at startup and every 4 hours</source>
+        <translation type="unfinished">Buscar actualizaciones de la aplicación al iniciar y cada 4 horas</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DeviceRenamingPane</name>
     <message>
-      <source>Renaming</source>
-      <translation type="unfinished">Cambio de nombre</translation>
+        <source>Renaming</source>
+        <translation type="unfinished">Cambio de nombre</translation>
     </message>
     <message>
-      <source>Show:</source>
-      <translation type="unfinished">Mostrar:</translation>
+        <source>Show:</source>
+        <translation type="unfinished">Mostrar:</translation>
     </message>
     <message>
-      <source>Devices</source>
-      <translation type="unfinished">Dispositivos</translation>
+        <source>Devices</source>
+        <translation type="unfinished">Dispositivos</translation>
     </message>
     <message>
-      <source>Applications</source>
-      <translation type="unfinished">Aplicaciones</translation>
+        <source>Applications</source>
+        <translation type="unfinished">Aplicaciones</translation>
     </message>
     <message>
-      <source>Streams</source>
-      <translation type="unfinished">Flujos</translation>
+        <source>Streams</source>
+        <translation type="unfinished">Flujos</translation>
     </message>
     <message>
-      <source>Custom name</source>
-      <translation type="unfinished">Nombre personalizado</translation>
+        <source>Custom name</source>
+        <translation type="unfinished">Nombre personalizado</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DevicesListView</name>
     <message>
-      <source>Rename Device</source>
-      <translation type="unfinished">Cambiar nombre del dispositivo</translation>
+        <source>Rename Device</source>
+        <translation type="unfinished">Cambiar nombre del dispositivo</translation>
     </message>
     <message>
-      <source>Reset to Original Name</source>
-      <translation type="unfinished">Restablecer nombre original</translation>
+        <source>Reset to Original Name</source>
+        <translation type="unfinished">Restablecer nombre original</translation>
     </message>
     <message>
-      <source>Cancel</source>
-      <translation type="unfinished">Cancelar</translation>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-      <source>Save</source>
-      <translation type="unfinished">Guardar</translation>
+        <source>Save</source>
+        <translation type="unfinished">Guardar</translation>
     </message>
     <message>
-      <source>Change Icon</source>
-      <translation type="unfinished">Cambiar icono</translation>
+        <source>Change Icon</source>
+        <translation type="unfinished">Cambiar icono</translation>
     </message>
     <message>
-      <source>Change Device Icon</source>
-      <translation type="unfinished">Cambiar icono del dispositivo</translation>
+        <source>Change Device Icon</source>
+        <translation type="unfinished">Cambiar icono del dispositivo</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>DonatePopup</name>
     <message>
-      <source>Found this app useful?</source>
-      <translation type="unfinished">¿Te ha resultado útil esta aplicación?</translation>
+        <source>Found this app useful?</source>
+        <translation type="unfinished">¿Te ha resultado útil esta aplicación?</translation>
     </message>
     <message>
-      <source>This app is made with care by an independent developer and is not financed by ad revenue.
-If you'd like to support my work, any contribution would be greatly appreciated!</source>
-      <translation type="unfinished">Esta aplicación ha sido creada con cuidado por un desarrollador independiente y no se financia con publicidad.
+        <source>This app is made with care by an independent developer and is not financed by ad revenue.
+If you&apos;d like to support my work, any contribution would be greatly appreciated!</source>
+        <translation type="unfinished">Esta aplicación ha sido creada con cuidado por un desarrollador independiente y no se financia con publicidad.
 Si quieres apoyar mi trabajo, cualquier contribución será muy apreciada.</translation>
     </message>
     <message>
-      <source>Support</source>
-      <translation type="unfinished">Apoyar</translation>
+        <source>Support</source>
+        <translation type="unfinished">Apoyar</translation>
     </message>
     <message>
-      <source>Maybe later</source>
-      <translation type="unfinished">Quizá más tarde</translation>
+        <source>Maybe later</source>
+        <translation type="unfinished">Quizá más tarde</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ExecutableRenameContextMenu</name>
     <message>
-      <source>Rename Application</source>
-      <translation type="unfinished">Cambiar nombre de la aplicación</translation>
+        <source>Rename Application</source>
+        <translation type="unfinished">Cambiar nombre de la aplicación</translation>
     </message>
     <message>
-      <source>Reset to Original Name</source>
-      <translation type="unfinished">Restablecer nombre original</translation>
+        <source>Reset to Original Name</source>
+        <translation type="unfinished">Restablecer nombre original</translation>
     </message>
     <message>
-      <source>Mute in Background</source>
-      <translation type="unfinished">Silenciar en segundo plano</translation>
+        <source>Mute in Background</source>
+        <translation type="unfinished">Silenciar en segundo plano</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ExecutableRenameDialog</name>
     <message>
-      <source>Rename Application</source>
-      <translation type="unfinished">Cambiar nombre de la aplicación</translation>
+        <source>Rename Application</source>
+        <translation type="unfinished">Cambiar nombre de la aplicación</translation>
     </message>
     <message>
-      <source>Original name: </source>
-      <translation type="unfinished">Nombre original: </translation>
+        <source>Original name: </source>
+        <translation type="unfinished">Nombre original: </translation>
     </message>
     <message>
-      <source>Custom name:</source>
-      <translation type="unfinished">Nombre personalizado:</translation>
+        <source>Custom name:</source>
+        <translation type="unfinished">Nombre personalizado:</translation>
     </message>
     <message>
-      <source>Cancel</source>
-      <translation type="unfinished">Cancelar</translation>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-      <source>Save</source>
-      <translation type="unfinished">Guardar</translation>
+        <source>Save</source>
+        <translation type="unfinished">Guardar</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>GeneralPane</name>
     <message>
-      <source>General Settings</source>
-      <translation type="unfinished">Configuración general</translation>
+        <source>General Settings</source>
+        <translation type="unfinished">Configuración general</translation>
     </message>
     <message>
-      <source>Run at system startup</source>
-      <translation type="unfinished">Iniciar con el sistema</translation>
+        <source>Run at system startup</source>
+        <translation type="unfinished">Iniciar con el sistema</translation>
     </message>
     <message>
-      <source>QSS will boot up when your computer starts</source>
-      <translation type="unfinished">QSS se iniciará cuando arranque el equipo</translation>
+        <source>QSS will boot up when your computer starts</source>
+        <translation type="unfinished">QSS se iniciará cuando arranque el equipo</translation>
     </message>
     <message>
-      <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
-      <translation type="unfinished">Mostrar un cuadro de confirmación al seleccionar una acción de energía en el menú de la bandeja del sistema</translation>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-      <source>Power action confirmation timeout (seconds)</source>
-      <translation type="unfinished">Tiempo de espera de confirmación de acción de energía (segundos)</translation>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-      <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
-      <translation type="unfinished">Tiempo antes de que el cuadro de confirmación de acción de energía ejecute automáticamente la acción seleccionada</translation>
+        <source>General</source>
+        <translation type="unfinished">General</translation>
     </message>
     <message>
-      <source>Slider wheel sensivity</source>
-      <translation type="unfinished">Sensibilidad de la rueda del control deslizante</translation>
+        <source>Components</source>
+        <translation type="unfinished">Componentes</translation>
     </message>
     <message>
-      <source>Normal</source>
-      <translation type="unfinished">Normal</translation>
+        <source>Appearance</source>
+        <translation type="unfinished">Apariencia</translation>
     </message>
     <message>
-      <source>Fast</source>
-      <translation type="unfinished">Rápido</translation>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Superposición multimedia</translation>
     </message>
     <message>
-      <source>Faster</source>
-      <translation type="unfinished">Más rápido</translation>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
-      <source>Lightspeed</source>
-      <translation type="unfinished">Ultrarrápido</translation>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Atajos</translation>
     </message>
     <message>
-      <source>DDC/CI brightness update rate</source>
-      <translation type="unfinished">Frecuencia de actualización del brillo DDC/CI</translation>
+        <source>App Hotkeys</source>
+        <translation type="unfinished">Atajos de apps</translation>
     </message>
     <message>
-      <source>Controls how frequently brightness commands are sent to external monitors</source>
-      <translation type="unfinished">Controla con qué frecuencia se envían comandos de brillo a los monitores externos</translation>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">HeadsetControl</translation>
     </message>
     <message>
-      <source>Show power action confirmation</source>
-      <translation type="unfinished">Mostrar confirmación de acciones de energía</translation>
+        <source>Renaming</source>
+        <translation type="unfinished">Cambio de nombre</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Idioma</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Actualizaciones</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Depuración</translation>
+    </message>
+    <message>
+        <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
+        <translation type="unfinished">Mostrar un cuadro de confirmación al seleccionar una acción de energía en el menú de la bandeja del sistema</translation>
+    </message>
+    <message>
+        <source>Power action confirmation timeout (seconds)</source>
+        <translation type="unfinished">Tiempo de espera de confirmación de acción de energía (segundos)</translation>
+    </message>
+    <message>
+        <source>Time before the power action confirmation dialog automatically triggers the selected action</source>
+        <translation type="unfinished">Tiempo antes de que el cuadro de confirmación de acción de energía ejecute automáticamente la acción seleccionada</translation>
+    </message>
+    <message>
+        <source>Slider wheel sensivity</source>
+        <translation type="unfinished">Sensibilidad de la rueda del control deslizante</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation type="unfinished">Normal</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation type="unfinished">Rápido</translation>
+    </message>
+    <message>
+        <source>Faster</source>
+        <translation type="unfinished">Más rápido</translation>
+    </message>
+    <message>
+        <source>Lightspeed</source>
+        <translation type="unfinished">Ultrarrápido</translation>
+    </message>
+    <message>
+        <source>DDC/CI brightness update rate</source>
+        <translation type="unfinished">Frecuencia de actualización del brillo DDC/CI</translation>
+    </message>
+    <message>
+        <source>Controls how frequently brightness commands are sent to external monitors</source>
+        <translation type="unfinished">Controla con qué frecuencia se envían comandos de brillo a los monitores externos</translation>
+    </message>
+    <message>
+        <source>Show power action confirmation</source>
+        <translation type="unfinished">Mostrar confirmación de acciones de energía</translation>
+    </message>
+</context>
+<context>
     <name>HeadsetControlPane</name>
     <message>
-      <source>No compatible device found.</source>
-      <translation type="unfinished">No se encontró ningún dispositivo compatible.</translation>
+        <source>No compatible device found.</source>
+        <translation type="unfinished">No se encontró ningún dispositivo compatible.</translation>
     </message>
     <message>
-      <source>Current battery level of the connected headset</source>
-      <translation type="unfinished">Nivel de batería actual de los auriculares conectados</translation>
+        <source>Current battery level of the connected headset</source>
+        <translation type="unfinished">Nivel de batería actual de los auriculares conectados</translation>
     </message>
     <message>
-      <source>(Charging)</source>
-      <translation type="unfinished">(Cargando)</translation>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
-      <source>ChatMix</source>
-      <translation type="unfinished">ChatMix</translation>
+        <source>ChatMix value of the connected headset</source>
+        <translation type="unfinished">Valor de ChatMix de los auriculares conectados</translation>
     </message>
     <message>
-      <source>ChatMix value of the connected headset</source>
-      <translation type="unfinished">Valor de ChatMix de los auriculares conectados</translation>
+        <source>Show battery status in panel footer</source>
+        <translation type="unfinished">Mostrar el estado de la batería en el pie del panel</translation>
     </message>
     <message>
-      <source>Show battery status in panel footer</source>
-      <translation type="unfinished">Mostrar el estado de la batería en el pie del panel</translation>
+        <source>Inactive time (minutes)</source>
+        <translation type="unfinished">Tiempo de inactividad (minutos)</translation>
     </message>
     <message>
-      <source>Inactive time (minutes)</source>
-      <translation type="unfinished">Tiempo de inactividad (minutos)</translation>
+        <source>Set the time of inactivity after which your headset will enter power-saving mode</source>
+        <translation type="unfinished">Establece el tiempo de inactividad tras el cual tus auriculares entrarán en modo de ahorro de energía</translation>
     </message>
     <message>
-      <source>Set the time of inactivity after which your headset will enter power-saving mode</source>
-      <translation type="unfinished">Establece el tiempo de inactividad tras el cual tus auriculares entrarán en modo de ahorro de energía</translation>
+        <source>Lights</source>
+        <translation type="unfinished">Luces</translation>
     </message>
     <message>
-      <source>Lights</source>
-      <translation type="unfinished">Luces</translation>
+        <source>Toggle RGB lights on your headset</source>
+        <translation type="unfinished">Activar o desactivar las luces RGB de tus auriculares</translation>
     </message>
     <message>
-      <source>Toggle RGB lights on your headset</source>
-      <translation type="unfinished">Activar o desactivar las luces RGB de tus auriculares</translation>
+        <source>Toggle rotate-to-mute feature on your headset</source>
+        <translation type="unfinished">Activar o desactivar la función de girar para silenciar en tus auriculares</translation>
     </message>
     <message>
-      <source>Toggle rotate-to-mute feature on your headset</source>
-      <translation type="unfinished">Activar o desactivar la función de girar para silenciar en tus auriculares</translation>
+        <source>Adjust your voice feedback level</source>
+        <translation type="unfinished">Ajusta el nivel de retorno de tu voz</translation>
     </message>
     <message>
-      <source>Adjust your voice feedback level</source>
-      <translation type="unfinished">Ajusta el nivel de retorno de tu voz</translation>
+        <source>Notification on low battery</source>
+        <translation type="unfinished">Notificación de batería baja</translation>
     </message>
     <message>
-      <source>Notification on low battery</source>
-      <translation type="unfinished">Notificación de batería baja</translation>
+        <source>Rotate-to-Mute</source>
+        <translation type="unfinished">Girar para silenciar</translation>
     </message>
     <message>
-      <source>Rotate-to-Mute</source>
-      <translation type="unfinished">Girar para silenciar</translation>
+        <source>Sidetone</source>
+        <translation type="unfinished">Retorno de voz</translation>
     </message>
     <message>
-      <source>Sidetone</source>
-      <translation type="unfinished">Retorno de voz</translation>
+        <source>Voice Prompts</source>
+        <translation type="unfinished">Indicaciones de voz</translation>
     </message>
     <message>
-      <source>Voice Prompts</source>
-      <translation type="unfinished">Indicaciones de voz</translation>
+        <source>Toggle voice prompts on your headset</source>
+        <translation type="unfinished">Activar o desactivar las indicaciones de voz en tus auriculares</translation>
     </message>
     <message>
-      <source>Toggle voice prompts on your headset</source>
-      <translation type="unfinished">Activar o desactivar las indicaciones de voz en tus auriculares</translation>
+        <source>Fetch rate (seconds)</source>
+        <translation type="unfinished">Intervalo de actualización (segundos)</translation>
     </message>
     <message>
-      <source>Fetch rate (seconds)</source>
-      <translation type="unfinished">Intervalo de actualización (segundos)</translation>
+        <source>Device battery</source>
+        <translation type="unfinished">Batería del dispositivo</translation>
     </message>
     <message>
-      <source>Device battery</source>
-      <translation type="unfinished">Batería del dispositivo</translation>
+        <source>Enable test mode below to simulate a supported headset and validate the HeadsetControl UI.</source>
+        <translation type="unfinished">Activa el modo de prueba a continuación para simular unos auriculares compatibles y validar la interfaz de HeadsetControl.</translation>
     </message>
     <message>
-      <source>Enable test mode below to simulate a supported headset and validate the HeadsetControl UI.</source>
-      <translation type="unfinished">Activa el modo de prueba a continuación para simular unos auriculares compatibles y validar la interfaz de HeadsetControl.</translation>
+        <source>HeadsetControl test mode</source>
+        <translation type="unfinished">Modo de prueba de HeadsetControl</translation>
     </message>
     <message>
-      <source>HeadsetControl test mode</source>
-      <translation type="unfinished">Modo de prueba de HeadsetControl</translation>
+        <source>Simulate a supported headset for testing. This stays enabled until the app closes.</source>
+        <translation type="unfinished">Simula unos auriculares compatibles para hacer pruebas. Esto permanecerá activado hasta que se cierre la aplicación.</translation>
     </message>
     <message>
-      <source>Simulate a supported headset for testing. This stays enabled until the app closes.</source>
-      <translation type="unfinished">Simula unos auriculares compatibles para hacer pruebas. Esto permanecerá activado hasta que se cierre la aplicación.</translation>
+        <source>Test headset profile</source>
+        <translation type="unfinished">Perfil de auriculares de prueba</translation>
     </message>
     <message>
-      <source>Test headset profile</source>
-      <translation type="unfinished">Perfil de auriculares de prueba</translation>
+        <source>Choose which synthetic headset scenario HeadsetControl should simulate.</source>
+        <translation type="unfinished">Elige qué escenario sintético de auriculares debe simular HeadsetControl.</translation>
     </message>
     <message>
-      <source>Choose which synthetic headset scenario HeadsetControl should simulate.</source>
-      <translation type="unfinished">Elige qué escenario sintético de auriculares debe simular HeadsetControl.</translation>
+        <source>1 - Error conditions</source>
+        <translation type="unfinished">1 - Condiciones de error</translation>
     </message>
     <message>
-      <source>1 - Error conditions</source>
-      <translation type="unfinished">1 - Condiciones de error</translation>
+        <source>2 - Charging battery</source>
+        <translation type="unfinished">2 - Batería cargándose</translation>
     </message>
     <message>
-      <source>2 - Charging battery</source>
-      <translation type="unfinished">2 - Batería cargándose</translation>
+        <source>3 - Basic battery</source>
+        <translation type="unfinished">3 - Batería básica</translation>
     </message>
     <message>
-      <source>3 - Basic battery</source>
-      <translation type="unfinished">3 - Batería básica</translation>
+        <source>4 - Battery unavailable</source>
+        <translation type="unfinished">4 - Batería no disponible</translation>
     </message>
     <message>
-      <source>4 - Battery unavailable</source>
-      <translation type="unfinished">4 - Batería no disponible</translation>
+        <source>5 - Timeout</source>
+        <translation type="unfinished">5 - Tiempo de espera agotado</translation>
     </message>
     <message>
-      <source>5 - Timeout</source>
-      <translation type="unfinished">5 - Tiempo de espera agotado</translation>
+        <source>6 - Full battery</source>
+        <translation type="unfinished">6 - Batería completa</translation>
     </message>
     <message>
-      <source>6 - Full battery</source>
-      <translation type="unfinished">6 - Batería completa</translation>
+        <source>7 - Low battery</source>
+        <translation type="unfinished">7 - Batería baja</translation>
     </message>
     <message>
-      <source>7 - Low battery</source>
-      <translation type="unfinished">7 - Batería baja</translation>
-    </message>
-    <message>
-      <source>HeadsetControl monitoring is disabled
+        <source>HeadsetControl monitoring is disabled
 You can enable it in the Components tab.</source>
-      <translation type="unfinished">La supervisión de HeadsetControl está desactivada
+        <translation type="unfinished">La supervisión de HeadsetControl está desactivada
 Puedes activarla en la pestaña Componentes.</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>IntroWindow</name>
     <message>
-      <source>Automatic application update</source>
-      <translation type="unfinished">Actualización automática de la aplicación</translation>
+        <source>Automatic application update</source>
+        <translation type="unfinished">Actualización automática de la aplicación</translation>
     </message>
     <message>
-      <source>Get Started</source>
-      <translation type="unfinished">Empezar</translation>
+        <source>Get Started</source>
+        <translation type="unfinished">Empezar</translation>
     </message>
     <message>
-      <source>Automatic translations update</source>
-      <translation type="unfinished">Actualización automática de traducciones</translation>
+        <source>Automatic translations update</source>
+        <translation type="unfinished">Actualización automática de traducciones</translation>
     </message>
     <message>
-      <source>Welcome to QontrolPanel!</source>
-      <translation type="unfinished">¡Bienvenido a QontrolPanel!</translation>
+        <source>Welcome to QontrolPanel!</source>
+        <translation type="unfinished">¡Bienvenido a QontrolPanel!</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>LabeledSwitch</name>
     <message>
-      <source>On</source>
-      <translation type="unfinished">Activado</translation>
+        <source>On</source>
+        <translation type="unfinished">Activado</translation>
     </message>
     <message>
-      <source>Off</source>
-      <translation type="unfinished">Desactivado</translation>
+        <source>Off</source>
+        <translation type="unfinished">Desactivado</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>LanguagePane</name>
     <message>
-      <source>Application language</source>
-      <translation type="unfinished">Idioma de la aplicación</translation>
+        <source>Application language</source>
+        <translation type="unfinished">Idioma de la aplicación</translation>
     </message>
     <message>
-      <source>System</source>
-      <translation type="unfinished">Sistema</translation>
+        <source>System</source>
+        <translation type="unfinished">Sistema</translation>
     </message>
     <message>
-      <source>Translation author</source>
-      <translation type="unfinished">Autor de la traducción</translation>
+        <source>Translation author</source>
+        <translation type="unfinished">Autor de la traducción</translation>
     </message>
     <message>
-      <source>Translation last updated</source>
-      <translation type="unfinished">Última actualización de la traducción</translation>
+        <source>Translation last updated</source>
+        <translation type="unfinished">Última actualización de la traducción</translation>
     </message>
     <message>
-      <source>Update Translations</source>
-      <translation type="unfinished">Actualizar traducciones</translation>
+        <source>Update Translations</source>
+        <translation type="unfinished">Actualizar traducciones</translation>
     </message>
     <message>
-      <source>Download the latest translation files from GitHub</source>
-      <translation type="unfinished">Descargar los archivos de traducción más recientes desde GitHub</translation>
+        <source>Download the latest translation files from GitHub</source>
+        <translation type="unfinished">Descargar los archivos de traducción más recientes desde GitHub</translation>
     </message>
     <message>
-      <source>Download</source>
-      <translation type="unfinished">Descargar</translation>
+        <source>Download</source>
+        <translation type="unfinished">Descargar</translation>
     </message>
     <message>
-      <source>Download completed successfully!</source>
-      <translation type="unfinished">¡Descarga completada correctamente!</translation>
+        <source>Download completed successfully!</source>
+        <translation type="unfinished">¡Descarga completada correctamente!</translation>
     </message>
     <message>
-      <source>Download failed: %1</source>
-      <translation type="unfinished">La descarga falló: %1</translation>
+        <source>Download failed: %1</source>
+        <translation type="unfinished">La descarga falló: %1</translation>
     </message>
     <message>
-      <source>Error: %1</source>
-      <translation type="unfinished">Error: %1</translation>
+        <source>Error: %1</source>
+        <translation type="unfinished">Error: %1</translation>
     </message>
     <message>
-      <source>Auto update translations</source>
-      <translation type="unfinished">Actualizar traducciones automáticamente</translation>
+        <source>Auto update translations</source>
+        <translation type="unfinished">Actualizar traducciones automáticamente</translation>
     </message>
     <message>
-      <source>Fetch for translations update at startup and every 4 hours</source>
-      <translation type="unfinished">Buscar actualizaciones de traducciones al iniciar y cada 4 horas</translation>
+        <source>Fetch for translations update at startup and every 4 hours</source>
+        <translation type="unfinished">Buscar actualizaciones de traducciones al iniciar y cada 4 horas</translation>
     </message>
     <message>
-      <source>Translation Progress</source>
-      <translation type="unfinished">Progreso de la traducción</translation>
+        <source>Translation Progress</source>
+        <translation type="unfinished">Progreso de la traducción</translation>
     </message>
     <message>
-      <source>Current language completion</source>
-      <translation type="unfinished">Progreso actual del idioma</translation>
+        <source>Current language completion</source>
+        <translation type="unfinished">Progreso actual del idioma</translation>
     </message>
     <message>
-      <source>Fetch for new translation to get data</source>
-      <translation type="unfinished">Buscar una nueva traducción para obtener datos</translation>
+        <source>Fetch for new translation to get data</source>
+        <translation type="unfinished">Buscar una nueva traducción para obtener datos</translation>
     </message>
     <message>
-      <source>Unknown author</source>
-      <translation type="unfinished">Autor desconocido</translation>
+        <source>Unknown author</source>
+        <translation type="unfinished">Autor desconocido</translation>
     </message>
     <message>
-      <source>Unknown date</source>
-      <translation type="unfinished">Fecha desconocida</translation>
+        <source>Unknown date</source>
+        <translation type="unfinished">Fecha desconocida</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>Main</name>
     <message>
-      <source>Update Available</source>
-      <translation type="unfinished">Actualización disponible</translation>
+        <source>Update Available</source>
+        <translation type="unfinished">Actualización disponible</translation>
     </message>
     <message>
-      <source>Version %1 is available for download</source>
-      <translation type="unfinished">La versión %1 está disponible para descargar</translation>
+        <source>Version %1 is available for download</source>
+        <translation type="unfinished">La versión %1 está disponible para descargar</translation>
     </message>
     <message>
-      <source>System sounds</source>
-      <translation type="unfinished">Sonidos del sistema</translation>
+        <source>System sounds</source>
+        <translation type="unfinished">Sonidos del sistema</translation>
     </message>
     <message>
-      <source>ChatMix</source>
-      <translation type="unfinished">ChatMix</translation>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
-      <source>Brightness</source>
-      <translation type="unfinished">Brillo</translation>
+        <source>Brightness</source>
+        <translation type="unfinished">Brillo</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MediaOverlay</name>
     <message>
-      <source>No media playing</source>
-      <translation type="unfinished">No se está reproduciendo contenido</translation>
+        <source>No media playing</source>
+        <translation type="unfinished">No se está reproduciendo contenido</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>MediaOverlayPane</name>
     <message>
-      <source>Media Overlay</source>
-      <translation type="unfinished">Superposición multimedia</translation>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Superposición multimedia</translation>
     </message>
     <message>
-      <source>Enable media overlay</source>
-      <translation type="unfinished">Activar superposición multimedia</translation>
+        <source>Enable media overlay</source>
+        <translation type="unfinished">Activar superposición multimedia</translation>
     </message>
     <message>
-      <source>Show a notification overlay when the currently playing song changes</source>
-      <translation type="unfinished">Mostrar una superposición de notificación cuando cambie la canción que se está reproduciendo</translation>
+        <source>Show a notification overlay when the currently playing song changes</source>
+        <translation type="unfinished">Mostrar una superposición de notificación cuando cambie la canción que se está reproduciendo</translation>
     </message>
     <message>
-      <source>Overlay size</source>
-      <translation type="unfinished">Tamaño de la superposición</translation>
+        <source>Overlay size</source>
+        <translation type="unfinished">Tamaño de la superposición</translation>
     </message>
     <message>
-      <source>Choose the size of the media overlay</source>
-      <translation type="unfinished">Elige el tamaño de la superposición multimedia</translation>
+        <source>Choose the size of the media overlay</source>
+        <translation type="unfinished">Elige el tamaño de la superposición multimedia</translation>
     </message>
     <message>
-      <source>Tiny</source>
-      <translation type="unfinished">Pequeña</translation>
+        <source>Tiny</source>
+        <translation type="unfinished">Pequeña</translation>
     </message>
     <message>
-      <source>Normal</source>
-      <translation type="unfinished">Normal</translation>
+        <source>Normal</source>
+        <translation type="unfinished">Normal</translation>
     </message>
     <message>
-      <source>Big</source>
-      <translation type="unfinished">Grande</translation>
+        <source>Big</source>
+        <translation type="unfinished">Grande</translation>
     </message>
     <message>
-      <source>Overlay position</source>
-      <translation type="unfinished">Posición de la superposición</translation>
+        <source>Overlay position</source>
+        <translation type="unfinished">Posición de la superposición</translation>
     </message>
     <message>
-      <source>Choose where the media overlay appears on screen</source>
-      <translation type="unfinished">Elige dónde aparece la superposición multimedia en la pantalla</translation>
+        <source>Choose where the media overlay appears on screen</source>
+        <translation type="unfinished">Elige dónde aparece la superposición multimedia en la pantalla</translation>
     </message>
     <message>
-      <source>Top Left</source>
-      <translation type="unfinished">Arriba a la izquierda</translation>
+        <source>Top Left</source>
+        <translation type="unfinished">Arriba a la izquierda</translation>
     </message>
     <message>
-      <source>Top Center</source>
-      <translation type="unfinished">Arriba en el centro</translation>
+        <source>Top Center</source>
+        <translation type="unfinished">Arriba en el centro</translation>
     </message>
     <message>
-      <source>Top Right</source>
-      <translation type="unfinished">Arriba a la derecha</translation>
+        <source>Top Right</source>
+        <translation type="unfinished">Arriba a la derecha</translation>
     </message>
     <message>
-      <source>Left</source>
-      <translation type="unfinished">Izquierda</translation>
+        <source>Left</source>
+        <translation type="unfinished">Izquierda</translation>
     </message>
     <message>
-      <source>Right</source>
-      <translation type="unfinished">Derecha</translation>
+        <source>Right</source>
+        <translation type="unfinished">Derecha</translation>
     </message>
     <message>
-      <source>Bottom Left</source>
-      <translation type="unfinished">Abajo a la izquierda</translation>
+        <source>Bottom Left</source>
+        <translation type="unfinished">Abajo a la izquierda</translation>
     </message>
     <message>
-      <source>Bottom Center</source>
-      <translation type="unfinished">Abajo en el centro</translation>
+        <source>Bottom Center</source>
+        <translation type="unfinished">Abajo en el centro</translation>
     </message>
     <message>
-      <source>Bottom Right</source>
-      <translation type="unfinished">Abajo a la derecha</translation>
+        <source>Bottom Right</source>
+        <translation type="unfinished">Abajo a la derecha</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>PanelFooter</name>
     <message>
-      <source>Update available</source>
-      <translation type="unfinished">Actualización disponible</translation>
+        <source>Update available</source>
+        <translation type="unfinished">Actualización disponible</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>PowerMenu</name>
     <message>
-      <source>Sleep</source>
-      <translation type="unfinished">Suspender</translation>
+        <source>Sleep</source>
+        <translation type="unfinished">Suspender</translation>
     </message>
     <message>
-      <source>Hibernate</source>
-      <translation type="unfinished">Hibernar</translation>
+        <source>Hibernate</source>
+        <translation type="unfinished">Hibernar</translation>
     </message>
     <message>
-      <source>Restart</source>
-      <translation type="unfinished">Reiniciar</translation>
+        <source>Restart</source>
+        <translation type="unfinished">Reiniciar</translation>
     </message>
     <message>
-      <source>Restart UEFI</source>
-      <translation type="unfinished">Reiniciar UEFI</translation>
+        <source>Restart UEFI</source>
+        <translation type="unfinished">Reiniciar UEFI</translation>
     </message>
     <message>
-      <source>Shutdown</source>
-      <translation type="unfinished">Apagar</translation>
+        <source>Shutdown</source>
+        <translation type="unfinished">Apagar</translation>
     </message>
     <message>
-      <source>Lock</source>
-      <translation type="unfinished">Bloquear</translation>
+        <source>Lock</source>
+        <translation type="unfinished">Bloquear</translation>
     </message>
     <message>
-      <source>Sign Out</source>
-      <translation type="unfinished">Cerrar sesión</translation>
+        <source>Sign Out</source>
+        <translation type="unfinished">Cerrar sesión</translation>
     </message>
     <message>
-      <source>Switch User</source>
-      <translation type="unfinished">Cambiar de usuario</translation>
+        <source>Switch User</source>
+        <translation type="unfinished">Cambiar de usuario</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>SettingsWindow</name>
     <message>
-      <source>QontrolPanel - Settings</source>
-      <translation type="unfinished">QontrolPanel - Configuración</translation>
+        <source>QontrolPanel - Settings</source>
+        <translation type="unfinished">QontrolPanel - Configuración</translation>
     </message>
     <message>
-      <source>General</source>
-      <translation type="unfinished">General</translation>
+        <source>General</source>
+        <translation type="unfinished">General</translation>
     </message>
     <message>
-      <source>Appearance</source>
-      <translation type="unfinished">Apariencia</translation>
+        <source>Appearance</source>
+        <translation type="unfinished">Apariencia</translation>
     </message>
     <message>
-      <source>Media Overlay</source>
-      <translation type="unfinished">Superposición multimedia</translation>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Superposición multimedia</translation>
     </message>
     <message>
-      <source>ChatMix</source>
-      <translation type="unfinished">ChatMix</translation>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
-      <source>Shortcuts</source>
-      <translation type="unfinished">Atajos</translation>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Atajos</translation>
     </message>
     <message>
-      <source>App Hotkeys</source>
-      <translation type="unfinished">Atajos de apps</translation>
+        <source>App Hotkeys</source>
+        <translation type="unfinished">Atajos de apps</translation>
     </message>
     <message>
-      <source>Language</source>
-      <translation type="unfinished">Idioma</translation>
+        <source>Language</source>
+        <translation type="unfinished">Idioma</translation>
     </message>
     <message>
-      <source>Updates</source>
-      <translation type="unfinished">Actualizaciones</translation>
+        <source>Updates</source>
+        <translation type="unfinished">Actualizaciones</translation>
     </message>
     <message>
-      <source>HeadsetControl</source>
-      <translation type="unfinished">HeadsetControl</translation>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">HeadsetControl</translation>
     </message>
     <message>
-      <source>Components</source>
-      <translation type="unfinished">Componentes</translation>
+        <source>Components</source>
+        <translation type="unfinished">Componentes</translation>
     </message>
     <message>
-      <source>Renaming</source>
-      <translation type="unfinished">Cambio de nombre</translation>
+        <source>Renaming</source>
+        <translation type="unfinished">Cambio de nombre</translation>
     </message>
     <message>
-      <source>Debug</source>
-      <translation type="unfinished">Depuración</translation>
+        <source>Debug</source>
+        <translation type="unfinished">Depuración</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>ShortcutsPane</name>
     <message>
-      <source>Global Shortcuts</source>
-      <translation type="unfinished">Atajos globales</translation>
+        <source>Global Shortcuts</source>
+        <translation type="unfinished">Atajos globales</translation>
     </message>
     <message>
-      <source>Enable global shortcuts</source>
-      <translation type="unfinished">Activar atajos globales</translation>
+        <source>Enable global shortcuts</source>
+        <translation type="unfinished">Activar atajos globales</translation>
     </message>
     <message>
-      <source>Allow QontrolPanel to respond to keyboard shortcuts globally</source>
-      <translation type="unfinished">Permitir que QontrolPanel responda a atajos de teclado globalmente</translation>
+        <source>Allow QontrolPanel to respond to keyboard shortcuts globally</source>
+        <translation type="unfinished">Permitir que QontrolPanel responda a atajos de teclado globalmente</translation>
     </message>
     <message>
-      <source>Notification on ChatMix toggle</source>
-      <translation type="unfinished">Notificación al alternar ChatMix</translation>
+        <source>Notification on ChatMix toggle</source>
+        <translation type="unfinished">Notificación al alternar ChatMix</translation>
     </message>
     <message>
-      <source>Show/Hide Panel</source>
-      <translation type="unfinished">Mostrar u ocultar panel</translation>
+        <source>Show/Hide Panel</source>
+        <translation type="unfinished">Mostrar u ocultar panel</translation>
     </message>
     <message>
-      <source>Shortcut to toggle the main panel visibility</source>
-      <translation type="unfinished">Atajo para alternar la visibilidad del panel principal</translation>
+        <source>Shortcut to toggle the main panel visibility</source>
+        <translation type="unfinished">Atajo para alternar la visibilidad del panel principal</translation>
     </message>
     <message>
-      <source>Change</source>
-      <translation type="unfinished">Cambiar</translation>
+        <source>Change</source>
+        <translation type="unfinished">Cambiar</translation>
     </message>
     <message>
-      <source>Toggle ChatMix</source>
-      <translation type="unfinished">Alternar ChatMix</translation>
+        <source>Toggle ChatMix</source>
+        <translation type="unfinished">Alternar ChatMix</translation>
     </message>
     <message>
-      <source>Shortcut to enable/disable ChatMix feature</source>
-      <translation type="unfinished">Atajo para activar o desactivar la función ChatMix</translation>
+        <source>Shortcut to enable/disable ChatMix feature</source>
+        <translation type="unfinished">Atajo para activar o desactivar la función ChatMix</translation>
     </message>
     <message>
-      <source>Toggle Microphone Mute</source>
-      <translation type="unfinished">Alternar silencio del micrófono</translation>
+        <source>Toggle Microphone Mute</source>
+        <translation type="unfinished">Alternar silencio del micrófono</translation>
     </message>
     <message>
-      <source>Shortcut to mute/unmute microphone</source>
-      <translation type="unfinished">Atajo para silenciar o reactivar el micrófono</translation>
+        <source>Shortcut to mute/unmute microphone</source>
+        <translation type="unfinished">Atajo para silenciar o reactivar el micrófono</translation>
     </message>
     <message>
-      <source>Set Panel Shortcut</source>
-      <translation type="unfinished">Establecer atajo del panel</translation>
+        <source>Set Panel Shortcut</source>
+        <translation type="unfinished">Establecer atajo del panel</translation>
     </message>
     <message>
-      <source>Set Microphone Mute Shortcut</source>
-      <translation type="unfinished">Establecer atajo para silenciar el micrófono</translation>
+        <source>Set Microphone Mute Shortcut</source>
+        <translation type="unfinished">Establecer atajo para silenciar el micrófono</translation>
     </message>
     <message>
-      <source>Press the desired key combination</source>
-      <translation type="unfinished">Pulsa la combinación de teclas deseada</translation>
+        <source>Press the desired key combination</source>
+        <translation type="unfinished">Pulsa la combinación de teclas deseada</translation>
     </message>
     <message>
-      <source>Cancel</source>
-      <translation type="unfinished">Cancelar</translation>
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-      <source>Apply</source>
-      <translation type="unfinished">Aplicar</translation>
+        <source>Apply</source>
+        <translation type="unfinished">Aplicar</translation>
     </message>
     <message>
-      <source>Set ChatMix Shortcut</source>
-      <translation type="unfinished">Establecer atajo de ChatMix</translation>
+        <source>Set ChatMix Shortcut</source>
+        <translation type="unfinished">Establecer atajo de ChatMix</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>SystemTray</name>
     <message>
-      <source>Output: </source>
-      <translation type="unfinished">Salida: </translation>
+        <source>Output: </source>
+        <translation type="unfinished">Salida: </translation>
     </message>
     <message>
-      <source>Input: </source>
-      <translation type="unfinished">Entrada: </translation>
+        <source>Input: </source>
+        <translation type="unfinished">Entrada: </translation>
     </message>
     <message>
-      <source>Exit</source>
-      <translation type="unfinished">Salir</translation>
+        <source>Exit</source>
+        <translation type="unfinished">Salir</translation>
     </message>
     <message>
-      <source>ChatMix</source>
-      <translation type="unfinished">ChatMix</translation>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
     </message>
     <message>
-      <source>Windows sound settings (Legacy)</source>
-      <translation type="unfinished">Configuración de sonido de Windows (heredada)</translation>
+        <source>Windows sound settings (Legacy)</source>
+        <translation type="unfinished">Configuración de sonido de Windows (heredada)</translation>
     </message>
     <message>
-      <source>Windows sound settings (Modern)</source>
-      <translation type="unfinished">Configuración de sonido de Windows (moderna)</translation>
+        <source>Windows sound settings (Modern)</source>
+        <translation type="unfinished">Configuración de sonido de Windows (moderna)</translation>
     </message>
     <message>
-      <source>QontrolPanel settings</source>
-      <translation type="unfinished">Configuración de QontrolPanel</translation>
+        <source>QontrolPanel settings</source>
+        <translation type="unfinished">Configuración de QontrolPanel</translation>
     </message>
-  </context>
-  <context>
+</context>
+<context>
     <name>Updater</name>
     <message>
-      <source>Update available: </source>
-      <translation type="unfinished">Actualización disponible: </translation>
+        <source>Update available: </source>
+        <translation type="unfinished">Actualización disponible: </translation>
     </message>
     <message>
-      <source>You are using the latest version</source>
-      <translation type="unfinished">Estás usando la versión más reciente</translation>
+        <source>You are using the latest version</source>
+        <translation type="unfinished">Estás usando la versión más reciente</translation>
     </message>
     <message>
-      <source>Update started.</source>
-      <translation type="unfinished">Actualización iniciada.</translation>
+        <source>Update started.</source>
+        <translation type="unfinished">Actualización iniciada.</translation>
     </message>
     <message>
-      <source>No translation files to download</source>
-      <translation type="unfinished">No hay archivos de traducción para descargar</translation>
+        <source>No translation files to download</source>
+        <translation type="unfinished">No hay archivos de traducción para descargar</translation>
     </message>
     <message>
-      <source>All translations downloaded successfully</source>
-      <translation type="unfinished">Todas las traducciones se descargaron correctamente</translation>
+        <source>All translations downloaded successfully</source>
+        <translation type="unfinished">Todas las traducciones se descargaron correctamente</translation>
     </message>
     <message>
-      <source>Downloaded %1 of %2 translation files</source>
-      <translation type="unfinished">Se descargaron %1 de %2 archivos de traducción</translation>
+        <source>Downloaded %1 of %2 translation files</source>
+        <translation type="unfinished">Se descargaron %1 de %2 archivos de traducción</translation>
     </message>
-  </context>
+</context>
 </TS>

--- a/i18n/QontrolPanel_es.ts
+++ b/i18n/QontrolPanel_es.ts
@@ -647,10 +647,6 @@ Si quieres apoyar mi trabajo, cualquier contribución será muy apreciada.</tran
         <translation type="unfinished">Iniciar con el sistema</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation type="unfinished">QSS se iniciará cuando arranque el equipo</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -741,6 +737,10 @@ Si quieres apoyar mi trabajo, cualquier contribución será muy apreciada.</tran
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation type="unfinished">Frecuencia de actualización del brillo DDC/CI</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -669,6 +669,62 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
         <translation>Lancer au démarrage</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Général</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">Composants</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Apparence</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Raccourcis</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">HeadsetControl</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">Renommage</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Langage</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Mises à jour</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Déboguer</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -761,10 +817,6 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -820,6 +820,10 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -661,12 +661,12 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
         <translation>Normal</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS démarrera en même temps que l’ordinateur</translation>
-    </message>
-    <message>
         <source>Run at system startup</source>
         <translation>Lancer au démarrage</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings startup page</source>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -647,10 +647,6 @@ Se vuoi supportare il mio lavoro, qualsiasi contributo sarebbe molto apprezzato!
         <translation>Esegui ad avvio del sistema</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS verrà eseguito ad avvio del sistema</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -741,6 +737,10 @@ Se vuoi supportare il mio lavoro, qualsiasi contributo sarebbe molto apprezzato!
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>Frequenza aggiornamento luminosità DDC/CI</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -651,6 +651,62 @@ Se vuoi supportare il mio lavoro, qualsiasi contributo sarebbe molto apprezzato!
         <translation>QSS verrà eseguito ad avvio del sistema</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Generale</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">Componenti</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Apparenza</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Overlay media</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Tasti rapidi</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">Controllo cuffie</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">Rinomina</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Lingua interfaccia</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Aggiornamenti</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Debug</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -751,10 +807,6 @@ Se vuoi supportare il mio lavoro, qualsiasi contributo sarebbe molto apprezzato!
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -810,6 +810,10 @@ Se vuoi supportare il mio lavoro, qualsiasi contributo sarebbe molto apprezzato!
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -651,6 +651,62 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>コンピューターの起動時に QSS を起動します</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">一般</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">コンポーネント</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">外観</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">ショートカット</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">ヘッドセット コントロール</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">名前の変更</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">言語</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">デバッグ</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -751,10 +807,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -810,6 +810,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -647,10 +647,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>システムのスタートアップ時に起動</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>コンピューターの起動時に QSS を起動します</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -741,6 +737,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>DDC/CI 輝度更新レート</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -810,6 +810,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">채팅 믹스</translation>
     </message>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -647,10 +647,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>시스템 시작 시 실행</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>컴퓨터가 시작되면 QSS가 부팅됩니다</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -741,6 +737,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>DDC/CI 밝기 업데이트 속도</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -651,6 +651,62 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>컴퓨터가 시작되면 QSS가 부팅됩니다</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">일반</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">구성 요소</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">외형</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished">미디어 오버레이</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">채팅 믹스</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">단축키</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">헤드셋 제어</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">이름 바꾸기</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">언어</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">업데이트</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">디버그</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -751,10 +807,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -651,6 +651,62 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
         <translation>QSS uruchomi się po uruchomieniu komputera</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Ogólne</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">Komponenty</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Wygląd</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Nakładka Multimedialna</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Skróty klawiaturowe</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">HeadsetControl</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">Zmiana nazwy</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Język</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Aktualizacje</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Debugowanie</translation>
+    </message>
+    <message>
         <source>Show power action confirmation</source>
         <translation>Pokaż potwierdzenie akcji zasilania</translation>
     </message>
@@ -803,10 +859,6 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -647,8 +647,8 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
         <translation>Uruchom podczas uruchamiania systemu</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS uruchomi się po uruchomieniu komputera</translation>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings startup page</source>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -862,6 +862,10 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -648,10 +648,6 @@ Se você quiser apoiar meu trabalho, qualquer contribuição será muito bem-vin
         <translation>Executar na inicialização do sistema</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS será iniciado quando o computador for ligado</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -742,6 +738,10 @@ Se você quiser apoiar meu trabalho, qualquer contribuição será muito bem-vin
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>Taxa de atualização do brilho via DDC/CI</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -811,6 +811,10 @@ Se você quiser apoiar meu trabalho, qualquer contribuição será muito bem-vin
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -652,6 +652,62 @@ Se você quiser apoiar meu trabalho, qualquer contribuição será muito bem-vin
         <translation>QSS será iniciado quando o computador for ligado</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Geral</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">Componentes</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Aparência</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Sobreposição de mídia</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Atalhos</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished">Atalhos de App</translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">HeadsetControl</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">Renomeação</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Idioma</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Atualizações</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Depuração</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -752,10 +808,6 @@ Se você quiser apoiar meu trabalho, qualquer contribuição será muito bem-vin
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -646,10 +646,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>Добавить в автозагрузку</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS запустится при включении компьютера</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -739,6 +735,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     </message>
     <message>
         <source>DDC/CI brightness update rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -809,6 +809,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -650,6 +650,62 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS запустится при включении компьютера</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Основные</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Вид</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Сочетания клавиш</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Язык</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Информация</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -750,10 +806,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -646,10 +646,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>Zaženi ob zagonu sistema</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS se bo zagnal ob zagonu računalnika</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -740,6 +736,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>Hitrost posodabljanja svetlosti DDC/CI</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -650,6 +650,62 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS se bo zagnal ob zagonu računalnika</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Splošno</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">Komponente</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">Videz</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished">Prekrivanje medijev</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">Bližnjice</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">Nadzor slušalk</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished">Preimenovanje</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">Jezik</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">Posodobitve</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">Razhroščevanje</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -750,10 +806,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -809,6 +809,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -646,10 +646,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>开机自启</translation>
     </message>
     <message>
-        <source>QSS will boot up when your computer starts</source>
-        <translation>QSS 将随系统启动时自动启动</translation>
-    </message>
-    <message>
         <source>Settings startup page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -740,6 +736,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     <message>
         <source>DDC/CI brightness update rate</source>
         <translation>DDC/CI 亮度更新率</translation>
+    </message>
+    <message>
+        <source>QontrolPanel will boot up when your computer starts</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Controls how frequently brightness commands are sent to external monitors</source>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -809,6 +809,10 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Notify when the connected headset reaches %1% or lower.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>ChatMix</source>
         <translation type="unfinished">ChatMix</translation>
     </message>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -650,6 +650,62 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>QSS 将随系统启动时自动启动</translation>
     </message>
     <message>
+        <source>Settings startup page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose which settings page opens when the settings window is shown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">常规</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation type="unfinished">组件</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation type="unfinished">外观</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation type="unfinished">ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation type="unfinished">快捷键</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation type="unfinished">耳机控制</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished">语言</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation type="unfinished">更新</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation type="unfinished">调试</translation>
+    </message>
+    <message>
         <source>Show a confirmation dialog when selecting a power action from the system tray menu</source>
         <translation type="unfinished"></translation>
     </message>
@@ -750,10 +806,6 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
     </message>
     <message>
         <source>Current battery level of the connected headset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Charging)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/include/headsetcontrolbridge.h
+++ b/include/headsetcontrolbridge.h
@@ -20,6 +20,7 @@ class HeadsetControlBridge : public QObject
     Q_PROPERTY(QString deviceName READ deviceName NOTIFY deviceNameChanged)
     Q_PROPERTY(QString batteryStatus READ batteryStatus NOTIFY batteryStatusChanged)
     Q_PROPERTY(int batteryLevel READ batteryLevel NOTIFY batteryLevelChanged)
+    Q_PROPERTY(QString batteryIcon READ batteryIcon NOTIFY batteryIconChanged)
     Q_PROPERTY(int chatMix READ chatMix NOTIFY chatMixChanged)
     Q_PROPERTY(bool anyDeviceFound READ anyDeviceFound NOTIFY anyDeviceFoundChanged)
     Q_PROPERTY(bool testModeEnabled READ testModeEnabled NOTIFY testModeEnabledChanged)
@@ -51,6 +52,7 @@ public:
     QString deviceName() const;
     QString batteryStatus() const;
     int batteryLevel() const;
+    QString batteryIcon() const;
     int chatMix() const;
     bool anyDeviceFound() const;
     bool testModeEnabled() const;
@@ -61,6 +63,7 @@ signals:
     void deviceNameChanged();
     void batteryStatusChanged();
     void batteryLevelChanged();
+    void batteryIconChanged();
     void chatMixChanged();
     void anyDeviceFoundChanged();
     void testModeEnabledChanged();

--- a/include/headsetcontrolbridge.h
+++ b/include/headsetcontrolbridge.h
@@ -84,6 +84,7 @@ private:
     static HeadsetControlBridge* m_instance;
     HeadsetControlMonitor* findMonitor() const;
     void connectToMonitor();
+    void updateLowBatteryNotificationState();
 
     bool m_lowBatteryNotificationSent = false;
 };

--- a/include/usersettings.h
+++ b/include/usersettings.h
@@ -61,6 +61,7 @@ class UserSettings : public QObject
     Q_PROPERTY(int panelStyle READ panelStyle WRITE setPanelStyle NOTIFY panelStyleChanged)
     Q_PROPERTY(int headsetcontrolFetchRate READ headsetcontrolFetchRate WRITE setHeadsetcontrolFetchRate NOTIFY headsetcontrolFetchRateChanged)
     Q_PROPERTY(bool enableNotifications READ enableNotifications WRITE setEnableNotifications NOTIFY enableNotificationsChanged)
+    Q_PROPERTY(int headsetcontrolLowBatteryThreshold READ headsetcontrolLowBatteryThreshold WRITE setHeadsetcontrolLowBatteryThreshold NOTIFY headsetcontrolLowBatteryThresholdChanged)
 
     Q_PROPERTY(bool enableMediaOverlay READ enableMediaOverlay WRITE setEnableMediaOverlay NOTIFY enableMediaOverlayChanged)
     Q_PROPERTY(int mediaOverlayPosition READ mediaOverlayPosition WRITE setMediaOverlayPosition NOTIFY mediaOverlayPositionChanged)
@@ -124,6 +125,7 @@ public:
     int panelStyle() const { return m_panelStyle; }
     int headsetcontrolFetchRate() const { return m_headsetcontrolFetchRate; }
     bool enableNotifications() const { return m_enableNotifications; }
+    int headsetcontrolLowBatteryThreshold() const { return m_headsetcontrolLowBatteryThreshold; }
 
     bool enableMediaOverlay() const { return m_enableMediaOverlay; }
     int mediaOverlayPosition() const { return m_mediaOverlayPosition; }
@@ -183,6 +185,7 @@ public:
     void setPanelStyle(int value);
     void setHeadsetcontrolFetchRate(int value);
     void setEnableNotifications(bool value);
+    void setHeadsetcontrolLowBatteryThreshold(int value);
 
     void setEnableMediaOverlay(bool value);
     void setMediaOverlayPosition(int value);
@@ -242,6 +245,7 @@ signals:
     void panelStyleChanged();
     void headsetcontrolFetchRateChanged();
     void enableNotificationsChanged();
+    void headsetcontrolLowBatteryThresholdChanged();
 
     void enableMediaOverlayChanged();
     void mediaOverlayPositionChanged();
@@ -307,6 +311,7 @@ private:
     int m_panelStyle;
     int m_headsetcontrolFetchRate;
     bool m_enableNotifications;
+    int m_headsetcontrolLowBatteryThreshold;
 
     bool m_enableMediaOverlay;
     int m_mediaOverlayPosition;

--- a/include/usersettings.h
+++ b/include/usersettings.h
@@ -36,6 +36,7 @@ class UserSettings : public QObject
     Q_PROPERTY(int micMuteShortcutModifiers READ micMuteShortcutModifiers WRITE setMicMuteShortcutModifiers NOTIFY micMuteShortcutModifiersChanged)
     Q_PROPERTY(bool autoUpdateTranslations READ autoUpdateTranslations WRITE setAutoUpdateTranslations NOTIFY autoUpdateTranslationsChanged)
     Q_PROPERTY(bool firstRun READ firstRun WRITE setFirstRun NOTIFY firstRunChanged)
+    Q_PROPERTY(int settingsStartupPage READ settingsStartupPage WRITE setSettingsStartupPage NOTIFY settingsStartupPageChanged)
 
     Q_PROPERTY(int trayIconTheme READ trayIconTheme WRITE setTrayIconTheme NOTIFY trayIconThemeChanged)
     Q_PROPERTY(int iconStyle READ iconStyle WRITE setIconStyle NOTIFY iconStyleChanged)
@@ -98,6 +99,7 @@ public:
     int micMuteShortcutModifiers() const { return m_micMuteShortcutModifiers; }
     bool autoUpdateTranslations() const { return m_autoUpdateTranslations; }
     bool firstRun() const { return m_firstRun; }
+    int settingsStartupPage() const { return m_settingsStartupPage; }
 
     int trayIconTheme() const { return m_trayIconTheme; }
     int iconStyle() const { return m_iconStyle; }
@@ -156,6 +158,7 @@ public:
     void setMicMuteShortcutModifiers(int value);
     void setAutoUpdateTranslations(bool value);
     void setFirstRun(bool value);
+    void setSettingsStartupPage(int value);
 
     void setTrayIconTheme(int value);
     void setIconStyle(int value);
@@ -214,6 +217,7 @@ signals:
     void micMuteShortcutModifiersChanged();
     void autoUpdateTranslationsChanged();
     void firstRunChanged();
+    void settingsStartupPageChanged();
 
     void trayIconThemeChanged();
     void iconStyleChanged();
@@ -278,6 +282,7 @@ private:
     int m_micMuteShortcutModifiers;
     bool m_autoUpdateTranslations;
     bool m_firstRun;
+    int m_settingsStartupPage;
 
     int m_trayIconTheme;
     int m_iconStyle;

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -181,7 +181,18 @@ ApplicationWindow {
 
     SystemTray {
         id: systemTray
-        onTogglePanelRequested: {
+        onTogglePanelRequested: trayToggleTimer.restart()
+        onSettingsWindowRequested: {
+            trayToggleTimer.stop()
+            settingsWindow.showPreferredPane()
+        }
+    }
+
+    Timer {
+        id: trayToggleTimer
+        interval: 200
+        repeat: false
+        onTriggered: {
             if (!panel.visible) {
                 panel.showPanel()
             }
@@ -550,12 +561,6 @@ ApplicationWindow {
 
     SettingsWindow {
         id: settingsWindow
-        Connections {
-            target: systemTray
-            function onSettingsWindowRequested() {
-                settingsWindow.showPreferredPane()
-            }
-        }
     }
 
     Item {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -553,7 +553,7 @@ ApplicationWindow {
         Connections {
             target: systemTray
             function onSettingsWindowRequested() {
-                settingsWindow.show()
+                settingsWindow.showPreferredPane()
             }
         }
     }
@@ -1222,7 +1222,7 @@ ApplicationWindow {
                         Layout.rightMargin: -14
                         Layout.bottomMargin: -14
                         onHidePanel: panel.hidePanel()
-                        onShowSettingsWindow: settingsWindow.show()
+                        onShowSettingsWindow: settingsWindow.showPreferredPane()
                         onShowUpdatePane: settingsWindow.showUpdatePane()
                         onShowPowerConfirmationWindow: function(action) {
                             powerConfirmationWindow.setAction(action)

--- a/qml/SettingsPane/GeneralPane.qml
+++ b/qml/SettingsPane/GeneralPane.qml
@@ -23,7 +23,7 @@ ColumnLayout {
             Card {
                 Layout.fillWidth: true
                 title: qsTr("Run at system startup")
-                description: qsTr("QSS will boot up when your computer starts")
+                description: qsTr("QontrolPanel will boot up when your computer starts")
 
                 additionalControl: LabeledSwitch {
                     checked: StartupShortcutBridge.getShortcutState()

--- a/qml/SettingsPane/GeneralPane.qml
+++ b/qml/SettingsPane/GeneralPane.qml
@@ -33,6 +33,31 @@ ColumnLayout {
 
             Card {
                 Layout.fillWidth: true
+                title: qsTr("Settings startup page")
+                description: qsTr("Choose which settings page opens when the settings window is shown")
+                additionalControl: CustomComboBox {
+                    Layout.preferredHeight: 35
+                    model: [
+                        qsTr("General"),
+                        qsTr("Components"),
+                        qsTr("Appearance"),
+                        qsTr("Media Overlay"),
+                        qsTr("ChatMix"),
+                        qsTr("Shortcuts"),
+                        qsTr("App Hotkeys"),
+                        qsTr("HeadsetControl"),
+                        qsTr("Renaming"),
+                        qsTr("Language"),
+                        qsTr("Updates"),
+                        qsTr("Debug")
+                    ]
+                    currentIndex: UserSettings.settingsStartupPage
+                    onActivated: UserSettings.settingsStartupPage = currentIndex
+                }
+            }
+
+            Card {
+                Layout.fillWidth: true
                 title: qsTr("Show power action confirmation")
                 description: qsTr("Show a confirmation dialog when selecting a power action from the system tray menu")
                 additionalControl: LabeledSwitch {

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -83,8 +83,7 @@ ColumnLayout {
                     Layout.fillWidth: true
                     title: qsTr("Device battery")
                     visible: HeadsetControlBridge.batteryStatus !== "BATTERY_UNAVAILABLE" && HeadsetControlBridge.anyDeviceFound
-                    description: qsTr("Current battery level of the connected headset") +
-                                 (HeadsetControlBridge.batteryStatus === "BATTERY_CHARGING" ? "\n" + "⚡︎" + qsTr("(Charging)") : "")
+                    description: qsTr("Current battery level of the connected headset")
                     additionalControl: Label {
                         text: "🔋" + HeadsetControlBridge.batteryLevel + "%"
                     }
@@ -94,7 +93,7 @@ ColumnLayout {
                     visible: HeadsetControlBridge.anyDeviceFound
                     Layout.fillWidth: true
                     title: qsTr("Notification on low battery")
-                    additionalControl: Switch {
+                    additionalControl: LabeledSwitch {
                         checked: UserSettings.enableNotifications
                         onClicked: {
                             UserSettings.enableNotifications = checked

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -93,11 +93,29 @@ ColumnLayout {
                     visible: HeadsetControlBridge.anyDeviceFound
                     Layout.fillWidth: true
                     title: qsTr("Notification on low battery")
-                    additionalControl: LabeledSwitch {
-                        checked: UserSettings.enableNotifications
-                        onClicked: {
-                            UserSettings.enableNotifications = checked
-                            HeadsetControlBridge.notificationsEnabled = checked
+                    description: qsTr("Notify when the connected headset reaches %1% or lower.").arg(UserSettings.headsetcontrolLowBatteryThreshold)
+                    additionalControl: RowLayout {
+                        spacing: 8
+
+                        SpinBox {
+                            from: 1
+                            to: 30
+                            value: UserSettings.headsetcontrolLowBatteryThreshold
+                            editable: true
+                            Layout.preferredWidth: 72
+                            onValueModified: UserSettings.headsetcontrolLowBatteryThreshold = value
+                        }
+
+                        Label {
+                            text: "%"
+                            opacity: 0.7
+                        }
+
+                        LabeledSwitch {
+                            checked: UserSettings.enableNotifications
+                            onClicked: {
+                                UserSettings.enableNotifications = checked
+                            }
                         }
                     }
                 }

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -98,11 +98,12 @@ ColumnLayout {
                         spacing: 8
 
                         SpinBox {
+                            Layout.preferredHeight: 35
+                            Layout.preferredWidth: 160
                             from: 1
                             to: 30
                             value: UserSettings.headsetcontrolLowBatteryThreshold
                             editable: true
-                            Layout.preferredWidth: 72
                             onValueModified: UserSettings.headsetcontrolLowBatteryThreshold = value
                         }
 

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -85,7 +85,7 @@ ColumnLayout {
                     visible: HeadsetControlBridge.batteryStatus !== "BATTERY_UNAVAILABLE" && HeadsetControlBridge.anyDeviceFound
                     description: qsTr("Current battery level of the connected headset")
                     additionalControl: Label {
-                        text: "🔋" + HeadsetControlBridge.batteryLevel + "%"
+                        text: HeadsetControlBridge.batteryIcon + HeadsetControlBridge.batteryLevel + "%"
                     }
                 }
 

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -15,20 +15,57 @@ ApplicationWindow {
     transientParent: null
     title: qsTr("QontrolPanel - Settings")
 
+    readonly property int maxSettingsPageIndex: 11
+
+    function pageComponentForIndex(index) {
+        switch (index) {
+        case 0: return generalPaneComponent
+        case 1: return componentsPaneComponent
+        case 2: return appearancePaneComponent
+        case 3: return mediaOverlayPaneComponent
+        case 4: return commAppsPaneComponent
+        case 5: return shortcutsPaneComponent
+        case 6: return appHotkeysPaneComponent
+        case 7: return headsetControlPaneComponent
+        case 8: return deviceRenamingPaneComponent
+        case 9: return languagePaneComponent
+        case 10: return debugPaneComponent
+        case 11: return consolePaneComponent
+        default: return generalPaneComponent
+        }
+    }
+
+    function openPage(index, forceOpen) {
+        const safeIndex = Math.max(0, Math.min(index, maxSettingsPageIndex))
+        const component = pageComponentForIndex(safeIndex)
+        const shouldNavigate = forceOpen || sidebarList.currentIndex !== safeIndex || !stackView.currentItem
+
+        sidebarList.currentIndex = safeIndex
+
+        if (!shouldNavigate) {
+            return
+        }
+
+        if (stackView.depth === 0) {
+            stackView.push(component)
+        } else {
+            stackView.replace(component)
+        }
+    }
+
+    function showPreferredPane() {
+        show()
+        openPage(UserSettings.settingsStartupPage, true)
+    }
+
     function showUpdatePane() {
         show()
-        if (sidebarList.currentIndex !== 10) {
-            sidebarList.currentIndex = 10
-            stackView.push(debugPaneComponent)
-        }
+        openPage(10, true)
     }
 
     function showHeadsetcontrolPane() {
         show()
-        if (sidebarList.currentIndex !== 7) {
-            sidebarList.currentIndex = 7
-            stackView.push(headsetControlPaneComponent)
-        }
+        openPage(7, true)
     }
 
     property int rowHeight: 35
@@ -148,7 +185,7 @@ ApplicationWindow {
 
                         function onLanguageIndexChanged() {
                             Qt.callLater(function() {
-                                sidebarList.currentIndex = 9
+                                root.openPage(9, true)
                             })
                         }
                     }
@@ -168,23 +205,7 @@ ApplicationWindow {
                         icon.height: 18
                         opacity: text === qsTr("Debug") && !ListView.isCurrentItem ? 0.5 : 1
                         onClicked: {
-                            if (sidebarList.currentIndex !== index) {
-                                sidebarList.currentIndex = index
-                                switch(index) {
-                                    case 0: stackView.push(generalPaneComponent); break
-                                    case 1: stackView.push(componentsPaneComponent); break
-                                    case 2: stackView.push(appearancePaneComponent); break
-                                    case 3: stackView.push(mediaOverlayPaneComponent); break
-                                    case 4: stackView.push(commAppsPaneComponent); break
-                                    case 5: stackView.push(shortcutsPaneComponent); break
-                                    case 6: stackView.push(appHotkeysPaneComponent); break
-                                    case 7: stackView.push(headsetControlPaneComponent); break
-                                    case 8: stackView.push(deviceRenamingPaneComponent); break
-                                    case 9: stackView.push(languagePaneComponent); break
-                                    case 10: stackView.push(debugPaneComponent); break
-                                    case 11: stackView.push(consolePaneComponent); break
-                                }
-                            }
+                            root.openPage(index, false)
                         }
                     }
                 }

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -76,12 +76,8 @@ Platform.SystemTrayIcon {
 
         var batteryText = "\n" + "🎧" + HeadsetControlBridge.deviceName + "\n";
 
-        if (HeadsetControlBridge.batteryStatus === "BATTERY_CHARGING") {
-            batteryText += "⚡︎"
-        }
-
-        batteryText += "🔋";
-            batteryText += HeadsetControlBridge.batteryLevel + "%";
+        batteryText += HeadsetControlBridge.batteryIcon;
+        batteryText += HeadsetControlBridge.batteryLevel + "%";
         if (HeadsetControlBridge.hasChatMixCapability) {
             batteryText += " " + "🎤" + qsTr("ChatMix") + ": " + HeadsetControlBridge.chatMix;
         }

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -5,15 +5,34 @@ import ChrisLauinger77.QontrolPanel
 Platform.SystemTrayIcon {
     id: systemTray
     visible: true
+    property double suppressSingleClickUntil: 0
     signal togglePanelRequested()
     signal showIntroRequested()
     signal settingsWindowRequested()
     icon.source: Constants.getTrayIcon(AudioBridge.outputVolume, AudioBridge.outputMuted)
     tooltip: getTooltip()
 
+    Timer {
+        id: trayClickTimer
+        interval: 200
+        repeat: false
+        onTriggered: systemTray.togglePanelRequested()
+    }
+
     onActivated: function(reason) {
+        if (reason === Platform.SystemTrayIcon.DoubleClick) {
+            trayClickTimer.stop()
+            suppressSingleClickUntil = Date.now() + trayClickTimer.interval
+            systemTray.settingsWindowRequested()
+            return
+        }
+
         if (reason === Platform.SystemTrayIcon.Trigger) {
-            systemTray.togglePanelRequested()
+            if (Date.now() < suppressSingleClickUntil) {
+                return
+            }
+
+            trayClickTimer.restart()
         }
     }
 

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -5,34 +5,20 @@ import ChrisLauinger77.QontrolPanel
 Platform.SystemTrayIcon {
     id: systemTray
     visible: true
-    property double suppressSingleClickUntil: 0
     signal togglePanelRequested()
     signal showIntroRequested()
     signal settingsWindowRequested()
     icon.source: Constants.getTrayIcon(AudioBridge.outputVolume, AudioBridge.outputMuted)
     tooltip: getTooltip()
 
-    Timer {
-        id: trayClickTimer
-        interval: 200
-        repeat: false
-        onTriggered: systemTray.togglePanelRequested()
-    }
-
     onActivated: function(reason) {
         if (reason === Platform.SystemTrayIcon.DoubleClick) {
-            trayClickTimer.stop()
-            suppressSingleClickUntil = Date.now() + trayClickTimer.interval
             systemTray.settingsWindowRequested()
             return
         }
 
         if (reason === Platform.SystemTrayIcon.Trigger) {
-            if (Date.now() < suppressSingleClickUntil) {
-                return
-            }
-
-            trayClickTimer.restart()
+            systemTray.togglePanelRequested()
         }
     }
 

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -10,9 +10,16 @@ HeadsetControlBridge::HeadsetControlBridge(QObject *parent)
     : QObject(parent)
 {
     m_instance = this;
-    connect(UserSettings::instance(), &UserSettings::headsetcontrolMonitoringChanged,
+    UserSettings* settings = UserSettings::instance();
+
+    connect(settings, &UserSettings::headsetcontrolMonitoringChanged,
             this, [this]() {
                 setMonitoringEnabled(UserSettings::instance()->headsetcontrolMonitoring());
+            });
+    connect(settings, &UserSettings::headsetcontrolLowBatteryThresholdChanged,
+            this, [this]() {
+                updateLowBatteryNotificationState();
+                emit batteryIconChanged();
             });
     QTimer::singleShot(100, this, &HeadsetControlBridge::connectToMonitor);
 }
@@ -77,6 +84,7 @@ void HeadsetControlBridge::connectToMonitor()
         emit deviceNameChanged();
         emit batteryStatusChanged();
         emit batteryLevelChanged();
+        emit batteryIconChanged();
         emit chatMixChanged();
         emit anyDeviceFoundChanged();
         emit testModeEnabledChanged();
@@ -211,6 +219,7 @@ QString HeadsetControlBridge::batteryIcon() const
 {
     const int level = batteryLevel();
     const QString status = batteryStatus();
+    const int lowBatteryThreshold = UserSettings::instance()->headsetcontrolLowBatteryThreshold();
 
     if (status == "BATTERY_UNAVAILABLE" || level < 0) {
         return QString();
@@ -221,7 +230,7 @@ QString HeadsetControlBridge::batteryIcon() const
         icon += QString::fromUtf8("⚡︎");
     }
 
-    icon += level <= 25 ? QString::fromUtf8("🪫") : QString::fromUtf8("🔋");
+    icon += level <= lowBatteryThreshold ? QString::fromUtf8("🪫") : QString::fromUtf8("🔋");
     return icon;
 }
 
@@ -267,17 +276,7 @@ void HeadsetControlBridge::onMonitorBatteryStatusChanged()
 
 void HeadsetControlBridge::onMonitorBatteryLevelChanged()
 {
-    int level = batteryLevel();
-
-    if (level < 20 && level >= 0) {
-        if (!m_lowBatteryNotificationSent && UserSettings::instance()->enableNotifications()) {
-            emit lowHeadsetBattery();
-            m_lowBatteryNotificationSent = true;
-        }
-    } else if (level >= 20 && UserSettings::instance()->enableNotifications()) {
-        m_lowBatteryNotificationSent = false;
-    }
-
+    updateLowBatteryNotificationState();
     emit batteryLevelChanged();
     emit batteryIconChanged();
 }
@@ -294,6 +293,22 @@ void HeadsetControlBridge::onMonitorAnyDeviceFoundChanged()
     }
 
     emit anyDeviceFoundChanged();
+}
+
+void HeadsetControlBridge::updateLowBatteryNotificationState()
+{
+    const int level = batteryLevel();
+    const int lowBatteryThreshold = UserSettings::instance()->headsetcontrolLowBatteryThreshold();
+
+    if (level < 0 || level > lowBatteryThreshold || !UserSettings::instance()->enableNotifications()) {
+        m_lowBatteryNotificationSent = false;
+        return;
+    }
+
+    if (!m_lowBatteryNotificationSent) {
+        emit lowHeadsetBattery();
+        m_lowBatteryNotificationSent = true;
+    }
 }
 
 void HeadsetControlBridge::onMonitorTestModeEnabledChanged()

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -207,6 +207,24 @@ int HeadsetControlBridge::batteryLevel() const
     return monitor ? monitor->batteryLevel() : -1;
 }
 
+QString HeadsetControlBridge::batteryIcon() const
+{
+    const int level = batteryLevel();
+    const QString status = batteryStatus();
+
+    if (status == "BATTERY_UNAVAILABLE" || level < 0) {
+        return QString();
+    }
+
+    QString icon;
+    if (status == "BATTERY_CHARGING") {
+        icon += QString::fromUtf8("⚡︎");
+    }
+
+    icon += level <= 25 ? QString::fromUtf8("🪫") : QString::fromUtf8("🔋");
+    return icon;
+}
+
 int HeadsetControlBridge::chatMix() const
 {
     HeadsetControlMonitor* monitor = findMonitor();
@@ -244,6 +262,7 @@ void HeadsetControlBridge::onMonitorDeviceNameChanged()
 void HeadsetControlBridge::onMonitorBatteryStatusChanged()
 {
     emit batteryStatusChanged();
+    emit batteryIconChanged();
 }
 
 void HeadsetControlBridge::onMonitorBatteryLevelChanged()
@@ -260,6 +279,7 @@ void HeadsetControlBridge::onMonitorBatteryLevelChanged()
     }
 
     emit batteryLevelChanged();
+    emit batteryIconChanged();
 }
 
 void HeadsetControlBridge::onMonitorChatMixChanged()

--- a/src/usersettings.cpp
+++ b/src/usersettings.cpp
@@ -3,6 +3,8 @@
 
 namespace {
 constexpr int kMaxSettingsStartupPage = 11;
+constexpr int kMinHeadsetcontrolLowBatteryThreshold = 1;
+constexpr int kMaxHeadsetcontrolLowBatteryThreshold = 30;
 }
 
 UserSettings* UserSettings::m_instance = nullptr;
@@ -89,6 +91,10 @@ void UserSettings::initProperties()
     m_panelStyle = settings.value("panelStyle", 0).toInt();
     m_headsetcontrolFetchRate = settings.value("headsetcontrolFetchRate", 20).toInt();
     m_enableNotifications = settings.value("enableNotifications", false).toBool();
+    m_headsetcontrolLowBatteryThreshold = qBound(
+        kMinHeadsetcontrolLowBatteryThreshold,
+        settings.value("headsetcontrolLowBatteryThreshold", 25).toInt(),
+        kMaxHeadsetcontrolLowBatteryThreshold);
 
     m_enableMediaOverlay = settings.value("enableMediaOverlay", false).toBool();
     m_mediaOverlayPosition = settings.value("mediaOverlayPosition", 1).toInt(); // Default: top-center
@@ -504,6 +510,19 @@ void UserSettings::setEnableNotifications(bool value)
         m_enableNotifications = value;
         saveValue("enableNotifications", value);
         emit enableNotificationsChanged();
+    }
+}
+
+void UserSettings::setHeadsetcontrolLowBatteryThreshold(int value)
+{
+    value = qBound(kMinHeadsetcontrolLowBatteryThreshold,
+                   value,
+                   kMaxHeadsetcontrolLowBatteryThreshold);
+
+    if (m_headsetcontrolLowBatteryThreshold != value) {
+        m_headsetcontrolLowBatteryThreshold = value;
+        saveValue("headsetcontrolLowBatteryThreshold", value);
+        emit headsetcontrolLowBatteryThresholdChanged();
     }
 }
 

--- a/src/usersettings.cpp
+++ b/src/usersettings.cpp
@@ -1,6 +1,10 @@
 #include "usersettings.h"
 #include <QSettings>
 
+namespace {
+constexpr int kMaxSettingsStartupPage = 11;
+}
+
 UserSettings* UserSettings::m_instance = nullptr;
 
 UserSettings::UserSettings(QObject *parent)
@@ -60,6 +64,7 @@ void UserSettings::initProperties()
     m_micMuteShortcutModifiers = settings.value("micMuteShortcutModifiers", 117440512).toInt();
     m_autoUpdateTranslations = settings.value("autoUpdateTranslations", false).toBool();
     m_firstRun = settings.value("firstRun", true).toBool();
+    m_settingsStartupPage = qBound(0, settings.value("settingsStartupPage", 0).toInt(), kMaxSettingsStartupPage);
 
     m_trayIconTheme = settings.value("trayIconTheme", 0).toInt();
     m_iconStyle = settings.value("iconStyle", 0).toInt();
@@ -306,6 +311,17 @@ void UserSettings::setFirstRun(bool value)
         m_firstRun = value;
         saveValue("firstRun", value);
         emit firstRunChanged();
+    }
+}
+
+void UserSettings::setSettingsStartupPage(int value)
+{
+    value = qBound(0, value, kMaxSettingsStartupPage);
+
+    if (m_settingsStartupPage != value) {
+        m_settingsStartupPage = value;
+        saveValue("settingsStartupPage", value);
+        emit settingsStartupPageChanged();
     }
 }
 


### PR DESCRIPTION
Adds a new user setting to allow selection of the default page that opens when the settings window is launched.

- Double-clicking the system tray icon now directly opens the settings window to the user's preferred page.
- Single-clicking the tray icon will toggle the main panel, with a slight delay implemented to differentiate from a double-click.
- Refactors settings window navigation into a consistent `openPage` function, improving code clarity and maintainability.
- Updates the low battery notification setting to use a `LabeledSwitch` component.