### PR TITLE
Display unavailable icon for battery status

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.14.2 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.14.3 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -248,7 +248,7 @@ QString HeadsetControlBridge::batteryIcon() const
     const int lowBatteryThreshold = UserSettings::instance()->headsetcontrolLowBatteryThreshold();
 
     if (status == "BATTERY_UNAVAILABLE" || level < 0) {
-        return QString();
+        return QString::fromUtf8("❌");
     }
 
     QString icon;


### PR DESCRIPTION
When the battery status from `headsetcontrol` is unavailable or invalid, a '❌' emoji is now displayed instead of an empty string. This provides clearer visual feedback to the user.

Also bumps the project version.
