### PR TITLE
Adds headset badge to tray icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.13.1 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.13.2 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SOURCES
     src/powerbridge.cpp
     src/languagebridge.cpp
     src/keyboardshortcutmanager.cpp
+    src/trayiconprovider.cpp
 )
 
 set(HEADERS
@@ -88,6 +89,7 @@ set(HEADERS
     include/powerbridge.h
     include/languagebridge.h
     include/keyboardshortcutmanager.h
+    include/trayiconprovider.h
 )
 
 # Get git commit hash

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ If you like my work, please consider supporting me !
 
 ## Usage
 
-Left click on the tray icon to reveal the panel.  
-Click anywhere or again on the tray icon to close the panel.
-Double click on tray icon will open the settings pane.
-Default page of settings pane is configurable in General section.
+Left click on the tray icon to reveal the panel.<br>
+Click anywhere or left again on the tray icon to close the panel.<br>
+Double click on tray icon will open the settings pane.<br>
+Default section of settings pane is configurable in General section.
 
 ## Translations
 

--- a/include/trayiconprovider.h
+++ b/include/trayiconprovider.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <QQuickImageProvider>
+
+class TrayIconProvider : public QQuickImageProvider
+{
+public:
+    TrayIconProvider();
+
+    QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;
+};

--- a/qml/Singletons/Constants.qml
+++ b/qml/Singletons/Constants.qml
@@ -52,11 +52,11 @@ Item {
 
     function getTrayIcon(volume, muted) {
         // Check for battery icon style first
-        if (UserSettings.iconStyle === 2 && HeadsetControlManager.anyDeviceFound) {
-            if (HeadsetControlManager.batteryStatus === "BATTERY_CHARGING") {
+        if (UserSettings.iconStyle === 2 && HeadsetControlBridge.anyDeviceFound) {
+            if (HeadsetControlBridge.batteryStatus === "BATTERY_CHARGING") {
                 return getBatteryChargingIcon()
             } else {
-                return getBatteryIcon(HeadsetControlManager.batteryLevel)
+                return getBatteryIcon(HeadsetControlBridge.batteryLevel)
             }
         }
 
@@ -84,7 +84,13 @@ Item {
         }
 
         let filledSuffix = UserSettings.iconStyle === 1 ? "_filled" : ""
-        return `qrc:/icons/tray_${theme}_${volumeLevel}${filledSuffix}.png`
+        let trayIconName = `tray_${theme}_${volumeLevel}${filledSuffix}.png`
+
+        if (HeadsetControlBridge.anyDeviceFound) {
+            return `image://trayicon/${trayIconName}`
+        }
+
+        return `qrc:/icons/${trayIconName}`
     }
 
     function getBatteryIcon(batteryLevel) {

--- a/src/panelengine.cpp
+++ b/src/panelengine.cpp
@@ -1,6 +1,7 @@
 #include "panelengine.h"
 #include "mediasessionmanager.h"
 #include "LanguageBridge.h"
+#include "trayiconprovider.h"
 #include "usersettings.h"
 #include <QMenu>
 #include <QApplication>
@@ -56,6 +57,7 @@ void PanelEngine::initializeQMLEngine()
     }
 
     engine = new QQmlApplicationEngine(this);
+    engine->addImageProvider("trayicon", new TrayIconProvider());
     engine->loadFromModule("ChrisLauinger77.QontrolPanel", "Main");
 
     if (!engine->rootObjects().isEmpty()) {

--- a/src/trayiconprovider.cpp
+++ b/src/trayiconprovider.cpp
@@ -1,0 +1,78 @@
+#include "trayiconprovider.h"
+
+#include <QColor>
+#include <QImage>
+#include <QPainter>
+#include <QPen>
+
+namespace {
+QString normalizeIconId(QString id)
+{
+    if (id.startsWith('/')) {
+        id.remove(0, 1);
+    }
+
+    return id;
+}
+
+QRect badgeRectFor(const QSize& size)
+{
+    const int minSide = qMin(size.width(), size.height());
+    const int badgeDiameter = qMax(8, qRound(minSide * 0.5));
+    const int margin = qMax(0, qRound(minSide * 0.03));
+
+    return QRect(size.width() - badgeDiameter - margin,
+                 size.height() - badgeDiameter - margin,
+                 badgeDiameter,
+                 badgeDiameter);
+}
+}
+
+TrayIconProvider::TrayIconProvider()
+    : QQuickImageProvider(QQuickImageProvider::Image)
+{
+}
+
+QImage TrayIconProvider::requestImage(const QString& id, QSize* size, const QSize& requestedSize)
+{
+    const QString iconId = normalizeIconId(id);
+    const QImage baseImage(QString(":/icons/%1").arg(iconId));
+
+    if (baseImage.isNull()) {
+        if (size) {
+            *size = QSize();
+        }
+
+        return QImage();
+    }
+
+    QImage result = requestedSize.isValid()
+        ? baseImage.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation)
+        : baseImage;
+
+    if (size) {
+        *size = result.size();
+    }
+
+    const QRect badgeRect = badgeRectFor(result.size());
+    const int borderWidth = qMax(1, qRound(qMin(result.width(), result.height()) * 0.08));
+    const int innerIconSize = qMax(5, qRound(badgeRect.width() * 0.58));
+    const QRect innerRect(badgeRect.center().x() - (innerIconSize / 2),
+                          badgeRect.center().y() - (innerIconSize / 2),
+                          innerIconSize,
+                          innerIconSize);
+
+    QPainter painter(&result);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setRenderHint(QPainter::SmoothPixmapTransform, true);
+    painter.setPen(QPen(QColor(0, 0, 0, 150), borderWidth));
+    painter.setBrush(QColor(255, 255, 255, 245));
+    painter.drawEllipse(badgeRect.adjusted(0, 0, -1, -1));
+
+    const QImage headsetImage(QStringLiteral(":/icons/devices/headset.png"));
+    if (!headsetImage.isNull()) {
+        painter.drawImage(innerRect, headsetImage);
+    }
+
+    return result;
+}


### PR DESCRIPTION
Implements a dynamic tray icon that displays a headset badge when a headset device is connected. This provides a clear visual indicator for the device's status directly on the system tray.

To achieve this:
- Introduces `TrayIconProvider` as a `QQuickImageProvider` to render the base tray icon with an overlaid headset badge when `HeadsetControlBridge` detects an active device.
- Updates QML logic to utilize the new `image://trayicon` provider for dynamic icon generation.

Also:
- Bumps the project version to 1.13.2.
- Refines the usage section in `README.md` for better clarity and formatting.
- Updates `HeadsetControlManager` references to `HeadsetControlBridge` in QML.