### PR TITLE
Localize UI strings and log export headers (#47)

### DIFF
--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -20,8 +20,12 @@
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <source>Step</source>
-        <translation>Schritt</translation>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove</source>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>Konsolenausgabe</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation>Löschen</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Links</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Rechts</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -990,6 +1101,17 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1151,6 +1273,14 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
         <translation>QontrolPanel - Einstellungen</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
@@ -1281,12 +1411,24 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
         <translation>Ausgabe: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>Eingabe: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>Beenden</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -21,11 +21,11 @@
     </message>
     <message>
         <source>Up %1  Down %2%3</source>
-        <translation type="unfinished"></translation>
+        <translation>Hoch %1 Runter %2%3</translation>
     </message>
     <message>
         <source>(Step: %1)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Schritt: %1)</translation>
     </message>
     <message>
         <source>Remove</source>
@@ -433,31 +433,31 @@
     <name>ConsolePane</name>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle</translation>
     </message>
     <message>
         <source>QontrolPanel Log Export</source>
-        <translation type="unfinished"></translation>
+        <translation>QontrolPanel-Protokollexport</translation>
     </message>
     <message>
         <source>Version: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Version: %1</translation>
     </message>
     <message>
         <source>Commit: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Commit: %1</translation>
     </message>
     <message>
         <source>Export Date: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Exportdatum: %1</translation>
     </message>
     <message>
         <source>Filter: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Filter: %1</translation>
     </message>
     <message>
         <source>Total Entries: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Gesamtzahl der Einträge: %1</translation>
     </message>
     <message>
         <source>Console output</source>
@@ -484,79 +484,79 @@
     <name>Context</name>
     <message>
         <source>Up</source>
-        <translation type="unfinished"></translation>
+        <translation>Hoch</translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Runter</translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="unfinished">Links</translation>
+        <translation>Links</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="unfinished">Rechts</translation>
+        <translation>Rechts</translation>
     </message>
     <message>
         <source>Space</source>
-        <translation type="unfinished"></translation>
+        <translation>Leer</translation>
     </message>
     <message>
         <source>Enter</source>
-        <translation type="unfinished"></translation>
+        <translation>Eingabe</translation>
     </message>
     <message>
         <source>Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Tab</translation>
     </message>
     <message>
         <source>Esc</source>
-        <translation type="unfinished"></translation>
+        <translation>Esc</translation>
     </message>
     <message>
         <source>Backspace</source>
-        <translation type="unfinished"></translation>
+        <translation>Rücktaste</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation>Einfügen</translation>
     </message>
     <message>
         <source>Home</source>
-        <translation type="unfinished"></translation>
+        <translation>Pos 1</translation>
     </message>
     <message>
         <source>End</source>
-        <translation type="unfinished"></translation>
+        <translation>Ende</translation>
     </message>
     <message>
         <source>Page Up</source>
-        <translation type="unfinished"></translation>
+        <translation>Bild auf</translation>
     </message>
     <message>
         <source>Page Down</source>
-        <translation type="unfinished"></translation>
+        <translation>Bild ab</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unbekannt</translation>
     </message>
     <message>
         <source>Ctrl</source>
-        <translation type="unfinished"></translation>
+        <translation>Strg</translation>
     </message>
     <message>
         <source>Shift</source>
-        <translation type="unfinished"></translation>
+        <translation>Umschalt</translation>
     </message>
     <message>
         <source>Alt</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt</translation>
     </message>
 </context>
 <context>
@@ -1104,11 +1104,11 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
     <name>LogBridge</name>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unbekannt</translation>
     </message>
 </context>
 <context>
@@ -1274,11 +1274,11 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
     </message>
     <message>
         <source>You just lost the game</source>
-        <translation type="unfinished"></translation>
+        <translation>Du hast gerade das Spiel verloren</translation>
     </message>
     <message>
         <source>Too bad</source>
-        <translation type="unfinished"></translation>
+        <translation>Schade</translation>
     </message>
     <message>
         <source>General</source>
@@ -1412,7 +1412,7 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
     </message>
     <message>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Wird geladen...</translation>
     </message>
     <message>
         <source>Input: </source>
@@ -1424,11 +1424,11 @@ Sie können sie auf der Registerkarte „Komponenten“ aktivieren.</translation
     </message>
     <message>
         <source>Unknown Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Unbekanntes Gerät</translation>
     </message>
     <message>
         <source>QontrolPanel</source>
-        <translation type="unfinished"></translation>
+        <translation>QontrolPanel</translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -20,7 +20,11 @@
         <translation type="unfinished">Add</translation>
     </message>
     <message>
-        <source>Step</source>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>Console output</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation>Clear</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Left</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Right</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -989,6 +1100,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1150,6 +1272,14 @@ You can enable it in the Components tab.</source>
         <translation>QontrolPanel - Settings</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>General</translation>
     </message>
@@ -1280,12 +1410,24 @@ You can enable it in the Components tab.</source>
         <translation>Output: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>Input: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>Exit</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_es.ts
+++ b/i18n/QontrolPanel_es.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_es.ts
+++ b/i18n/QontrolPanel_es.ts
@@ -20,8 +20,12 @@
         <translation type="unfinished">Añadir</translation>
     </message>
     <message>
-        <source>Step</source>
-        <translation type="unfinished">Paso</translation>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove</source>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation type="unfinished">Salida de consola</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation type="unfinished">Limpiar</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Izquierda</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Derecha</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -990,6 +1101,17 @@ Puedes activarla en la pestaña Componentes.</translation>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1151,6 +1273,14 @@ Puedes activarla en la pestaña Componentes.</translation>
         <translation type="unfinished">QontrolPanel - Configuración</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation type="unfinished">General</translation>
     </message>
@@ -1281,12 +1411,24 @@ Puedes activarla en la pestaña Componentes.</translation>
         <translation type="unfinished">Salida: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation type="unfinished">Entrada: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation type="unfinished">Salir</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -20,7 +20,11 @@
         <translation type="unfinished">Ajouter</translation>
     </message>
     <message>
-        <source>Step</source>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -430,6 +434,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>Sortie console</translation>
     </message>
@@ -448,6 +480,85 @@
     <message>
         <source>Clear</source>
         <translation>Effacer</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Gauche</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Droite</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -991,6 +1102,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>ChatMix</source>
@@ -1169,6 +1291,14 @@ You can enable it in the Components tab.</source>
         <translation>ChatMix</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Appearance</source>
         <translation>Apparence</translation>
     </message>
@@ -1299,8 +1429,20 @@ You can enable it in the Components tab.</source>
         <translation>Sortie: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>QontrolPanel settings</source>
         <translation>Paramètres de QontrolPanel</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -20,8 +20,12 @@
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <source>Step</source>
-        <translation>Step</translation>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove</source>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>Output console</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation>Azzera</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">A sinistra</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">A destra</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -990,6 +1101,17 @@ Puoi abilitarlo nella scheda Componenti.</translation>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1151,6 +1273,14 @@ Puoi abilitarlo nella scheda Componenti.</translation>
         <translation>QontrolPanel - Impostazioni</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>Generale</translation>
     </message>
@@ -1281,12 +1411,24 @@ Puoi abilitarlo nella scheda Componenti.</translation>
         <translation>Output: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>Ingresso: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>Esci da QontrolPanel</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -20,7 +20,11 @@
         <translation type="unfinished">追加</translation>
     </message>
     <message>
-        <source>Step</source>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>コンソール出力</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation>消去</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">右</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -989,6 +1100,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1150,6 +1272,14 @@ You can enable it in the Components tab.</source>
         <translation>QontrolPanel - 設定</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>一般</translation>
     </message>
@@ -1280,12 +1410,24 @@ You can enable it in the Components tab.</source>
         <translation>出力: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>入力: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>終了</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -20,7 +20,11 @@
         <translation type="unfinished">추가</translation>
     </message>
     <message>
-        <source>Step</source>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>콘솔 출력</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation>지우기</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">왼쪽</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">오른쪽</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -989,6 +1100,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>System sounds</source>
@@ -1150,6 +1272,14 @@ You can enable it in the Components tab.</source>
         <translation>QontrolPanel - 설정</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>일반</translation>
     </message>
@@ -1280,12 +1410,24 @@ You can enable it in the Components tab.</source>
         <translation>출력: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>입력: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>종료</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -20,7 +20,11 @@
         <translation type="unfinished">Dodaj</translation>
     </message>
     <message>
-        <source>Step</source>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>Wyjście konsoli</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Lewa</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Prawa</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -989,6 +1100,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1150,6 +1272,14 @@ You can enable it in the Components tab.</source>
         <translation>QontrolPanel - Ustawienia</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
@@ -1280,6 +1410,10 @@ You can enable it in the Components tab.</source>
         <translation>Wyjście: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>Wejście: </translation>
     </message>
@@ -1298,6 +1432,14 @@ You can enable it in the Components tab.</source>
     <message>
         <source>Exit</source>
         <translation>Wyjście</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -20,8 +20,12 @@
         <translation>Adicionar</translation>
     </message>
     <message>
-        <source>Step</source>
-        <translation>Passo</translation>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove</source>
@@ -429,6 +433,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>Saída do console</translation>
     </message>
@@ -447,6 +479,85 @@
     <message>
         <source>Clear</source>
         <translation>Limpar</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Esquerda</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Direita</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -990,6 +1101,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1151,6 +1273,14 @@ You can enable it in the Components tab.</source>
         <translation>QontrolPanel - Configurações</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>Geral</translation>
     </message>
@@ -1281,12 +1411,24 @@ You can enable it in the Components tab.</source>
         <translation>Saída: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>Entrada: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>Sair</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -20,7 +20,11 @@
         <translation type="unfinished">Добавить</translation>
     </message>
     <message>
-        <source>Step</source>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation type="unfinished"></translation>
     </message>
@@ -445,6 +477,85 @@
     </message>
     <message>
         <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Слева</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Справа</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -988,6 +1099,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>ChatMix</source>
@@ -1149,6 +1271,14 @@ You can enable it in the Components tab.</source>
         <translation>QontrolPanel - Настройки</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>Основные</translation>
     </message>
@@ -1279,12 +1409,24 @@ You can enable it in the Components tab.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Exit</source>
         <translation type="unfinished">Выход</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -20,8 +20,12 @@
         <translation>Dodaj</translation>
     </message>
     <message>
-        <source>Step</source>
-        <translation>Korak</translation>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove</source>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>Izhod konzole</translation>
     </message>
@@ -446,6 +478,85 @@
     <message>
         <source>Clear</source>
         <translation>Počisti</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">Levo</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">Desno</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -989,6 +1100,17 @@ Omogočite ga lahko na zavihku Komponente.</translation>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>Low Battery</source>
@@ -1150,6 +1272,14 @@ Omogočite ga lahko na zavihku Komponente.</translation>
         <translation>QontrolPanel - Nastavitve</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>Splošno</translation>
     </message>
@@ -1280,12 +1410,24 @@ Omogočite ga lahko na zavihku Komponente.</translation>
         <translation>Izhod: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>Vnos: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>Izhod</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -24,7 +24,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>  (Step: %1)</source>
+        <source>(Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -20,7 +20,11 @@
         <translation type="unfinished">添加</translation>
     </message>
     <message>
-        <source>Step</source>
+        <source>Up %1  Down %2%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>  (Step: %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -428,6 +432,34 @@
 <context>
     <name>ConsolePane</name>
     <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Commit: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Date: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Total Entries: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Console output</source>
         <translation>控制台输出</translation>
     </message>
@@ -445,6 +477,85 @@
     </message>
     <message>
         <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished">左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished">右</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -988,6 +1099,17 @@ You can enable it in the Components tab.</source>
     </message>
 </context>
 <context>
+    <name>LogBridge</name>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Main</name>
     <message>
         <source>ChatMix</source>
@@ -1149,6 +1271,14 @@ You can enable it in the Components tab.</source>
         <translation>QontrolPanel - 设置</translation>
     </message>
     <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>General</source>
         <translation>常规</translation>
     </message>
@@ -1279,12 +1409,24 @@ You can enable it in the Components tab.</source>
         <translation>输出: </translation>
     </message>
     <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Input: </source>
         <translation>输入: </translation>
     </message>
     <message>
         <source>Exit</source>
         <translation>退出</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>ChatMix</source>

--- a/qml/ChatMixNotification.qml
+++ b/qml/ChatMixNotification.qml
@@ -45,7 +45,7 @@ ApplicationWindow {
 
             if (UserSettings.chatMixShortcutNotification) {
                 notificationType = "chatmix"
-                var message = UserSettings.chatMixEnabled ? "ChatMix Enabled" : "ChatMix Disabled"
+                var message = UserSettings.chatMixEnabled ? qsTr("ChatMix Enabled") : qsTr("ChatMix Disabled")
                 notificationWindow.showNotification(message)
 
                 if (UserSettings.chatMixEnabled) {

--- a/qml/SettingsPane/AppHotkeysPane.qml
+++ b/qml/SettingsPane/AppHotkeysPane.qml
@@ -48,9 +48,12 @@ ColumnLayout {
                         required property int index
                         width: parent.width
                         title: hotkeyCard.modelData.executableName
-                        description: "▲ " + Context.getShortcutText(hotkeyCard.modelData.volumeUpModifiers, hotkeyCard.modelData.volumeUpKey) +
-                                     "  ▼ " + Context.getShortcutText(hotkeyCard.modelData.volumeDownModifiers, hotkeyCard.modelData.volumeDownKey) +
-                                     (hotkeyCard.modelData.volumeStepSize > 0 ? "  (" + qsTr("Step") + ": " + hotkeyCard.modelData.volumeStepSize + ")" : "")
+                        description: qsTr("Up %1  Down %2%3")
+                                     .arg(Context.getShortcutText(hotkeyCard.modelData.volumeUpModifiers, hotkeyCard.modelData.volumeUpKey))
+                                     .arg(Context.getShortcutText(hotkeyCard.modelData.volumeDownModifiers, hotkeyCard.modelData.volumeDownKey))
+                                     .arg(hotkeyCard.modelData.volumeStepSize > 0
+                                          ? qsTr("  (Step: %1)").arg(hotkeyCard.modelData.volumeStepSize)
+                                          : "")
 
                         additionalControl: Button {
                             text: qsTr("Remove")

--- a/qml/SettingsPane/AppHotkeysPane.qml
+++ b/qml/SettingsPane/AppHotkeysPane.qml
@@ -52,7 +52,7 @@ ColumnLayout {
                                      .arg(Context.getShortcutText(hotkeyCard.modelData.volumeUpModifiers, hotkeyCard.modelData.volumeUpKey))
                                      .arg(Context.getShortcutText(hotkeyCard.modelData.volumeDownModifiers, hotkeyCard.modelData.volumeDownKey))
                                      .arg(hotkeyCard.modelData.volumeStepSize > 0
-                                          ? qsTr("  (Step: %1)").arg(hotkeyCard.modelData.volumeStepSize)
+                                          ? "  " + qsTr("(Step: %1)").arg(hotkeyCard.modelData.volumeStepSize)
                                           : "")
 
                         additionalControl: Button {

--- a/qml/SettingsPane/ConsolePane.qml
+++ b/qml/SettingsPane/ConsolePane.qml
@@ -122,7 +122,7 @@ ColumnLayout {
             Layout.preferredWidth: 200
             model: ListModel {
                 id: senderOptions
-                ListElement { text: qsTr("All"); value: qsTr("All") }
+                ListElement { text: qsTr("All"); value: "All" }
             }
             textRole: "text"
             valueRole: "value"

--- a/qml/SettingsPane/ConsolePane.qml
+++ b/qml/SettingsPane/ConsolePane.qml
@@ -8,7 +8,7 @@ ColumnLayout {
     id: logViewer
     spacing: 3
 
-    property string selectedSender: "All"
+    property string selectedSender: qsTr("All")
     property bool autoScroll: true
 
     Component.onCompleted: {
@@ -63,13 +63,13 @@ ColumnLayout {
         let version = Updater.getAppVersion()
         let commitHash = Updater.getCommitHash()
         let currentDate = new Date().toISOString().split('T')[0]
-        let header = "QontrolPanel Log Export\n"
+        let header = qsTr("QontrolPanel Log Export") + "\n"
         header += "========================\n"
-        header += "Version: " + version + "\n"
-        header += "Commit: " + commitHash + "\n"
-        header += "Export Date: " + currentDate + "\n"
-        header += "Filter: " + selectedSender + "\n"
-        header += "Total Entries: " + LogBridge.filteredModel.count + "\n"
+        header += qsTr("Version: %1").arg(version) + "\n"
+        header += qsTr("Commit: %1").arg(commitHash) + "\n"
+        header += qsTr("Export Date: %1").arg(currentDate) + "\n"
+        header += qsTr("Filter: %1").arg(selectedSender) + "\n"
+        header += qsTr("Total Entries: %1").arg(LogBridge.filteredModel.count) + "\n"
         header += "========================\n\n"
 
         let allLogsText = header
@@ -122,7 +122,7 @@ ColumnLayout {
             Layout.preferredWidth: 200
             model: ListModel {
                 id: senderOptions
-                ListElement { text: "All"; value: "All" }
+                ListElement { text: qsTr("All"); value: qsTr("All") }
             }
             textRole: "text"
             valueRole: "value"

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -95,14 +95,14 @@ ApplicationWindow {
             anchors.fill: parent
 
             Label {
-                text: "You just lost the game"
+                text: qsTr("You just lost the game")
                 font.bold: true
                 font.pixelSize: 18
                 Layout.alignment: Qt.AlignCenter
             }
 
             Button {
-                text: "Too bad"
+                text: qsTr("Too bad")
                 onClicked: easterEggDialog.close()
                 Layout.alignment: Qt.AlignCenter
             }

--- a/qml/Singletons/Context.qml
+++ b/qml/Singletons/Context.qml
@@ -27,22 +27,22 @@ QtObject {
             [Qt.Key_0]: "0", [Qt.Key_1]: "1", [Qt.Key_2]: "2", [Qt.Key_3]: "3",
             [Qt.Key_4]: "4", [Qt.Key_5]: "5", [Qt.Key_6]: "6", [Qt.Key_7]: "7",
             [Qt.Key_8]: "8", [Qt.Key_9]: "9",
-            [Qt.Key_Up]: "Up", [Qt.Key_Down]: "Down", [Qt.Key_Left]: "Left", [Qt.Key_Right]: "Right",
-            [Qt.Key_Space]: "Space", [Qt.Key_Return]: "Enter", [Qt.Key_Enter]: "Enter",
-            [Qt.Key_Tab]: "Tab", [Qt.Key_Escape]: "Esc", [Qt.Key_Backspace]: "Backspace",
-            [Qt.Key_Delete]: "Delete", [Qt.Key_Insert]: "Insert",
-            [Qt.Key_Home]: "Home", [Qt.Key_End]: "End",
-            [Qt.Key_PageUp]: "Page Up", [Qt.Key_PageDown]: "Page Down"
+            [Qt.Key_Up]: qsTr("Up"), [Qt.Key_Down]: qsTr("Down"), [Qt.Key_Left]: qsTr("Left"), [Qt.Key_Right]: qsTr("Right"),
+            [Qt.Key_Space]: qsTr("Space"), [Qt.Key_Return]: qsTr("Enter"), [Qt.Key_Enter]: qsTr("Enter"),
+            [Qt.Key_Tab]: qsTr("Tab"), [Qt.Key_Escape]: qsTr("Esc"), [Qt.Key_Backspace]: qsTr("Backspace"),
+            [Qt.Key_Delete]: qsTr("Delete"), [Qt.Key_Insert]: qsTr("Insert"),
+            [Qt.Key_Home]: qsTr("Home"), [Qt.Key_End]: qsTr("End"),
+            [Qt.Key_PageUp]: qsTr("Page Up"), [Qt.Key_PageDown]: qsTr("Page Down")
         }
-        return keyMap[key] || "Unknown"
+        return keyMap[key] || qsTr("Unknown")
     }
 
     function getShortcutText(modifiers, key) {
         let parts = []
 
-        if (modifiers & Qt.ControlModifier) parts.push("Ctrl")
-        if (modifiers & Qt.ShiftModifier) parts.push("Shift")
-        if (modifiers & Qt.AltModifier) parts.push("Alt")
+        if (modifiers & Qt.ControlModifier) parts.push(qsTr("Ctrl"))
+        if (modifiers & Qt.ShiftModifier) parts.push(qsTr("Shift"))
+        if (modifiers & Qt.AltModifier) parts.push(qsTr("Alt"))
 
         let keyText = getKeyText(key)
         if (keyText) parts.push(keyText)

--- a/qml/Singletons/LogBridge.qml
+++ b/qml/Singletons/LogBridge.qml
@@ -8,7 +8,7 @@ Item {
     property int maxLogEntries: 500
     property ListModel logModel: ListModel {}
     property ListModel filteredModel: ListModel {}
-    property string currentFilter: "All"
+    property string currentFilter: qsTr("All")
     property var senderRegex: /^\[[^\]]+\]\s+(\w+)\s+\[\w+\]/
 
     signal logEntryAdded(string message, int type, string sender)
@@ -50,7 +50,7 @@ Item {
         logModel.append(newEntry)
 
         // Only add to filtered model if it matches current filter
-        if (currentFilter === "All" || sender === currentFilter) {
+        if (currentFilter === qsTr("All") || sender === currentFilter) {
             filteredModel.append(newEntry)
         }
 
@@ -59,7 +59,7 @@ Item {
 
     function extractSenderFromMessage(message) {
         let match = message.match(senderRegex)
-        return match ? match[1] : "Unknown"
+        return match ? match[1] : qsTr("Unknown")
     }
 
     function clearLogs() {
@@ -74,7 +74,7 @@ Item {
         currentFilter = selectedSender
         filteredModel.clear()
 
-        if (selectedSender === "All") {
+        if (selectedSender === qsTr("All")) {
             // Copy all entries
             for (let i = 0; i < logModel.count; i++) {
                 filteredModel.append(logModel.get(i))

--- a/qml/Singletons/LogBridge.qml
+++ b/qml/Singletons/LogBridge.qml
@@ -8,7 +8,7 @@ Item {
     property int maxLogEntries: 500
     property ListModel logModel: ListModel {}
     property ListModel filteredModel: ListModel {}
-    property string currentFilter: qsTr("All")
+    property string currentFilter: "All"
     property var senderRegex: /^\[[^\]]+\]\s+(\w+)\s+\[\w+\]/
 
     signal logEntryAdded(string message, int type, string sender)

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -26,12 +26,12 @@ Platform.SystemTrayIcon {
         Platform.MenuItem {
             enabled: false
             text: systemTray.truncateText(qsTr("Output: ") + (AudioBridge.isReady ?
-                                                                  systemTray.getOutputDeviceInfo() : "Loading..."), 50)
+                                                                  systemTray.getOutputDeviceInfo() : qsTr("Loading...")), 50)
         }
         Platform.MenuItem {
             enabled: false
             text: systemTray.truncateText(qsTr("Input: ") + (AudioBridge.isReady ?
-                                                                 systemTray.getInputDeviceInfo() : "Loading..."), 50)
+                                                                 systemTray.getInputDeviceInfo() : qsTr("Loading...")), 50)
         }
         Platform.MenuSeparator {}
         Platform.MenuItem {
@@ -59,15 +59,15 @@ Platform.SystemTrayIcon {
     }
 
     function getOutputDeviceInfo() {
-        return AudioBridge.outputDeviceDisplayName || "Unknown Device"
+        return AudioBridge.outputDeviceDisplayName || qsTr("Unknown Device")
     }
 
     function getInputDeviceInfo() {
-        return AudioBridge.inputDeviceDisplayName || "Unknown Device"
+        return AudioBridge.inputDeviceDisplayName || qsTr("Unknown Device")
     }
 
     function getTooltip() {
-        var baseTooltip = "QontrolPanel";
+        var baseTooltip = qsTr("QontrolPanel");
         var isWirelessHeadsetAvailable = HeadsetControlBridge.anyDeviceFound &&
                 HeadsetControlBridge.batteryStatus !== "BATTERY_UNAVAILABLE";
         if (!isWirelessHeadsetAvailable) {


### PR DESCRIPTION
Wraps several user-facing strings across various QML components in `qsTr()` to enable translation support. This includes keyboard shortcut labels, notification messages, and log export metadata.
