### PR TITLE
Improve audio device switching and headset polling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.15.3 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.15.4 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.15.4 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.16.0 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -2,151 +2,6 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pl_PL">
 <context>
-    <name>ConfirmPowerActionDialog</name>
-    <message>
-        <source>OK</source>
-        <translation>OK</translation>
-    </message>
-    <message>
-        <source>System will restart to UEFI in %1 seconds</source>
-        <translation>System uruchomi się ponownie do UEFI za %1 sekund</translation>
-    </message>
-    <message>
-        <source>Restart to UEFI</source>
-        <translation>Restartuj do UEFI</translation>
-    </message>
-    <message>
-        <source>Action</source>
-        <translation>Działanie</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Anuluj</translation>
-    </message>
-    <message>
-        <source>System will shutdown in %1 seconds</source>
-        <translation>System zostanie zamknięty za %1 sekund</translation>
-    </message>
-    <message>
-        <source>Hibernate</source>
-        <translation>Hibernuj</translation>
-    </message>
-    <message>
-        <source>Restart</source>
-        <translation>Restartuj</translation>
-    </message>
-    <message>
-        <source>System will hibernate in %1 seconds</source>
-        <translation>System przejdzie w stan hibernacji za %1 sekund</translation>
-    </message>
-    <message>
-        <source>You will be signed out in %1 seconds</source>
-        <translation>Zostaniesz wylogowany za %1 sekund</translation>
-    </message>
-    <message>
-        <source>System will restart in %1 seconds</source>
-        <translation>System uruchomi się ponownie za %1 sekund</translation>
-    </message>
-    <message>
-        <source>Shutdown</source>
-        <translation>Wyłącz</translation>
-    </message>
-    <message>
-        <source>Sign Out</source>
-        <translation>Wyloguj</translation>
-    </message>
-</context>
-<context>
-    <name>LabeledSwitch</name>
-    <message>
-        <source>On</source>
-        <translation>Wł.</translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation>Wył.</translation>
-    </message>
-</context>
-<context>
-    <name>Context</name>
-    <message>
-        <source>Up</source>
-        <translation>Góra</translation>
-    </message>
-    <message>
-        <source>Alt</source>
-        <translation>Alt</translation>
-    </message>
-    <message>
-        <source>End</source>
-        <translation>End</translation>
-    </message>
-    <message>
-        <source>Esc</source>
-        <translation>ESC</translation>
-    </message>
-    <message>
-        <source>Tab</source>
-        <translation>Tab</translation>
-    </message>
-    <message>
-        <source>Ctrl</source>
-        <translation>Crl</translation>
-    </message>
-    <message>
-        <source>Down</source>
-        <translation>Dół</translation>
-    </message>
-    <message>
-        <source>Home</source>
-        <translation>Home</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Lewa</translation>
-    </message>
-    <message>
-        <source>Enter</source>
-        <translation>Enter</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Prawa</translation>
-    </message>
-    <message>
-        <source>Shift</source>
-        <translation>Shift</translation>
-    </message>
-    <message>
-        <source>Space</source>
-        <translation>Space</translation>
-    </message>
-    <message>
-        <source>Delete</source>
-        <translation>Delete</translation>
-    </message>
-    <message>
-        <source>Insert</source>
-        <translation>Insert</translation>
-    </message>
-    <message>
-        <source>Page Up</source>
-        <translation>Page Up</translation>
-    </message>
-    <message>
-        <source>Backspace</source>
-        <translation>Backspace</translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation>Nieznany</translation>
-    </message>
-    <message>
-        <source>Page Down</source>
-        <translation>Page Down</translation>
-    </message>
-</context>
-<context>
     <name>AppHotkeysPane</name>
     <message>
         <source>Add</source>
@@ -203,199 +58,6 @@
     <message>
         <source>Add App Volume Hotkey</source>
         <translation>Dodaj Klawisz Skrótu Głośności Aplikacji</translation>
-    </message>
-</context>
-<context>
-    <name>CommAppsPane</name>
-    <message>
-        <source>Add</source>
-        <translation>Dodaj</translation>
-    </message>
-    <message>
-        <source>Add Communication App</source>
-        <translation>Dodaj aplikację do komunikacji</translation>
-    </message>
-    <message>
-        <source>Communication Applications</source>
-        <translation>Aplikacje Komunikacyjne</translation>
-    </message>
-    <message>
-        <source>The volume to set for non communication applications when ChatMix is enabled</source>
-        <translation>Ustawienie głośności dla aplikacji niekomunikacyjnych, gdy włączony jest ChatMix</translation>
-    </message>
-    <message>
-        <source>Enter application name (e.g., Discord)</source>
-        <translation>Wpisz nazwę aplikacji (np. Discord)</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Anuluj</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>Usuń</translation>
-    </message>
-    <message>
-        <source>Communication Apps</source>
-        <translation>Aplikacje Komunikacyjne</translation>
-    </message>
-    <message>
-        <source>Add App</source>
-        <translation>Dodaj Aplikację</translation>
-    </message>
-    <message>
-        <source>Activating ChatMix will initially set all non communication application volumes to 50%. This might cause loud audio output.</source>
-        <translation>Aktywacja ChatMix początkowo ustawi głośność wszystkich aplikacji niezwiązanych z komunikacją na 50%. Może to powodować głośny dźwięk.</translation>
-    </message>
-    <message>
-        <source>The volume to set for applications when ChatMix is disabled</source>
-        <translation>Głośność ustawiana dla aplikacji, gdy ChatMix jest wyłączony</translation>
-    </message>
-    <message>
-        <source>Activate ChatMix</source>
-        <translation>Aktywuj ChatMix</translation>
-    </message>
-    <message>
-        <source>ChatMix volume</source>
-        <translation>Głośność ChatMix</translation>
-    </message>
-    <message>
-        <source>Activate</source>
-        <translation>Aktywuj</translation>
-    </message>
-    <message>
-        <source>It is recommended to lower your master volume before proceeding to avoid sudden loud sounds.</source>
-        <translation>Przed kontynuowaniem zaleca się zmniejszenie głośności głównej, aby uniknąć nagłych, głośnych dźwięków.</translation>
-    </message>
-    <message>
-        <source>Discord</source>
-        <translation>Discord</translation>
-    </message>
-    <message>
-        <source>Enable ChatMix Warning</source>
-        <translation>Włącz Ostrzeżenia ChatMix</translation>
-    </message>
-    <message>
-        <source>Control communication apps separately from other applications</source>
-        <translation>Sterowanie aplikacjami komunikacyjnymi niezależnie od innych aplikacji</translation>
-    </message>
-    <message>
-        <source>Restored volume</source>
-        <translation>Przywrócona głośność</translation>
-    </message>
-    <message>
-        <source>Enable ChatMix</source>
-        <translation>Włącz ChatMix</translation>
-    </message>
-    <message>
-        <source>Add application names that should be treated as communication apps</source>
-        <translation>Dodaj nazwy aplikacji, które powinny być traktowane jako aplikacje komunikacyjne</translation>
-    </message>
-</context>
-<context>
-    <name>DebugPane</name>
-    <message>
-        <source>All</source>
-        <translation>Wszystko</translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation>Wyczyść</translation>
-    </message>
-    <message>
-        <source>Console output</source>
-        <translation>Wyjście konsoli</translation>
-    </message>
-    <message>
-        <source>Auto-scroll</source>
-        <translation>Auto-przewijanie</translation>
-    </message>
-    <message>
-        <source>QontrolPanel Log Export</source>
-        <translation>QontrolPanel Eksport Dziennika</translation>
-    </message>
-    <message>
-        <source>Copy All</source>
-        <translation>Kopiuj wszystko</translation>
-    </message>
-    <message>
-        <source>Filter by:</source>
-        <translation>Filtruj wg:</translation>
-    </message>
-</context>
-<context>
-    <name>MediaOverlayPane</name>
-    <message>
-        <source>Big</source>
-        <translation>Duży</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>Lewa</translation>
-    </message>
-    <message>
-        <source>Tiny</source>
-        <translation>Malutki</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>Prawa</translation>
-    </message>
-    <message>
-        <source>Enable media overlay</source>
-        <translation>Włącz nakładkę multimedialną</translation>
-    </message>
-    <message>
-        <source>Top Right</source>
-        <translation>Góra Prawa</translation>
-    </message>
-    <message>
-        <source>Top Center</source>
-        <translation>Góra Środek</translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation>Normalny</translation>
-    </message>
-    <message>
-        <source>Media Overlay</source>
-        <translation>Nakładka Multimedialna</translation>
-    </message>
-    <message>
-        <source>Choose where the media overlay appears on screen</source>
-        <translation>Wybierz, gdzie na ekranie ma się pojawiać nakładka multimediów</translation>
-    </message>
-    <message>
-        <source>Bottom Left</source>
-        <translation>Dół Lewa</translation>
-    </message>
-    <message>
-        <source>Top Left</source>
-        <translation>Góra Lewa</translation>
-    </message>
-    <message>
-        <source>Choose the size of the media overlay</source>
-        <translation>Wybierz rozmiar nakładki multimedialnej</translation>
-    </message>
-    <message>
-        <source>Show a notification overlay when the currently playing song changes</source>
-        <translation>Pokaż nakładkę powiadomienia, gdy zmieni się aktualnie odtwarzany utwór</translation>
-    </message>
-    <message>
-        <source>Bottom Right</source>
-        <translation>Dół Prawa</translation>
-    </message>
-    <message>
-        <source>Overlay size</source>
-        <translation>Rozmiar nakładki</translation>
-    </message>
-    <message>
-        <source>Bottom Center</source>
-        <translation>Dół Środek</translation>
-    </message>
-    <message>
-        <source>Overlay position</source>
-        <translation>Pozycja nakładki</translation>
     </message>
 </context>
 <context>
@@ -502,30 +164,492 @@
     </message>
 </context>
 <context>
-    <name>Updater</name>
+    <name>ApplicationsListView</name>
     <message>
-        <source>Update started.</source>
-        <translation>Aktualizacja uruchomiona.</translation>
+        <source>Lock</source>
+        <translation>Blokuj</translation>
     </message>
     <message>
-        <source>Update available: </source>
-        <translation>Dostępna aktualizacja: </translation>
+        <source>Save</source>
+        <translation>Zapisz</translation>
     </message>
     <message>
-        <source>You are using the latest version</source>
-        <translation>Używasz najnowszej wersji</translation>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
     </message>
     <message>
-        <source>Downloaded %1 of %2 translation files</source>
-        <translation>Pobrano %1 z %2 plików tłumaczeń</translation>
+        <source>Stream index: </source>
+        <translation>Indeks strumienia: </translation>
     </message>
     <message>
-        <source>No translation files to download</source>
-        <translation>Brak plików tłumaczeniowych do pobrania</translation>
+        <source>Unlock</source>
+        <translation>Odblokuj</translation>
     </message>
     <message>
-        <source>All translations downloaded successfully</source>
-        <translation>Wszystkie tłumaczenia zostały pobrane pomyślnie</translation>
+        <source>Original name: </source>
+        <translation>Oryginalna nazwa: </translation>
+    </message>
+    <message>
+        <source>Custom name:</source>
+        <translation>Nazwa własna:</translation>
+    </message>
+    <message>
+        <source>System sounds</source>
+        <translation>Dźwięki systemowe</translation>
+    </message>
+    <message>
+        <source>Reset to Original Name</source>
+        <translation>Resetuj do oryginalnej nazwy</translation>
+    </message>
+    <message>
+        <source>Rename Application</source>
+        <translation>Zmiana Nazwy Aplikacji</translation>
+    </message>
+</context>
+<context>
+    <name>AudioWorker</name>
+    <message>
+        <source>System sounds</source>
+        <translation>Dźwięki systemowe</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMixNotification</name>
+    <message>
+        <source>ChatMix Enabled</source>
+        <translation>ChatMix Włączono</translation>
+    </message>
+    <message>
+        <source>Microphone Unmuted</source>
+        <translation>Mikrofon Niewyciszony</translation>
+    </message>
+    <message>
+        <source>ChatMix Disabled</source>
+        <translation>Wyłączono ChatMix</translation>
+    </message>
+    <message>
+        <source>Microphone Muted</source>
+        <translation>Mikrofon Wyciszony</translation>
+    </message>
+</context>
+<context>
+    <name>CommAppsPane</name>
+    <message>
+        <source>Add</source>
+        <translation>Dodaj</translation>
+    </message>
+    <message>
+        <source>Add Communication App</source>
+        <translation>Dodaj aplikację do komunikacji</translation>
+    </message>
+    <message>
+        <source>Communication Applications</source>
+        <translation>Aplikacje Komunikacyjne</translation>
+    </message>
+    <message>
+        <source>The volume to set for non communication applications when ChatMix is enabled</source>
+        <translation>Ustawienie głośności dla aplikacji niekomunikacyjnych, gdy włączony jest ChatMix</translation>
+    </message>
+    <message>
+        <source>Enter application name (e.g., Discord)</source>
+        <translation>Wpisz nazwę aplikacji (np. Discord)</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Usuń</translation>
+    </message>
+    <message>
+        <source>Communication Apps</source>
+        <translation>Aplikacje Komunikacyjne</translation>
+    </message>
+    <message>
+        <source>Add App</source>
+        <translation>Dodaj Aplikację</translation>
+    </message>
+    <message>
+        <source>Activating ChatMix will initially set all non communication application volumes to 50%. This might cause loud audio output.</source>
+        <translation>Aktywacja ChatMix początkowo ustawi głośność wszystkich aplikacji niezwiązanych z komunikacją na 50%. Może to powodować głośny dźwięk.</translation>
+    </message>
+    <message>
+        <source>The volume to set for applications when ChatMix is disabled</source>
+        <translation>Głośność ustawiana dla aplikacji, gdy ChatMix jest wyłączony</translation>
+    </message>
+    <message>
+        <source>Activate ChatMix</source>
+        <translation>Aktywuj ChatMix</translation>
+    </message>
+    <message>
+        <source>ChatMix volume</source>
+        <translation>Głośność ChatMix</translation>
+    </message>
+    <message>
+        <source>Activate</source>
+        <translation>Aktywuj</translation>
+    </message>
+    <message>
+        <source>It is recommended to lower your master volume before proceeding to avoid sudden loud sounds.</source>
+        <translation>Przed kontynuowaniem zaleca się zmniejszenie głośności głównej, aby uniknąć nagłych, głośnych dźwięków.</translation>
+    </message>
+    <message>
+        <source>Discord</source>
+        <translation>Discord</translation>
+    </message>
+    <message>
+        <source>Enable ChatMix Warning</source>
+        <translation>Włącz Ostrzeżenia ChatMix</translation>
+    </message>
+    <message>
+        <source>Control communication apps separately from other applications</source>
+        <translation>Sterowanie aplikacjami komunikacyjnymi niezależnie od innych aplikacji</translation>
+    </message>
+    <message>
+        <source>Restored volume</source>
+        <translation>Przywrócona głośność</translation>
+    </message>
+    <message>
+        <source>Enable ChatMix</source>
+        <translation>Włącz ChatMix</translation>
+    </message>
+    <message>
+        <source>Add application names that should be treated as communication apps</source>
+        <translation>Dodaj nazwy aplikacji, które powinny być traktowane jako aplikacje komunikacyjne</translation>
+    </message>
+</context>
+<context>
+    <name>ComponentsPane</name>
+    <message>
+        <source>Show brightness control in panel</source>
+        <translation>Pokaż kontrolę jasności w panelu</translation>
+    </message>
+    <message>
+        <source>Enable audio device manager</source>
+        <translation>Włącz menedżera urządzeń audio</translation>
+    </message>
+    <message>
+        <source>Enable application volume mixer</source>
+        <translation>Włącz mikser głośności aplikacji</translation>
+    </message>
+    <message>
+        <source>Display currently playing media from Windows known sources</source>
+        <translation>Wyświetl aktualnie odtwarzane multimedia ze znanych źródeł Windows</translation>
+    </message>
+    <message>
+        <source>Enable HeadsetControl integration</source>
+        <translation>Włącz integrację Zestawu Słuchawkowego</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation>Komponenty</translation>
+    </message>
+    <message>
+        <source>Display application volume mixer in panel</source>
+        <translation>Wyświetl mikser głośności aplikacji w panelu</translation>
+    </message>
+    <message>
+        <source>Monitor battery using HeadsetControl for supported devices</source>
+        <translation>Monitoruj baterię używając Zestawu Słuchawkowego dla obsługiwanych urządzeń</translation>
+    </message>
+    <message>
+        <source>Enable brightness control</source>
+        <translation>Włącz kontrolę jasności</translation>
+    </message>
+    <message>
+        <source>Enable media session manager</source>
+        <translation>Włącz menedżera sesji multimedialnych</translation>
+    </message>
+    <message>
+        <source>Show power button in the panel footer</source>
+        <translation>Pokaż przycisk zasilania w stopce panelu</translation>
+    </message>
+    <message>
+        <source>Enable power menu</source>
+        <translation>Włącz menu zasilania</translation>
+    </message>
+    <message>
+        <source>Display audio device manager in panel</source>
+        <translation>Wyświetl menedżera urządzeń audio w panelu</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmPowerActionDialog</name>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>System will restart to UEFI in %1 seconds</source>
+        <translation>System uruchomi się ponownie do UEFI za %1 sekund</translation>
+    </message>
+    <message>
+        <source>Restart to UEFI</source>
+        <translation>Restartuj do UEFI</translation>
+    </message>
+    <message>
+        <source>Action</source>
+        <translation>Działanie</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <source>System will shutdown in %1 seconds</source>
+        <translation>System zostanie zamknięty za %1 sekund</translation>
+    </message>
+    <message>
+        <source>Hibernate</source>
+        <translation>Hibernuj</translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation>Restartuj</translation>
+    </message>
+    <message>
+        <source>System will hibernate in %1 seconds</source>
+        <translation>System przejdzie w stan hibernacji za %1 sekund</translation>
+    </message>
+    <message>
+        <source>You will be signed out in %1 seconds</source>
+        <translation>Zostaniesz wylogowany za %1 sekund</translation>
+    </message>
+    <message>
+        <source>System will restart in %1 seconds</source>
+        <translation>System uruchomi się ponownie za %1 sekund</translation>
+    </message>
+    <message>
+        <source>Shutdown</source>
+        <translation>Wyłącz</translation>
+    </message>
+    <message>
+        <source>Sign Out</source>
+        <translation>Wyloguj</translation>
+    </message>
+</context>
+<context>
+    <name>Context</name>
+    <message>
+        <source>Up</source>
+        <translation>Góra</translation>
+    </message>
+    <message>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <source>End</source>
+        <translation>End</translation>
+    </message>
+    <message>
+        <source>Esc</source>
+        <translation>ESC</translation>
+    </message>
+    <message>
+        <source>Tab</source>
+        <translation>Tab</translation>
+    </message>
+    <message>
+        <source>Ctrl</source>
+        <translation>Crl</translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation>Dół</translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation>Home</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>Lewa</translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation>Enter</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Prawa</translation>
+    </message>
+    <message>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation>Space</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Delete</translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation>Insert</translation>
+    </message>
+    <message>
+        <source>Page Up</source>
+        <translation>Page Up</translation>
+    </message>
+    <message>
+        <source>Backspace</source>
+        <translation>Backspace</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Nieznany</translation>
+    </message>
+    <message>
+        <source>Page Down</source>
+        <translation>Page Down</translation>
+    </message>
+</context>
+<context>
+    <name>DebugPane</name>
+    <message>
+        <source>All</source>
+        <translation>Wszystko</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation>Wyczyść</translation>
+    </message>
+    <message>
+        <source>Console output</source>
+        <translation>Wyjście konsoli</translation>
+    </message>
+    <message>
+        <source>Auto-scroll</source>
+        <translation>Auto-przewijanie</translation>
+    </message>
+    <message>
+        <source>QontrolPanel Log Export</source>
+        <translation>QontrolPanel Eksport Dziennika</translation>
+    </message>
+    <message>
+        <source>Copy All</source>
+        <translation>Kopiuj wszystko</translation>
+    </message>
+    <message>
+        <source>Filter by:</source>
+        <translation>Filtruj wg:</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceRenamingPane</name>
+    <message>
+        <source>Show:</source>
+        <translation>Pokaż:</translation>
+    </message>
+    <message>
+        <source>Custom name</source>
+        <translation>Nazwa własna</translation>
+    </message>
+    <message>
+        <source>Streams</source>
+        <translation>Strumienie</translation>
+    </message>
+    <message>
+        <source>Devices</source>
+        <translation>Urządzenia</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation>Zmiana nazwy</translation>
+    </message>
+    <message>
+        <source>Applications</source>
+        <translation>Aplikacje</translation>
+    </message>
+</context>
+<context>
+    <name>DevicesListView</name>
+    <message>
+        <source>Save</source>
+        <translation>Zapisz</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <source>Change Device Icon</source>
+        <translation>Zmień ikonę urządzenia</translation>
+    </message>
+    <message>
+        <source>Rename Device</source>
+        <translation>Zmiana Nazwy Urządzenia</translation>
+    </message>
+    <message>
+        <source>Reset to Original Name</source>
+        <translation>Resetuj Oryginalną Nazwę</translation>
+    </message>
+    <message>
+        <source>Change Icon</source>
+        <translation>Zmień Ikonę</translation>
+    </message>
+</context>
+<context>
+    <name>DonatePopup</name>
+    <message>
+        <source>This app is made with care by an independent developer and is not financed by ad revenue.
+If you&apos;d like to support my work, any contribution would be greatly appreciated!</source>
+        <translation>Ta aplikacja została stworzona z dbałością przez niezależnego dewelopera i nie jest finansowana z przychodów z reklam.
+Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widziana!</translation>
+    </message>
+    <message>
+        <source>Maybe later</source>
+        <translation>Może później</translation>
+    </message>
+    <message>
+        <source>Support</source>
+        <translation>Wsparcie</translation>
+    </message>
+    <message>
+        <source>Found this app useful?</source>
+        <translation>Czy ta aplikacja była przydatna?</translation>
+    </message>
+</context>
+<context>
+    <name>ExecutableRenameContextMenu</name>
+    <message>
+        <source>Mute in Background</source>
+        <translation>Wyciszenie w tle</translation>
+    </message>
+    <message>
+        <source>Reset to Original Name</source>
+        <translation>Zresetuj do oryginalnej nazwy</translation>
+    </message>
+    <message>
+        <source>Rename Application</source>
+        <translation>Zmień nazwę aplikacji</translation>
+    </message>
+</context>
+<context>
+    <name>ExecutableRenameDialog</name>
+    <message>
+        <source>Save</source>
+        <translation>Zapisz</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <source>Original name: </source>
+        <translation>Oryginalna nazwa: </translation>
+    </message>
+    <message>
+        <source>Custom name:</source>
+        <translation>Własna nazwa:</translation>
+    </message>
+    <message>
+        <source>Rename Application</source>
+        <translation>Zmiana Nazwy Aplikacji</translation>
     </message>
 </context>
 <context>
@@ -641,240 +765,6 @@
     <message>
         <source>Lightspeed</source>
         <translation>Prędkości światła</translation>
-    </message>
-</context>
-<context>
-    <name>SystemTray</name>
-    <message>
-        <source>Exit</source>
-        <translation>Wyjście</translation>
-    </message>
-    <message>
-        <source>Input: </source>
-        <translation>Wejście: </translation>
-    </message>
-    <message>
-        <source>Windows sound settings (Modern)</source>
-        <translation>Ustawienia dźwięku Windows (nowsze)</translation>
-    </message>
-    <message>
-        <source>Windows sound settings (Legacy)</source>
-        <translation>Ustawienia dźwięku Windows (starsze)</translation>
-    </message>
-    <message>
-        <source>HeadsetControl</source>
-        <translation>Zestaw Słuchawkowy</translation>
-    </message>
-    <message>
-        <source>ChatMix</source>
-        <translation>ChatMix</translation>
-    </message>
-    <message>
-        <source>Output: </source>
-        <translation>Wyjście: </translation>
-    </message>
-    <message>
-        <source>QontrolPanel settings</source>
-        <translation>Ustawienia QontrolPanel</translation>
-    </message>
-</context>
-<context>
-    <name>ApplicationsListView</name>
-    <message>
-        <source>Lock</source>
-        <translation>Blokuj</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>Zapisz</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Anuluj</translation>
-    </message>
-    <message>
-        <source>Stream index: </source>
-        <translation>Indeks strumienia: </translation>
-    </message>
-    <message>
-        <source>Unlock</source>
-        <translation>Odblokuj</translation>
-    </message>
-    <message>
-        <source>Original name: </source>
-        <translation>Oryginalna nazwa: </translation>
-    </message>
-    <message>
-        <source>Custom name:</source>
-        <translation>Nazwa własna:</translation>
-    </message>
-    <message>
-        <source>System sounds</source>
-        <translation>Dźwięki systemowe</translation>
-    </message>
-    <message>
-        <source>Reset to Original Name</source>
-        <translation>Resetuj do oryginalnej nazwy</translation>
-    </message>
-    <message>
-        <source>Rename Application</source>
-        <translation>Zmiana Nazwy Aplikacji</translation>
-    </message>
-</context>
-<context>
-    <name>PowerMenu</name>
-    <message>
-        <source>Lock</source>
-        <translation>Blokuj</translation>
-    </message>
-    <message>
-        <source>Sleep</source>
-        <translation>Uśpij</translation>
-    </message>
-    <message>
-        <source>Hibernate</source>
-        <translation>Hibernuj</translation>
-    </message>
-    <message>
-        <source>Restart</source>
-        <translation>Restartuj</translation>
-    </message>
-    <message>
-        <source>Switch User</source>
-        <translation>Zmień użytkownika</translation>
-    </message>
-    <message>
-        <source>Restart UEFI</source>
-        <translation>Restartuj UEFI</translation>
-    </message>
-    <message>
-        <source>Shutdown</source>
-        <translation>Wyłącz</translation>
-    </message>
-    <message>
-        <source>Sign Out</source>
-        <translation>Wyloguj się</translation>
-    </message>
-</context>
-<context>
-    <name>DevicesListView</name>
-    <message>
-        <source>Save</source>
-        <translation>Zapisz</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Anuluj</translation>
-    </message>
-    <message>
-        <source>Change Device Icon</source>
-        <translation>Zmień ikonę urządzenia</translation>
-    </message>
-    <message>
-        <source>Rename Device</source>
-        <translation>Zmiana Nazwy Urządzenia</translation>
-    </message>
-    <message>
-        <source>Reset to Original Name</source>
-        <translation>Resetuj Oryginalną Nazwę</translation>
-    </message>
-    <message>
-        <source>Change Icon</source>
-        <translation>Zmień Ikonę</translation>
-    </message>
-</context>
-<context>
-    <name>ExecutableRenameDialog</name>
-    <message>
-        <source>Save</source>
-        <translation>Zapisz</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Anuluj</translation>
-    </message>
-    <message>
-        <source>Original name: </source>
-        <translation>Oryginalna nazwa: </translation>
-    </message>
-    <message>
-        <source>Custom name:</source>
-        <translation>Własna nazwa:</translation>
-    </message>
-    <message>
-        <source>Rename Application</source>
-        <translation>Zmiana Nazwy Aplikacji</translation>
-    </message>
-</context>
-<context>
-    <name>UpdatePane</name>
-    <message>
-        <source>Show</source>
-        <translation>Pokaż</translation>
-    </message>
-    <message>
-        <source>Download and Install</source>
-        <translation>Pobieranie i instalacja</translation>
-    </message>
-    <message>
-        <source>Version %1 is available</source>
-        <translation>Dostępna %1 jest wersja</translation>
-    </message>
-    <message>
-        <source>Check for Updates</source>
-        <translation>Sprawdź aktualizacje</translation>
-    </message>
-    <message>
-        <source>Checking...</source>
-        <translation>Sprawdzanie...</translation>
-    </message>
-    <message>
-        <source>Build date</source>
-        <translation>Data kompilacji</translation>
-    </message>
-    <message>
-        <source>Commit</source>
-        <translation>Zatwierdzenie</translation>
-    </message>
-    <message>
-        <source>No release notes available</source>
-        <translation>Brak dostępnych informacji o wydaniu</translation>
-    </message>
-    <message>
-        <source>View what&apos;s new in version %1</source>
-        <translation>Zobacz nowości w wersji %1</translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation>Wersja %1</translation>
-    </message>
-    <message>
-        <source>Application version</source>
-        <translation>Wersja aplikacji</translation>
-    </message>
-    <message>
-        <source>Downloading...</source>
-        <translation>Pobieranie...</translation>
-    </message>
-    <message>
-        <source>Application Updates</source>
-        <translation>Aktualizacje Aplikacji</translation>
-    </message>
-    <message>
-        <source>QT version</source>
-        <translation>Wersja QT</translation>
-    </message>
-    <message>
-        <source>Auto check for app updates</source>
-        <translation>Automatycznie sprawdzaj aktualizacje aplikacji</translation>
-    </message>
-    <message>
-        <source>Check for application updates at startup and every 4 hours</source>
-        <translation>Sprawdzaj aktualizacje aplikacji przy uruchamianiu i co 4 godziny</translation>
-    </message>
-    <message>
-        <source>Release notes</source>
-        <translation>Informacje o wydaniu</translation>
     </message>
 </context>
 <context>
@@ -1035,228 +925,33 @@ Możesz ją włączyć w zakładce Komponenty.</translation>
     </message>
 </context>
 <context>
-    <name>ShortcutsPane</name>
+    <name>IntroWindow</name>
     <message>
-        <source>Apply</source>
-        <translation>Zastosuj</translation>
+        <source>Welcome to QontrolPanel!</source>
+        <translation>Witamy w QontrolPanel!</translation>
     </message>
     <message>
-        <source>Toggle Microphone Mute</source>
-        <translation>Przełącznik Wyciszenie Mikrofonu</translation>
+        <source>Automatic translations update</source>
+        <translation>Automatyczna aktualizacja tłumaczeń</translation>
     </message>
     <message>
-        <source>Show/Hide Panel</source>
-        <translation>Pokaż/Ukryj Panel</translation>
+        <source>Get Started</source>
+        <translation>Rozpocznij Uruchamianie</translation>
     </message>
     <message>
-        <source>Notification on ChatMix toggle</source>
-        <translation>Powiadomienie o przełączeniu ChatMix</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Anuluj</translation>
-    </message>
-    <message>
-        <source>Change</source>
-        <translation>Zmień</translation>
-    </message>
-    <message>
-        <source>Shortcut to mute/unmute microphone</source>
-        <translation>Skrót klawiaturowy do wyciszenia/włączenia mikrofonu</translation>
-    </message>
-    <message>
-        <source>Press the desired key combination</source>
-        <translation>Naciśnij żądaną kombinację klawiszy</translation>
-    </message>
-    <message>
-        <source>Set Microphone Mute Shortcut</source>
-        <translation>Ustaw Skrót Klawiaturowy Wyciszania Mikrofonu</translation>
-    </message>
-    <message>
-        <source>Set ChatMix Shortcut</source>
-        <translation>Ustaw Skrót Klawiaturowy ChatMix</translation>
-    </message>
-    <message>
-        <source>Toggle ChatMix</source>
-        <translation>Przełącznik ChatMix</translation>
-    </message>
-    <message>
-        <source>Shortcut to enable/disable ChatMix feature</source>
-        <translation>Skrót klawiaturowy do włączenia/wyłączenia funkcji ChatMix</translation>
-    </message>
-    <message>
-        <source>Enable global shortcuts</source>
-        <translation>Włącz globalne skróty klawiaturowe</translation>
-    </message>
-    <message>
-        <source>Allow QontrolPanel to respond to keyboard shortcuts globally</source>
-        <translation>Pozwól QontrolPanel globalnie reagować na skróty klawiaturowe</translation>
-    </message>
-    <message>
-        <source>Shortcut to toggle the main panel visibility</source>
-        <translation>Skrót klawiaturowy do przełączania widoczności panelu głównego</translation>
-    </message>
-    <message>
-        <source>Set Panel Shortcut</source>
-        <translation>Ustaw Skrót Klawiaturowy Panelu</translation>
-    </message>
-    <message>
-        <source>Global Shortcuts</source>
-        <translation>Globalne Skróty Klawiaturowe</translation>
+        <source>Automatic application update</source>
+        <translation>Automatyczna aktualizacja aplikacji</translation>
     </message>
 </context>
 <context>
-    <name>SettingsWindow</name>
+    <name>LabeledSwitch</name>
     <message>
-        <source>Debug</source>
-        <translation>Debugowanie</translation>
+        <source>On</source>
+        <translation>Wł.</translation>
     </message>
     <message>
-        <source>HeadsetControl</source>
-        <translation>Zestaw Słuchawkowy</translation>
-    </message>
-    <message>
-        <source>Media Overlay</source>
-        <translation>Nakładka Multimedialna</translation>
-    </message>
-    <message>
-        <source>Shortcuts</source>
-        <translation>Skróty Klawiaturowe</translation>
-    </message>
-    <message>
-        <source>Components</source>
-        <translation>Komponenty</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation>Język</translation>
-    </message>
-    <message>
-        <source>ChatMix</source>
-        <translation>ChatMix</translation>
-    </message>
-    <message>
-        <source>Appearance</source>
-        <translation>Wygląd</translation>
-    </message>
-    <message>
-        <source>Renaming</source>
-        <translation>Zmiana Nazwy</translation>
-    </message>
-    <message>
-        <source>Updates</source>
-        <translation>Aktualizacje</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Ogólne</translation>
-    </message>
-    <message>
-        <source>QontrolPanel - Settings</source>
-        <translation>QontrolPanel - Ustawienia</translation>
-    </message>
-</context>
-<context>
-    <name>DeviceRenamingPane</name>
-    <message>
-        <source>Show:</source>
-        <translation>Pokaż:</translation>
-    </message>
-    <message>
-        <source>Custom name</source>
-        <translation>Nazwa własna</translation>
-    </message>
-    <message>
-        <source>Streams</source>
-        <translation>Strumienie</translation>
-    </message>
-    <message>
-        <source>Devices</source>
-        <translation>Urządzenia</translation>
-    </message>
-    <message>
-        <source>Renaming</source>
-        <translation>Zmiana nazwy</translation>
-    </message>
-    <message>
-        <source>Applications</source>
-        <translation>Aplikacje</translation>
-    </message>
-</context>
-<context>
-    <name>DonatePopup</name>
-    <message>
-        <source>This app is made with care by an independent developer and is not financed by ad revenue.
-If you&apos;d like to support my work, any contribution would be greatly appreciated!</source>
-        <translation>Ta aplikacja została stworzona z dbałością przez niezależnego dewelopera i nie jest finansowana z przychodów z reklam.
-Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widziana!</translation>
-    </message>
-    <message>
-        <source>Maybe later</source>
-        <translation>Może później</translation>
-    </message>
-    <message>
-        <source>Support</source>
-        <translation>Wsparcie</translation>
-    </message>
-    <message>
-        <source>Found this app useful?</source>
-        <translation>Czy ta aplikacja była przydatna?</translation>
-    </message>
-</context>
-<context>
-    <name>ComponentsPane</name>
-    <message>
-        <source>Show brightness control in panel</source>
-        <translation>Pokaż kontrolę jasności w panelu</translation>
-    </message>
-    <message>
-        <source>Enable audio device manager</source>
-        <translation>Włącz menedżera urządzeń audio</translation>
-    </message>
-    <message>
-        <source>Enable application volume mixer</source>
-        <translation>Włącz mikser głośności aplikacji</translation>
-    </message>
-    <message>
-        <source>Display currently playing media from Windows known sources</source>
-        <translation>Wyświetl aktualnie odtwarzane multimedia ze znanych źródeł Windows</translation>
-    </message>
-    <message>
-        <source>Enable HeadsetControl integration</source>
-        <translation>Włącz integrację Zestawu Słuchawkowego</translation>
-    </message>
-    <message>
-        <source>Components</source>
-        <translation>Komponenty</translation>
-    </message>
-    <message>
-        <source>Display application volume mixer in panel</source>
-        <translation>Wyświetl mikser głośności aplikacji w panelu</translation>
-    </message>
-    <message>
-        <source>Monitor battery using HeadsetControl for supported devices</source>
-        <translation>Monitoruj baterię używając Zestawu Słuchawkowego dla obsługiwanych urządzeń</translation>
-    </message>
-    <message>
-        <source>Enable brightness control</source>
-        <translation>Włącz kontrolę jasności</translation>
-    </message>
-    <message>
-        <source>Enable media session manager</source>
-        <translation>Włącz menedżera sesji multimedialnych</translation>
-    </message>
-    <message>
-        <source>Show power button in the panel footer</source>
-        <translation>Pokaż przycisk zasilania w stopce panelu</translation>
-    </message>
-    <message>
-        <source>Enable power menu</source>
-        <translation>Włącz menu zasilania</translation>
-    </message>
-    <message>
-        <source>Display audio device manager in panel</source>
-        <translation>Wyświetl menedżera urządzeń audio w panelu</translation>
+        <source>Off</source>
+        <translation>Wył.</translation>
     </message>
 </context>
 <context>
@@ -1335,48 +1030,10 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
     </message>
 </context>
 <context>
-    <name>IntroWindow</name>
+    <name>LogBridge</name>
     <message>
-        <source>Welcome to QontrolPanel!</source>
-        <translation>Witamy w QontrolPanel!</translation>
-    </message>
-    <message>
-        <source>Automatic translations update</source>
-        <translation>Automatyczna aktualizacja tłumaczeń</translation>
-    </message>
-    <message>
-        <source>Get Started</source>
-        <translation>Rozpocznij Uruchamianie</translation>
-    </message>
-    <message>
-        <source>Automatic application update</source>
-        <translation>Automatyczna aktualizacja aplikacji</translation>
-    </message>
-</context>
-<context>
-    <name>ChatMixNotification</name>
-    <message>
-        <source>ChatMix Enabled</source>
-        <translation>ChatMix Włączono</translation>
-    </message>
-    <message>
-        <source>Microphone Unmuted</source>
-        <translation>Mikrofon Niewyciszony</translation>
-    </message>
-    <message>
-        <source>ChatMix Disabled</source>
-        <translation>Wyłączono ChatMix</translation>
-    </message>
-    <message>
-        <source>Microphone Muted</source>
-        <translation>Mikrofon Wyciszony</translation>
-    </message>
-</context>
-<context>
-    <name>MediaOverlay</name>
-    <message>
-        <source>No media playing</source>
-        <translation>Brak odtwarzania multimediów</translation>
+        <source>Unknown</source>
+        <translation>Nieznany</translation>
     </message>
 </context>
 <context>
@@ -1411,32 +1068,85 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
     </message>
 </context>
 <context>
-    <name>ExecutableRenameContextMenu</name>
+    <name>MediaOverlay</name>
     <message>
-        <source>Mute in Background</source>
-        <translation>Wyciszenie w tle</translation>
-    </message>
-    <message>
-        <source>Reset to Original Name</source>
-        <translation>Zresetuj do oryginalnej nazwy</translation>
-    </message>
-    <message>
-        <source>Rename Application</source>
-        <translation>Zmień nazwę aplikacji</translation>
+        <source>No media playing</source>
+        <translation>Brak odtwarzania multimediów</translation>
     </message>
 </context>
 <context>
-    <name>LogBridge</name>
+    <name>MediaOverlayPane</name>
     <message>
-        <source>Unknown</source>
-        <translation>Nieznany</translation>
+        <source>Big</source>
+        <translation>Duży</translation>
     </message>
-</context>
-<context>
-    <name>AudioWorker</name>
     <message>
-        <source>System sounds</source>
-        <translation>Dźwięki systemowe</translation>
+        <source>Left</source>
+        <translation>Lewa</translation>
+    </message>
+    <message>
+        <source>Tiny</source>
+        <translation>Malutki</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Prawa</translation>
+    </message>
+    <message>
+        <source>Enable media overlay</source>
+        <translation>Włącz nakładkę multimedialną</translation>
+    </message>
+    <message>
+        <source>Top Right</source>
+        <translation>Góra Prawa</translation>
+    </message>
+    <message>
+        <source>Top Center</source>
+        <translation>Góra Środek</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normalny</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation>Nakładka Multimedialna</translation>
+    </message>
+    <message>
+        <source>Choose where the media overlay appears on screen</source>
+        <translation>Wybierz, gdzie na ekranie ma się pojawiać nakładka multimediów</translation>
+    </message>
+    <message>
+        <source>Bottom Left</source>
+        <translation>Dół Lewa</translation>
+    </message>
+    <message>
+        <source>Top Left</source>
+        <translation>Góra Lewa</translation>
+    </message>
+    <message>
+        <source>Choose the size of the media overlay</source>
+        <translation>Wybierz rozmiar nakładki multimedialnej</translation>
+    </message>
+    <message>
+        <source>Show a notification overlay when the currently playing song changes</source>
+        <translation>Pokaż nakładkę powiadomienia, gdy zmieni się aktualnie odtwarzany utwór</translation>
+    </message>
+    <message>
+        <source>Bottom Right</source>
+        <translation>Dół Prawa</translation>
+    </message>
+    <message>
+        <source>Overlay size</source>
+        <translation>Rozmiar nakładki</translation>
+    </message>
+    <message>
+        <source>Bottom Center</source>
+        <translation>Dół Środek</translation>
+    </message>
+    <message>
+        <source>Overlay position</source>
+        <translation>Pozycja nakładki</translation>
     </message>
 </context>
 <context>
@@ -1444,6 +1154,360 @@ Jeśli chcesz wesprzeć moją pracę, każda wpłata będzie bardzo mile widzian
     <message>
         <source>Update available</source>
         <translation>Dostępna aktualizacja</translation>
+    </message>
+</context>
+<context>
+    <name>PowerMenu</name>
+    <message>
+        <source>Lock</source>
+        <translation>Blokuj</translation>
+    </message>
+    <message>
+        <source>Sleep</source>
+        <translation>Uśpij</translation>
+    </message>
+    <message>
+        <source>Hibernate</source>
+        <translation>Hibernuj</translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation>Restartuj</translation>
+    </message>
+    <message>
+        <source>Switch User</source>
+        <translation>Zmień użytkownika</translation>
+    </message>
+    <message>
+        <source>Restart UEFI</source>
+        <translation>Restartuj UEFI</translation>
+    </message>
+    <message>
+        <source>Shutdown</source>
+        <translation>Wyłącz</translation>
+    </message>
+    <message>
+        <source>Sign Out</source>
+        <translation>Wyloguj się</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>Debug</source>
+        <translation>Debugowanie</translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation>Zestaw Słuchawkowy</translation>
+    </message>
+    <message>
+        <source>Media Overlay</source>
+        <translation>Nakładka Multimedialna</translation>
+    </message>
+    <message>
+        <source>Shortcuts</source>
+        <translation>Skróty Klawiaturowe</translation>
+    </message>
+    <message>
+        <source>Components</source>
+        <translation>Komponenty</translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation>Język</translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation>ChatMix</translation>
+    </message>
+    <message>
+        <source>You just lost the game</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Too bad</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>Wygląd</translation>
+    </message>
+    <message>
+        <source>App Hotkeys</source>
+        <translation type="unfinished">Skróty Klawiaturowe Aplikacji</translation>
+    </message>
+    <message>
+        <source>Renaming</source>
+        <translation>Zmiana Nazwy</translation>
+    </message>
+    <message>
+        <source>Updates</source>
+        <translation>Aktualizacje</translation>
+    </message>
+    <message>
+        <source>Donate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Ogólne</translation>
+    </message>
+    <message>
+        <source>QontrolPanel - Settings</source>
+        <translation>QontrolPanel - Ustawienia</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutsPane</name>
+    <message>
+        <source>Apply</source>
+        <translation>Zastosuj</translation>
+    </message>
+    <message>
+        <source>Toggle Microphone Mute</source>
+        <translation>Przełącznik Wyciszenie Mikrofonu</translation>
+    </message>
+    <message>
+        <source>Show/Hide Panel</source>
+        <translation>Pokaż/Ukryj Panel</translation>
+    </message>
+    <message>
+        <source>Notification on ChatMix toggle</source>
+        <translation>Powiadomienie o przełączeniu ChatMix</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <source>Change</source>
+        <translation>Zmień</translation>
+    </message>
+    <message>
+        <source>Shortcut to mute/unmute microphone</source>
+        <translation>Skrót klawiaturowy do wyciszenia/włączenia mikrofonu</translation>
+    </message>
+    <message>
+        <source>Press the desired key combination</source>
+        <translation>Naciśnij żądaną kombinację klawiszy</translation>
+    </message>
+    <message>
+        <source>Set Microphone Mute Shortcut</source>
+        <translation>Ustaw Skrót Klawiaturowy Wyciszania Mikrofonu</translation>
+    </message>
+    <message>
+        <source>Set ChatMix Shortcut</source>
+        <translation>Ustaw Skrót Klawiaturowy ChatMix</translation>
+    </message>
+    <message>
+        <source>Toggle ChatMix</source>
+        <translation>Przełącznik ChatMix</translation>
+    </message>
+    <message>
+        <source>Shortcut to enable/disable ChatMix feature</source>
+        <translation>Skrót klawiaturowy do włączenia/wyłączenia funkcji ChatMix</translation>
+    </message>
+    <message>
+        <source>Enable global shortcuts</source>
+        <translation>Włącz globalne skróty klawiaturowe</translation>
+    </message>
+    <message>
+        <source>Allow QontrolPanel to respond to keyboard shortcuts globally</source>
+        <translation>Pozwól QontrolPanel globalnie reagować na skróty klawiaturowe</translation>
+    </message>
+    <message>
+        <source>Shortcut to toggle the main panel visibility</source>
+        <translation>Skrót klawiaturowy do przełączania widoczności panelu głównego</translation>
+    </message>
+    <message>
+        <source>Set Panel Shortcut</source>
+        <translation>Ustaw Skrót Klawiaturowy Panelu</translation>
+    </message>
+    <message>
+        <source>Global Shortcuts</source>
+        <translation>Globalne Skróty Klawiaturowe</translation>
+    </message>
+</context>
+<context>
+    <name>SystemTray</name>
+    <message>
+        <source>Exit</source>
+        <translation>Wyjście</translation>
+    </message>
+    <message>
+        <source>Input: </source>
+        <translation>Wejście: </translation>
+    </message>
+    <message>
+        <source>Windows sound settings (Modern)</source>
+        <translation>Ustawienia dźwięku Windows (nowsze)</translation>
+    </message>
+    <message>
+        <source>Windows sound settings (Legacy)</source>
+        <translation>Ustawienia dźwięku Windows (starsze)</translation>
+    </message>
+    <message>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HeadsetControl</source>
+        <translation>Zestaw Słuchawkowy</translation>
+    </message>
+    <message>
+        <source>Fetch</source>
+        <translation type="unfinished">Wydobycie</translation>
+    </message>
+    <message>
+        <source>Equalizer Preset</source>
+        <translation type="unfinished">Predefiniowane Korektora</translation>
+    </message>
+    <message>
+        <source>Lights</source>
+        <translation type="unfinished">Jasność</translation>
+    </message>
+    <message>
+        <source>Voice Prompts</source>
+        <translation type="unfinished">Podpowiedzi głosowe</translation>
+    </message>
+    <message>
+        <source>Rotate-to-Mute</source>
+        <translation type="unfinished">Obrót-do-wyciszenia</translation>
+    </message>
+    <message>
+        <source>Unknown Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>QontrolPanel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Device disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ChatMix</source>
+        <translation>ChatMix</translation>
+    </message>
+    <message>
+        <source>Output: </source>
+        <translation>Wyjście: </translation>
+    </message>
+    <message>
+        <source>QontrolPanel settings</source>
+        <translation>Ustawienia QontrolPanel</translation>
+    </message>
+</context>
+<context>
+    <name>UpdatePane</name>
+    <message>
+        <source>Show</source>
+        <translation>Pokaż</translation>
+    </message>
+    <message>
+        <source>Download and Install</source>
+        <translation>Pobieranie i instalacja</translation>
+    </message>
+    <message>
+        <source>Updates and information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1 is available</source>
+        <translation>Dostępna %1 jest wersja</translation>
+    </message>
+    <message>
+        <source>Check for Updates</source>
+        <translation>Sprawdź aktualizacje</translation>
+    </message>
+    <message>
+        <source>Checking...</source>
+        <translation>Sprawdzanie...</translation>
+    </message>
+    <message>
+        <source>Build date</source>
+        <translation>Data kompilacji</translation>
+    </message>
+    <message>
+        <source>Commit</source>
+        <translation>Zatwierdzenie</translation>
+    </message>
+    <message>
+        <source>GitHub repository</source>
+        <translation type="unfinished">GitHub repository</translation>
+    </message>
+    <message>
+        <source>View on GitHub</source>
+        <translation type="unfinished">Zobacz w GitHubie</translation>
+    </message>
+    <message>
+        <source>No release notes available</source>
+        <translation>Brak dostępnych informacji o wydaniu</translation>
+    </message>
+    <message>
+        <source>View what&apos;s new in version %1</source>
+        <translation>Zobacz nowości w wersji %1</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation>Wersja %1</translation>
+    </message>
+    <message>
+        <source>Application version</source>
+        <translation>Wersja aplikacji</translation>
+    </message>
+    <message>
+        <source>Downloading...</source>
+        <translation>Pobieranie...</translation>
+    </message>
+    <message>
+        <source>Application Updates</source>
+        <translation>Aktualizacje Aplikacji</translation>
+    </message>
+    <message>
+        <source>QT version</source>
+        <translation>Wersja QT</translation>
+    </message>
+    <message>
+        <source>Auto check for app updates</source>
+        <translation>Automatycznie sprawdzaj aktualizacje aplikacji</translation>
+    </message>
+    <message>
+        <source>Check for application updates at startup and every 4 hours</source>
+        <translation>Sprawdzaj aktualizacje aplikacji przy uruchamianiu i co 4 godziny</translation>
+    </message>
+    <message>
+        <source>Release notes</source>
+        <translation>Informacje o wydaniu</translation>
+    </message>
+</context>
+<context>
+    <name>Updater</name>
+    <message>
+        <source>Update started.</source>
+        <translation>Aktualizacja uruchomiona.</translation>
+    </message>
+    <message>
+        <source>Update available: </source>
+        <translation>Dostępna aktualizacja: </translation>
+    </message>
+    <message>
+        <source>You are using the latest version</source>
+        <translation>Używasz najnowszej wersji</translation>
+    </message>
+    <message>
+        <source>Downloaded %1 of %2 translation files</source>
+        <translation>Pobrano %1 z %2 plików tłumaczeń</translation>
+    </message>
+    <message>
+        <source>No translation files to download</source>
+        <translation>Brak plików tłumaczeniowych do pobrania</translation>
+    </message>
+    <message>
+        <source>All translations downloaded successfully</source>
+        <translation>Wszystkie tłumaczenia zostały pobrane pomyślnie</translation>
     </message>
 </context>
 </TS>

--- a/i18n_compiled/translation_progress.json
+++ b/i18n_compiled/translation_progress.json
@@ -1,7 +1,7 @@
 {
   "en": {
     "percentage": 100,
-    "last_updated": "2026-05-17 09:27:26",
+    "last_updated": "2026-05-17 09:31:43",
     "contributor": "ChrisLauinger77"
   },
   "ja": {

--- a/include/audiomanager.h
+++ b/include/audiomanager.h
@@ -6,6 +6,8 @@
 #include <QIcon>
 #include <QMap>
 #include <QAbstractListModel>
+#include <array>
+#include <optional>
 #include <windows.h>
 #include <mmdeviceapi.h>
 #include <endpointvolume.h>
@@ -411,4 +413,16 @@ private:
     bool m_cachedInputMute;
     QList<AudioApplication> m_cachedApplications;
     QList<AudioDevice> m_cachedDevices;
+
+    struct PendingDefaultDeviceSwitch {
+        QString deviceId;
+        bool isInput = false;
+        bool forCommunications = false;
+    };
+
+    void processPendingDefaultDeviceSwitches();
+
+    mutable QMutex m_pendingDefaultDeviceMutex;
+    std::array<std::optional<PendingDefaultDeviceSwitch>, 4> m_pendingDefaultDeviceSwitches;
+    bool m_defaultDeviceSwitchDispatchQueued = false;
 };

--- a/include/audiomanager.h
+++ b/include/audiomanager.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <QObject>
-#include <QThread>
 #include <QMutex>
 #include <QIcon>
 #include <QMap>
 #include <QAbstractListModel>
+#include <QThread>
 #include <array>
 #include <optional>
 #include <windows.h>
@@ -226,6 +226,7 @@ private:
 
     QTimer* m_audioLevelTimer;
     QList<AudioApplication> m_cachedApplications;
+    QList<HeadsetControlDevice> m_cachedHeadsetDevices;
 
     int getDeviceAudioLevel(EDataFlow dataFlow);
 
@@ -240,6 +241,7 @@ private:
     void updateDevicesBatteryInfo(const QList<HeadsetControlDevice>& headsetDevices);
 
     HeadsetControlMonitor* m_headsetControlMonitor;
+    QThread* m_headsetControlThread;
 };
 
 // Device change notification callback

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -53,6 +53,7 @@ public:
 public slots:
     void startMonitoring();
     void stopMonitoring();
+    void requestRefresh();
     void setLights(bool enabled);
     void setRotateToMute(bool enabled);
     void setVoicePrompts(bool enabled);

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -81,6 +81,7 @@ private slots:
 
 private:
     void applyTestDeviceConfiguration();
+    void updateFetchTimerInterval(bool deviceFound);
     void updateDeviceCache();
     void updateCapabilities();
     QString batteryStatusToString(battery_status status) const;

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -442,13 +442,19 @@ AudioWorker::AudioWorker()
     , m_audioLevelTimer(nullptr)
     , m_sessionManagerInvalid(false)
     , m_headsetControlMonitor(nullptr)
+    , m_headsetControlThread(nullptr)
 {
     qRegisterMetaType<AudioApplication>("AudioApplication");
     qRegisterMetaType<QList<AudioApplication>>("QList<AudioApplication>");
     qRegisterMetaType<AudioDevice>("AudioDevice");
     qRegisterMetaType<QList<AudioDevice>>("QList<AudioDevice>");
+    qRegisterMetaType<HeadsetControlDevice>("HeadsetControlDevice");
+    qRegisterMetaType<QList<HeadsetControlDevice>>("QList<HeadsetControlDevice>");
 
-    m_headsetControlMonitor = new HeadsetControlMonitor(this);
+    m_headsetControlMonitor = new HeadsetControlMonitor();
+    m_headsetControlThread = new QThread(this);
+    m_headsetControlMonitor->moveToThread(m_headsetControlThread);
+    m_headsetControlThread->start();
     connect(m_headsetControlMonitor, &HeadsetControlMonitor::headsetDataUpdated,
             this, &AudioWorker::onHeadsetDataUpdated);
 }
@@ -519,6 +525,10 @@ void AudioWorker::initialize()
 
 void AudioWorker::cleanup()
 {
+    if (m_headsetControlMonitor) {
+        QMetaObject::invokeMethod(m_headsetControlMonitor, "stopMonitoring", Qt::QueuedConnection);
+    }
+
     if (m_audioLevelTimer) {
         m_audioLevelTimer->stop();
         delete m_audioLevelTimer;
@@ -612,12 +622,38 @@ void AudioWorker::cleanup()
         m_deviceEnumerator = nullptr;
     }
 
+    if (m_headsetControlMonitor) {
+        QMetaObject::invokeMethod(m_headsetControlMonitor, "deleteLater", Qt::QueuedConnection);
+        m_headsetControlMonitor = nullptr;
+    }
+
+    if (m_headsetControlThread) {
+        m_headsetControlThread->quit();
+        bool headsetThreadStopped = m_headsetControlThread->wait(3000);
+        if (!headsetThreadStopped) {
+            LOG_WARN("AudioManager", "HeadsetControl thread did not finish gracefully, terminating...");
+            m_headsetControlThread->terminate();
+            headsetThreadStopped = m_headsetControlThread->wait();
+        }
+
+        if (!headsetThreadStopped) {
+            LOG_CRITICAL("AudioManager",
+                         "HeadsetControl thread failed to stop; refusing to continue cleanup to avoid deleting a running QThread");
+            return;
+        }
+
+        m_headsetControlThread = nullptr;
+    }
+
+    m_cachedHeadsetDevices.clear();
+
     CoUninitialize();
 }
 
 void AudioWorker::onHeadsetDataUpdated(const QList<HeadsetControlDevice>& headsetDevices)
 {
-    updateDevicesBatteryInfo(headsetDevices);
+    m_cachedHeadsetDevices = headsetDevices;
+    updateDevicesBatteryInfo(m_cachedHeadsetDevices);
     emit devicesChanged(m_devices);
 }
 
@@ -997,15 +1033,7 @@ void AudioWorker::enumerateDevices()
     m_devices = newDevices;
 
 
-    if (m_headsetControlMonitor && m_headsetControlMonitor->isMonitoring()) {
-        QList<HeadsetControlDevice> cachedDevices = m_headsetControlMonitor->getCachedDevices();
-        if (!cachedDevices.isEmpty()) {
-            updateDevicesBatteryInfo(cachedDevices);
-        }
-    } else if (m_headsetControlMonitor) {
-        // If monitoring is stopped, clear any headset battery info
-        updateDevicesBatteryInfo(QList<HeadsetControlDevice>());
-    }
+    updateDevicesBatteryInfo(m_cachedHeadsetDevices);
 
     emit devicesChanged(m_devices);
 }

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -1897,6 +1897,12 @@ void AudioManager::cleanup()
 {
     QMutexLocker locker(&m_mutex);
 
+    {
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        m_pendingDefaultDeviceSwitches.fill(std::nullopt);
+        m_defaultDeviceSwitchDispatchQueued = false;
+    }
+
     if (!m_workerThread) return;
 
     if (m_worker) {

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -9,6 +9,7 @@
 #include <QPainter>
 #include <QTimer>
 #include <QRegularExpression>
+#include <algorithm>
 #include <atlbase.h>
 #include <psapi.h>
 #include <Shlobj.h>
@@ -1754,9 +1755,22 @@ void AudioWorker::setDefaultDevice(const QString& deviceId, bool isInput, bool f
 void AudioWorker::setVolumeForDevice(EDataFlow dataFlow, int volume)
 {
     IAudioEndpointVolume* volumeControl = (dataFlow == eRender) ? m_outputVolumeControl : m_inputVolumeControl;
-    if (volumeControl) {
-        float volumeScalar = static_cast<float>(volume) / 100.0f;
-        volumeControl->SetMasterVolumeLevelScalar(volumeScalar, nullptr);
+    if (!volumeControl) {
+        LOG_WARN("AudioManager",
+                 QString("No %1 endpoint volume control available")
+                     .arg(dataFlow == eRender ? "output" : "input"));
+        return;
+    }
+
+    const int clampedVolume = std::clamp(volume, 0, 100);
+    const float volumeScalar = static_cast<float>(clampedVolume) / 100.0f;
+    const HRESULT hr = volumeControl->SetMasterVolumeLevelScalar(volumeScalar, nullptr);
+    if (!SUCCEEDED(hr)) {
+        LOG_CRITICAL("AudioManager",
+                     QString("Failed to set %1 volume to %2, HRESULT: %3")
+                         .arg(dataFlow == eRender ? "output" : "input")
+                         .arg(clampedVolume)
+                         .arg(QString::number(hr, 16)));
     }
 }
 

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -1002,10 +1002,6 @@ void AudioWorker::enumerateDevices()
         if (!cachedDevices.isEmpty()) {
             updateDevicesBatteryInfo(cachedDevices);
         }
-        // Trigger a fresh fetch
-        QMetaObject::invokeMethod(m_headsetControlMonitor,
-                                  "fetchHeadsetInfo",
-                                  Qt::QueuedConnection);
     } else if (m_headsetControlMonitor) {
         // If monitoring is stopped, clear any headset battery info
         updateDevicesBatteryInfo(QList<HeadsetControlDevice>());

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -1999,18 +1999,93 @@ void AudioManager::setApplicationMuteAsync(const QString& appId, bool mute)
 
 void AudioManager::setDefaultDeviceAsync(const QString& deviceId, bool isInput, bool forCommunications)
 {
-    if (m_worker) {
-        const bool invokeOk = QMetaObject::invokeMethod(m_worker, [this, deviceId, isInput, forCommunications]() {
-            if (m_worker) {
-                m_worker->setDefaultDevice(deviceId, isInput, forCommunications);
-            }
-        }, Qt::QueuedConnection);
+    if (!m_worker) {
+        return;
+    }
+
+    bool shouldQueueDispatcher = false;
+    {
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        const int requestIndex = (isInput ? 2 : 0) + (forCommunications ? 1 : 0);
+        m_pendingDefaultDeviceSwitches[requestIndex] = PendingDefaultDeviceSwitch{deviceId, isInput, forCommunications};
+        if (!m_defaultDeviceSwitchDispatchQueued) {
+            m_defaultDeviceSwitchDispatchQueued = true;
+            shouldQueueDispatcher = true;
+        }
+    }
+
+    if (!shouldQueueDispatcher) {
+        return;
+    }
+
+    const bool invokeOk = QMetaObject::invokeMethod(this, &AudioManager::processPendingDefaultDeviceSwitches, Qt::QueuedConnection);
+    if (!invokeOk) {
+        LOG_CRITICAL("AudioManager",
+                     QString("Failed to queue setDefaultDevice dispatcher for %1 device")
+                         .arg(isInput ? "input" : "output"));
+
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        m_defaultDeviceSwitchDispatchQueued = false;
+    }
+}
+
+void AudioManager::processPendingDefaultDeviceSwitches()
+{
+    std::array<std::optional<PendingDefaultDeviceSwitch>, 4> switchesToProcess;
+    {
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        switchesToProcess = m_pendingDefaultDeviceSwitches;
+        m_pendingDefaultDeviceSwitches.fill(std::nullopt);
+        m_defaultDeviceSwitchDispatchQueued = false;
+    }
+
+    if (!m_worker) {
+        return;
+    }
+
+    bool hadQueuedRequest = false;
+    for (const auto& pendingSwitch : switchesToProcess) {
+        if (!pendingSwitch.has_value()) {
+            continue;
+        }
+
+        hadQueuedRequest = true;
+        const PendingDefaultDeviceSwitch request = *pendingSwitch;
+        const bool invokeOk = QMetaObject::invokeMethod(
+            m_worker,
+            [worker = m_worker, request]() {
+                if (worker) {
+                    worker->setDefaultDevice(request.deviceId, request.isInput, request.forCommunications);
+                }
+            },
+            Qt::QueuedConnection);
 
         if (!invokeOk) {
             LOG_CRITICAL("AudioManager",
-                         QString("Failed to queue setDefaultDevice call for %1 device")
-                             .arg(isInput ? "input" : "output"));
+                         QString("Failed to queue setDefaultDevice execution for %1 device communicationsRole=%2")
+                             .arg(request.isInput ? "input" : "output")
+                             .arg(request.forCommunications ? "true" : "false"));
         }
+    }
+
+    if (!hadQueuedRequest) {
+        return;
+    }
+
+    bool needsAnotherPass = false;
+    {
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        for (const auto& pendingSwitch : m_pendingDefaultDeviceSwitches) {
+            if (pendingSwitch.has_value() && !m_defaultDeviceSwitchDispatchQueued) {
+                m_defaultDeviceSwitchDispatchQueued = true;
+                needsAnotherPass = true;
+                break;
+            }
+        }
+    }
+
+    if (needsAnotherPass) {
+        QMetaObject::invokeMethod(this, &AudioManager::processPendingDefaultDeviceSwitches, Qt::QueuedConnection);
     }
 }
 

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -177,7 +177,7 @@ void HeadsetControlBridge::refreshNow()
 {
     HeadsetControlMonitor* monitor = findMonitor();
     if (monitor) {
-        QMetaObject::invokeMethod(monitor, "fetchHeadsetInfo", Qt::QueuedConnection);
+        QMetaObject::invokeMethod(monitor, "requestRefresh", Qt::QueuedConnection);
     }
 }
 

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -2,6 +2,10 @@
 #include "logmanager.h"
 #include "usersettings.h"
 
+namespace {
+constexpr int kDisconnectedFetchIntervalMs = 60000;
+}
+
 HeadsetControlMonitor::HeadsetControlMonitor(QObject *parent)
     : QObject(parent)
     , m_fetchTimer(new QTimer(this))
@@ -341,9 +345,12 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
                 emit anyDeviceFoundChanged();
             }
             emit headsetDataUpdated(m_cachedDevices);
+            updateFetchTimerInterval(false);
             m_isFetching = false;
             return;
         }
+
+        updateFetchTimerInterval(true);
 
         LOG_INFO("HeadsetControlManager",
                                         QString("Found %1 headset device(s)").arg(m_headsets.size()));
@@ -604,10 +611,21 @@ QStringList HeadsetControlMonitor::getCapabilityList(const headsetcontrol::Heads
 void HeadsetControlMonitor::setFetchInterval(int intervalMs)
 {
     m_fetchIntervalMs = intervalMs;
-    m_fetchTimer->setInterval(m_fetchIntervalMs);
+    updateFetchTimerInterval(m_anyDeviceFound);
 
     LOG_INFO("HeadsetControlManager",
                                     QString("Fetch interval updated to %1ms").arg(m_fetchIntervalMs));
+}
+
+void HeadsetControlMonitor::updateFetchTimerInterval(bool deviceFound)
+{
+    const int effectiveInterval = deviceFound || m_testModeEnabled
+        ? m_fetchIntervalMs
+        : qMax(m_fetchIntervalMs, kDisconnectedFetchIntervalMs);
+
+    if (m_fetchTimer->interval() != effectiveInterval) {
+        m_fetchTimer->setInterval(effectiveInterval);
+    }
 }
 
 void HeadsetControlMonitor::setTestModeEnabled(bool enabled)

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -301,7 +301,13 @@ void HeadsetControlMonitor::setInactiveTime(int value)
 
 void HeadsetControlMonitor::fetchHeadsetInfo()
 {
-    if (!m_isMonitoring || m_isFetching) {
+    if (!m_isMonitoring) {
+        return;
+    }
+
+    if (m_isFetching) {
+        LOG_INFO("HeadsetControlManager",
+                 "Headset polling already active, skipping duplicate polling request");
         return;
     }
 
@@ -365,6 +371,11 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
     }
 
     m_isFetching = false;
+}
+
+void HeadsetControlMonitor::requestRefresh()
+{
+    fetchHeadsetInfo();
 }
 
 void HeadsetControlMonitor::updateDeviceCache()


### PR DESCRIPTION
## Summary

- Improves audio default-device switching by preserving separate output/input and communications-role requests while coalescing rapid changes.
- Clears pending default-device switch requests during `AudioManager` teardown so stale queued work cannot replay after audio is re-enabled.
- Hardens endpoint volume updates by clamping volume values and logging unavailable controls or failed Windows API calls with HRESULT details.
- Reduces HeadsetControl polling while no device is connected, restores the configured interval once a device is found, and updates the vendored HeadsetControl submodule.
- Bumps the app version to 1.15.4 and refreshes Polish translation/progress data.

## Validation

- `git diff --check` was run locally for the audio manager cleanup change.
- Full Windows CMake/Release validation still needs to run in CI or on a Windows development machine.
