### PR TITLE
Coalesce queued default-audio-device switch requests

### DIFF
--- a/include/audiomanager.h
+++ b/include/audiomanager.h
@@ -6,6 +6,7 @@
 #include <QIcon>
 #include <QMap>
 #include <QAbstractListModel>
+#include <optional>
 #include <windows.h>
 #include <mmdeviceapi.h>
 #include <endpointvolume.h>
@@ -411,4 +412,16 @@ private:
     bool m_cachedInputMute;
     QList<AudioApplication> m_cachedApplications;
     QList<AudioDevice> m_cachedDevices;
+
+    struct PendingDefaultDeviceSwitch {
+        QString deviceId;
+        bool isInput = false;
+        bool forCommunications = false;
+    };
+
+    void processPendingDefaultDeviceSwitches();
+
+    mutable QMutex m_pendingDefaultDeviceMutex;
+    std::optional<PendingDefaultDeviceSwitch> m_pendingDefaultDeviceSwitch;
+    bool m_defaultDeviceSwitchDispatchQueued = false;
 };

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -1999,18 +1999,75 @@ void AudioManager::setApplicationMuteAsync(const QString& appId, bool mute)
 
 void AudioManager::setDefaultDeviceAsync(const QString& deviceId, bool isInput, bool forCommunications)
 {
-    if (m_worker) {
-        const bool invokeOk = QMetaObject::invokeMethod(m_worker, [this, deviceId, isInput, forCommunications]() {
-            if (m_worker) {
-                m_worker->setDefaultDevice(deviceId, isInput, forCommunications);
-            }
-        }, Qt::QueuedConnection);
+    if (!m_worker) {
+        return;
+    }
 
-        if (!invokeOk) {
-            LOG_CRITICAL("AudioManager",
-                         QString("Failed to queue setDefaultDevice call for %1 device")
-                             .arg(isInput ? "input" : "output"));
+    bool shouldQueueDispatcher = false;
+    {
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        m_pendingDefaultDeviceSwitch = PendingDefaultDeviceSwitch{deviceId, isInput, forCommunications};
+        if (!m_defaultDeviceSwitchDispatchQueued) {
+            m_defaultDeviceSwitchDispatchQueued = true;
+            shouldQueueDispatcher = true;
         }
+    }
+
+    if (!shouldQueueDispatcher) {
+        return;
+    }
+
+    const bool invokeOk = QMetaObject::invokeMethod(this, &AudioManager::processPendingDefaultDeviceSwitches, Qt::QueuedConnection);
+    if (!invokeOk) {
+        LOG_CRITICAL("AudioManager",
+                     QString("Failed to queue setDefaultDevice dispatcher for %1 device")
+                         .arg(isInput ? "input" : "output"));
+
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        m_defaultDeviceSwitchDispatchQueued = false;
+    }
+}
+
+void AudioManager::processPendingDefaultDeviceSwitches()
+{
+    std::optional<PendingDefaultDeviceSwitch> nextSwitch;
+    {
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        nextSwitch = m_pendingDefaultDeviceSwitch;
+        m_pendingDefaultDeviceSwitch.reset();
+        m_defaultDeviceSwitchDispatchQueued = false;
+    }
+
+    if (!nextSwitch.has_value() || !m_worker) {
+        return;
+    }
+
+    const bool invokeOk = QMetaObject::invokeMethod(
+        m_worker,
+        [worker = m_worker, request = *nextSwitch]() {
+            if (worker) {
+                worker->setDefaultDevice(request.deviceId, request.isInput, request.forCommunications);
+            }
+        },
+        Qt::QueuedConnection);
+
+    if (!invokeOk) {
+        LOG_CRITICAL("AudioManager",
+                     QString("Failed to queue setDefaultDevice execution for %1 device")
+                         .arg(nextSwitch->isInput ? "input" : "output"));
+    }
+
+    bool needsAnotherPass = false;
+    {
+        QMutexLocker pendingLock(&m_pendingDefaultDeviceMutex);
+        if (m_pendingDefaultDeviceSwitch.has_value() && !m_defaultDeviceSwitchDispatchQueued) {
+            m_defaultDeviceSwitchDispatchQueued = true;
+            needsAnotherPass = true;
+        }
+    }
+
+    if (needsAnotherPass) {
+        QMetaObject::invokeMethod(this, &AudioManager::processPendingDefaultDeviceSwitches, Qt::QueuedConnection);
     }
 }
 


### PR DESCRIPTION
### Motivation
- Rapid sequences of default-device switch requests could pile up in the event queue and later replay, causing switching and volume to appear to stop working until the app was restarted. 
- Logs showed many `AudioBridge` request lines without timely `AudioManager` application lines, indicating queued/backlogged switch operations. 

### Description
- Added a `PendingDefaultDeviceSwitch` struct and synchronized state (`m_pendingDefaultDeviceSwitch`, `m_pendingDefaultDeviceMutex`, `m_defaultDeviceSwitchDispatchQueued`) to `AudioManager` to hold the latest pending switch request (file: `include/audiomanager.h`).
- Changed `AudioManager::setDefaultDeviceAsync` to coalesce rapid requests by storing only the newest request and scheduling a single dispatcher instead of enqueueing each request directly to the worker (file: `src/audiomanager.cpp`).
- Implemented `AudioManager::processPendingDefaultDeviceSwitches` to dequeue the pending request and invoke `AudioWorker::setDefaultDevice` on the worker thread via `QMetaObject::invokeMethod`, and to re-dispatch itself if additional requests arrived while processing (file: `src/audiomanager.cpp`).

### Testing
- Verified the patch applied cleanly and inspected the changes with `git diff` and `git status`, and created a commit (`Coalesce queued default-audio-device switch requests`), all of which succeeded. 
- Performed no Windows/Qt runtime or device interaction tests in this environment, so no integration or unit test runs against the modified audio runtime were executed. 
- No automated build or CI test was run in this container; runtime validation on Windows is still required to confirm behavior with real devices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aaae371708327a7e40763ffcf292a)