### PR TITLE
Potential fix for code scanning alert no. 2: Code injection

### DIFF
--- a/.github/workflows/compile_translations.yml
+++ b/.github/workflows/compile_translations.yml
@@ -168,6 +168,8 @@ jobs:
 
       - name: Commit compiled translations to PR branch
         if: github.event_name == 'workflow_run' && steps.pr_context.outputs.has_translation_changes == 'true'
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
@@ -179,7 +181,7 @@ jobs:
           fi
 
           git commit -m "Update compiled translations [skip ci]"
-          git push origin HEAD:${{ github.event.workflow_run.head_branch }}
+          git push origin "HEAD:$HEAD_BRANCH"
 
       - name: Commit compiled translations to current branch
         if: github.event_name != 'workflow_run' && github.ref_name != 'main'


### PR DESCRIPTION
Potential fix for [https://github.com/ChrisLauinger77/QontrolPanel/security/code-scanning/2](https://github.com/ChrisLauinger77/QontrolPanel/security/code-scanning/2)

Use an intermediate environment variable for the untrusted expression and reference it with native shell syntax in the script (`"$VAR"`), not with `${{ ... }}` in the command body.

Best fix in this file:
- In the step **“Commit compiled translations to PR branch”** (around lines 169–183), add an `env:` block:
  - `HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}`
- Replace:
  - `git push origin HEAD:${{ github.event.workflow_run.head_branch }}`
  with:
  - `git push origin "HEAD:$HEAD_BRANCH"`

This preserves behavior while removing direct expression interpolation from the shell command and prevents expression-based command injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
