### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -7,6 +7,8 @@ on:
       release_tag:
         description: "Release tag to publish (e.g., 1.10.4)"
         required: true
+permissions:
+  contents: read
 jobs:
   publish:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ChrisLauinger77/QontrolPanel/security/code-scanning/3](https://github.com/ChrisLauinger77/QontrolPanel/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/winget-publish.yml` so the workflow does not inherit potentially broad defaults.

Best fix (without changing functionality): set minimal read-only permissions at workflow root:
- `contents: read`

This keeps behavior stable for workflows that only need repository metadata/read access and use a separate secret for external publishing. Place the block after the trigger/input section and before `jobs:` so it applies uniformly to all jobs in this workflow.

No imports, methods, or dependency changes are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
