### PR TITLE
Make low battery notification strings translatable

### DIFF
--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -988,6 +988,14 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation>Batterie schwach</translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation>Der Akku des Headsets ist fast leer</translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation>Update verfügbar</translation>
     </message>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -987,6 +987,14 @@ You can enable it in the Components tab.</source>
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation>Update Available</translation>
     </message>

--- a/i18n/QontrolPanel_es.ts
+++ b/i18n/QontrolPanel_es.ts
@@ -988,6 +988,14 @@ Puedes activarla en la pestaña Componentes.</translation>
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation type="unfinished">Actualización disponible</translation>
     </message>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -997,6 +997,14 @@ You can enable it in the Components tab.</source>
         <translation>Sons système</translation>
     </message>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Brightness</source>
         <translation>Luminosité</translation>
     </message>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -987,6 +987,14 @@ You can enable it in the Components tab.</source>
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation>Disponibile aggiornamento</translation>
     </message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -987,6 +987,14 @@ You can enable it in the Components tab.</source>
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation>更新が利用可能です</translation>
     </message>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -999,6 +999,14 @@ You can enable it in the Components tab.</source>
         <translation>업데이트 가능</translation>
     </message>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Version %1 is available for download</source>
         <translation>버전 %1은 다운로드할 수 있습니다</translation>
     </message>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -987,6 +987,14 @@ You can enable it in the Components tab.</source>
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation>Dostępna aktualizacja</translation>
     </message>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -988,6 +988,14 @@ You can enable it in the Components tab.</source>
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation>Atualização disponível</translation>
     </message>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -994,6 +994,14 @@ You can enable it in the Components tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Version %1 is available for download</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -986,6 +986,14 @@ You can enable it in the Components tab.</source>
 <context>
     <name>Main</name>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Update Available</source>
         <translation>Posodobitev je na voljo</translation>
     </message>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -994,6 +994,14 @@ You can enable it in the Components tab.</source>
         <translation>有更新可用</translation>
     </message>
     <message>
+        <source>Low Battery</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Headset battery is getting low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Version %1 is available for download</source>
         <translation>版本 %1 可下载</translation>
     </message>

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -543,7 +543,7 @@ ApplicationWindow {
     Connections {
         target: HeadsetControlBridge
         function onLowHeadsetBattery() {
-            systemTray.showMessage("Low Battery", "Headset battery is getting low")
+            systemTray.showMessage(qsTr("Low Battery"), qsTr("Headset battery is getting low"))
         }
     }
 


### PR DESCRIPTION
Wraps the low battery notification title and message in qsTr() to ensure they are available for translation.
