### PR TITLE
Isolate headset polling and prevent overlapping refresh requests

### DIFF
--- a/include/audiomanager.h
+++ b/include/audiomanager.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <QObject>
-#include <QThread>
 #include <QMutex>
 #include <QIcon>
 #include <QMap>
 #include <QAbstractListModel>
+#include <QThread>
 #include <array>
 #include <optional>
 #include <windows.h>
@@ -240,6 +240,7 @@ private:
     void updateDevicesBatteryInfo(const QList<HeadsetControlDevice>& headsetDevices);
 
     HeadsetControlMonitor* m_headsetControlMonitor;
+    QThread* m_headsetControlThread;
 };
 
 // Device change notification callback

--- a/include/audiomanager.h
+++ b/include/audiomanager.h
@@ -226,6 +226,7 @@ private:
 
     QTimer* m_audioLevelTimer;
     QList<AudioApplication> m_cachedApplications;
+    QList<HeadsetControlDevice> m_cachedHeadsetDevices;
 
     int getDeviceAudioLevel(EDataFlow dataFlow);
 

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -53,6 +53,7 @@ public:
 public slots:
     void startMonitoring();
     void stopMonitoring();
+    void requestRefresh();
     void setLights(bool enabled);
     void setRotateToMute(bool enabled);
     void setVoicePrompts(bool enabled);

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -635,12 +635,15 @@ void AudioWorker::cleanup()
         m_headsetControlThread = nullptr;
     }
 
+    m_cachedHeadsetDevices.clear();
+
     CoUninitialize();
 }
 
 void AudioWorker::onHeadsetDataUpdated(const QList<HeadsetControlDevice>& headsetDevices)
 {
-    updateDevicesBatteryInfo(headsetDevices);
+    m_cachedHeadsetDevices = headsetDevices;
+    updateDevicesBatteryInfo(m_cachedHeadsetDevices);
     emit devicesChanged(m_devices);
 }
 
@@ -1020,15 +1023,7 @@ void AudioWorker::enumerateDevices()
     m_devices = newDevices;
 
 
-    if (m_headsetControlMonitor && m_headsetControlMonitor->isMonitoring()) {
-        QList<HeadsetControlDevice> cachedDevices = m_headsetControlMonitor->getCachedDevices();
-        if (!cachedDevices.isEmpty()) {
-            updateDevicesBatteryInfo(cachedDevices);
-        }
-    } else if (m_headsetControlMonitor) {
-        // If monitoring is stopped, clear any headset battery info
-        updateDevicesBatteryInfo(QList<HeadsetControlDevice>());
-    }
+    updateDevicesBatteryInfo(m_cachedHeadsetDevices);
 
     emit devicesChanged(m_devices);
 }

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -448,6 +448,8 @@ AudioWorker::AudioWorker()
     qRegisterMetaType<QList<AudioApplication>>("QList<AudioApplication>");
     qRegisterMetaType<AudioDevice>("AudioDevice");
     qRegisterMetaType<QList<AudioDevice>>("QList<AudioDevice>");
+    qRegisterMetaType<HeadsetControlDevice>("HeadsetControlDevice");
+    qRegisterMetaType<QList<HeadsetControlDevice>>("QList<HeadsetControlDevice>");
 
     m_headsetControlMonitor = new HeadsetControlMonitor();
     m_headsetControlThread = new QThread(this);

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -442,13 +442,17 @@ AudioWorker::AudioWorker()
     , m_audioLevelTimer(nullptr)
     , m_sessionManagerInvalid(false)
     , m_headsetControlMonitor(nullptr)
+    , m_headsetControlThread(nullptr)
 {
     qRegisterMetaType<AudioApplication>("AudioApplication");
     qRegisterMetaType<QList<AudioApplication>>("QList<AudioApplication>");
     qRegisterMetaType<AudioDevice>("AudioDevice");
     qRegisterMetaType<QList<AudioDevice>>("QList<AudioDevice>");
 
-    m_headsetControlMonitor = new HeadsetControlMonitor(this);
+    m_headsetControlMonitor = new HeadsetControlMonitor();
+    m_headsetControlThread = new QThread(this);
+    m_headsetControlMonitor->moveToThread(m_headsetControlThread);
+    m_headsetControlThread->start();
     connect(m_headsetControlMonitor, &HeadsetControlMonitor::headsetDataUpdated,
             this, &AudioWorker::onHeadsetDataUpdated);
 }
@@ -519,6 +523,10 @@ void AudioWorker::initialize()
 
 void AudioWorker::cleanup()
 {
+    if (m_headsetControlMonitor) {
+        QMetaObject::invokeMethod(m_headsetControlMonitor, "stopMonitoring", Qt::QueuedConnection);
+    }
+
     if (m_audioLevelTimer) {
         m_audioLevelTimer->stop();
         delete m_audioLevelTimer;
@@ -610,6 +618,21 @@ void AudioWorker::cleanup()
     if (m_deviceEnumerator) {
         m_deviceEnumerator->Release();
         m_deviceEnumerator = nullptr;
+    }
+
+    if (m_headsetControlMonitor) {
+        QMetaObject::invokeMethod(m_headsetControlMonitor, "deleteLater", Qt::QueuedConnection);
+        m_headsetControlMonitor = nullptr;
+    }
+
+    if (m_headsetControlThread) {
+        m_headsetControlThread->quit();
+        if (!m_headsetControlThread->wait(3000)) {
+            LOG_WARN("AudioManager", "HeadsetControl thread did not finish gracefully, terminating...");
+            m_headsetControlThread->terminate();
+            m_headsetControlThread->wait(1000);
+        }
+        m_headsetControlThread = nullptr;
     }
 
     CoUninitialize();

--- a/src/audiomanager.cpp
+++ b/src/audiomanager.cpp
@@ -629,11 +629,19 @@ void AudioWorker::cleanup()
 
     if (m_headsetControlThread) {
         m_headsetControlThread->quit();
-        if (!m_headsetControlThread->wait(3000)) {
+        bool headsetThreadStopped = m_headsetControlThread->wait(3000);
+        if (!headsetThreadStopped) {
             LOG_WARN("AudioManager", "HeadsetControl thread did not finish gracefully, terminating...");
             m_headsetControlThread->terminate();
-            m_headsetControlThread->wait(1000);
+            headsetThreadStopped = m_headsetControlThread->wait();
         }
+
+        if (!headsetThreadStopped) {
+            LOG_CRITICAL("AudioManager",
+                         "HeadsetControl thread failed to stop; refusing to continue cleanup to avoid deleting a running QThread");
+            return;
+        }
+
         m_headsetControlThread = nullptr;
     }
 

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -177,7 +177,7 @@ void HeadsetControlBridge::refreshNow()
 {
     HeadsetControlMonitor* monitor = findMonitor();
     if (monitor) {
-        QMetaObject::invokeMethod(monitor, "fetchHeadsetInfo", Qt::QueuedConnection);
+        QMetaObject::invokeMethod(monitor, "requestRefresh", Qt::QueuedConnection);
     }
 }
 

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -301,7 +301,13 @@ void HeadsetControlMonitor::setInactiveTime(int value)
 
 void HeadsetControlMonitor::fetchHeadsetInfo()
 {
-    if (!m_isMonitoring || m_isFetching) {
+    if (!m_isMonitoring) {
+        return;
+    }
+
+    if (m_isFetching) {
+        LOG_INFO("HeadsetControlManager",
+                 "Headset polling already active, skipping duplicate polling request");
         return;
     }
 
@@ -365,6 +371,11 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
     }
 
     m_isFetching = false;
+}
+
+void HeadsetControlMonitor::requestRefresh()
+{
+    fetchHeadsetInfo();
 }
 
 void HeadsetControlMonitor::updateDeviceCache()


### PR DESCRIPTION
### Motivation
- Headset polling could take long and run from multiple UI entry points, causing audio input/output switching to be delayed when polling ran on the shared audio worker thread.
- Ensure only one headset poll runs at a time and drop duplicate requests to avoid queueing and unexpected latency for audio actions.

### Description
- Move `HeadsetControlMonitor` off the audio worker and run it on a dedicated `QThread` by adding `m_headsetControlThread`, calling `moveToThread`, and starting the thread in the `AudioWorker` constructor.
- Add overlap protection in `HeadsetControlMonitor::fetchHeadsetInfo()` by early-returning when `m_isFetching` is true and logging "Headset polling already active, skipping duplicate polling request".
- Expose a public `requestRefresh()` slot on `HeadsetControlMonitor` and update `HeadsetControlBridge::refreshNow()` to invoke `requestRefresh()` instead of calling the private fetch directly.
- Clean up headset thread and monitor on shutdown by invoking `stopMonitoring`, queuing `deleteLater` for the monitor, quitting/waiting the thread, and using a terminate fallback to avoid hangs.

### Testing
- Ran automated repository inspections (code search for refresh entry points and diff inspection) to verify refresh callers now go through the guarded `requestRefresh` path and the changes appear in the diffs, and these checks succeeded.
- No compilation or CI build was executed as part of this change; recommend running a CMake configure and a Release build on Windows and the existing test/validation steps in `AGENTS.md` before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ed6329a6c832789b807eec5292140)