### PR TITLE
Set default endpoint for Console and Multimedia roles in setDefaultDevice and improve logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.15.2 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.15.3 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/src/audiobridge.cpp
+++ b/src/audiobridge.cpp
@@ -367,6 +367,11 @@ void AudioBridge::setApplicationMute(const QString& appId, bool mute)
 // Device management methods (unchanged)
 void AudioBridge::setDefaultDevice(const QString& deviceId, bool isInput, bool forCommunications)
 {
+    LOG_INFO("AudioBridge",
+             QString("Request default %1 device switch id=%2 communicationsRole=%3")
+                 .arg(isInput ? "input" : "output")
+                 .arg(deviceId)
+                 .arg(forCommunications ? "true" : "false"));
     AudioManager::instance()->setDefaultDeviceAsync(deviceId, isInput, forCommunications);
 }
 

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -1728,12 +1728,20 @@ void AudioWorker::setDefaultDevice(const QString& deviceId, bool isInput, bool f
         return;
     }
 
-    ERole role = forCommunications ? eCommunications : eConsole;
     std::wstring wDeviceId = deviceId.toStdWString();
-    HRESULT hr = m_policyConfig->SetDefaultEndpoint(wDeviceId.c_str(), role);
-    if (!SUCCEEDED(hr)) {
-        LOG_CRITICAL("AudioManager",
-                                             QString("Failed to set default device, HRESULT: %1").arg(QString::number(hr, 16)));
+    const QVector<ERole> roles = forCommunications
+        ? QVector<ERole>{eCommunications}
+        : QVector<ERole>{eConsole, eMultimedia};
+
+    for (const ERole role : roles) {
+        const HRESULT hr = m_policyConfig->SetDefaultEndpoint(wDeviceId.c_str(), role);
+        if (!SUCCEEDED(hr)) {
+            LOG_CRITICAL("AudioManager",
+                         QString("Failed to set default %1 device endpoint role=%2, HRESULT: %3")
+                             .arg(isInput ? "input" : "output")
+                             .arg(static_cast<int>(role))
+                             .arg(QString::number(hr, 16)));
+        }
     }
 }
 

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -1728,6 +1728,12 @@ void AudioWorker::setDefaultDevice(const QString& deviceId, bool isInput, bool f
         return;
     }
 
+    LOG_INFO("AudioManager",
+             QString("Applying default %1 device switch id=%2 communicationsRole=%3")
+                 .arg(isInput ? "input" : "output")
+                 .arg(deviceId)
+                 .arg(forCommunications ? "true" : "false"));
+
     std::wstring wDeviceId = deviceId.toStdWString();
     const QVector<ERole> roles = forCommunications
         ? QVector<ERole>{eCommunications}
@@ -1984,8 +1990,17 @@ void AudioManager::setApplicationMuteAsync(const QString& appId, bool mute)
 void AudioManager::setDefaultDeviceAsync(const QString& deviceId, bool isInput, bool forCommunications)
 {
     if (m_worker) {
-        QMetaObject::invokeMethod(m_worker, "setDefaultDevice", Qt::QueuedConnection,
-                                  Q_ARG(QString, deviceId), Q_ARG(bool, isInput), Q_ARG(bool, forCommunications));
+        const bool invokeOk = QMetaObject::invokeMethod(m_worker, [this, deviceId, isInput, forCommunications]() {
+            if (m_worker) {
+                m_worker->setDefaultDevice(deviceId, isInput, forCommunications);
+            }
+        }, Qt::QueuedConnection);
+
+        if (!invokeOk) {
+            LOG_CRITICAL("AudioManager",
+                         QString("Failed to queue setDefaultDevice call for %1 device")
+                             .arg(isInput ? "input" : "output"));
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

- Ensure that when changing the default device for non-communications the code updates both `eConsole` and `eMultimedia` roles instead of only a single role.
- Provide clearer diagnostics when setting the default endpoint by including the device direction, role, and HRESULT in log messages.

### Description

- Replace single-role assignment with a `QVector<ERole>` of roles and iterate to call `SetDefaultEndpoint` for each role.
- Use `for` loop to call `m_policyConfig->SetDefaultEndpoint` for `eConsole` and `eMultimedia` (or `eCommunications` when requested). 
- Improve failure logging to include whether the device is an input or output, the numeric `role`, and the `HRESULT` returned from `SetDefaultEndpoint`.

### Testing

- Built the project and ran the existing automated test suite; no tests were added or modified and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fc48d3bc832782a739dd044bfe41)