### PR TITLE
Implements minimum headset polling interval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.16.0 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.16.1 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/include/headsetcontrolbridge.h
+++ b/include/headsetcontrolbridge.h
@@ -90,10 +90,31 @@ private slots:
     void onMonitorTestProfileChanged();
 
 private:
+    struct CachedState {
+        bool hasSidetoneCapability = false;
+        bool hasLightsCapability = false;
+        bool hasRotateToMuteCapability = false;
+        bool hasChatMixCapability = false;
+        bool hasVoicePromptsCapability = false;
+        bool hasEqualizerPresetsCapability = false;
+        bool hasInactiveTimeCapability = false;
+        QString deviceName;
+        QString batteryStatus = "BATTERY_UNAVAILABLE";
+        int batteryLevel = -1;
+        int chatMix = -1;
+        QStringList equalizerPresetNames;
+        bool anyDeviceFound = false;
+        bool testModeEnabled = false;
+        int testProfile = 1;
+    };
+
     static HeadsetControlBridge* m_instance;
     HeadsetControlMonitor* findMonitor() const;
     void connectToMonitor();
+    void queueCacheRefresh(HeadsetControlMonitor* monitor);
+    void resetCachedStateToDefaults();
     void updateLowBatteryNotificationState();
 
     bool m_lowBatteryNotificationSent = false;
+    CachedState m_cachedState;
 };

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -84,6 +84,7 @@ private slots:
 private:
     void fetchHeadsetInfoInternal(bool bypassRecentFetch);
     bool shouldBypassRecentFetchForManualRequest() const;
+    void scheduleNextFetch();
     void applyTestDeviceConfiguration();
     void updateFetchTimerInterval(bool deviceFound);
     void updateDeviceCache();

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -83,6 +83,7 @@ private slots:
 
 private:
     void fetchHeadsetInfoInternal(bool bypassRecentFetch);
+    bool shouldBypassRecentFetchForManualRequest() const;
     void applyTestDeviceConfiguration();
     void updateFetchTimerInterval(bool deviceFound);
     void updateDeviceCache();

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -2,6 +2,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QTimer>
+#include <QElapsedTimer>
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <QJsonArray>
@@ -109,6 +110,7 @@ private:
     QStringList m_equalizerPresetNames;
     bool m_anyDeviceFound;
     bool m_isFetching;
+    QElapsedTimer m_lastSuccessfulFetch;
     bool m_testModeEnabled;
     int m_testProfile;
 };

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -82,6 +82,7 @@ private slots:
     void fetchHeadsetInfo();
 
 private:
+    void fetchHeadsetInfo(bool bypassRecentFetch);
     void applyTestDeviceConfiguration();
     void updateFetchTimerInterval(bool deviceFound);
     void updateDeviceCache();
@@ -110,7 +111,7 @@ private:
     QStringList m_equalizerPresetNames;
     bool m_anyDeviceFound;
     bool m_isFetching;
-    QElapsedTimer m_lastSuccessfulFetch;
+    QElapsedTimer m_lastFetchCompleted;
     bool m_testModeEnabled;
     int m_testProfile;
 };

--- a/include/headsetcontrolmonitor.h
+++ b/include/headsetcontrolmonitor.h
@@ -82,7 +82,7 @@ private slots:
     void fetchHeadsetInfo();
 
 private:
-    void fetchHeadsetInfo(bool bypassRecentFetch);
+    void fetchHeadsetInfoInternal(bool bypassRecentFetch);
     void applyTestDeviceConfiguration();
     void updateFetchTimerInterval(bool deviceFound);
     void updateDeviceCache();

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -289,7 +289,7 @@ ColumnLayout {
                         }
 
                         SpinBox {
-                            from: 10
+                            from: 60
                             to: 3600
                             value: UserSettings.headsetcontrolFetchRate
                             editable: true

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -72,6 +72,13 @@ void HeadsetControlBridge::connectToMonitor()
             this, &HeadsetControlBridge::onMonitorTestModeEnabledChanged);
         connect(monitor, &HeadsetControlMonitor::testProfileChanged,
             this, &HeadsetControlBridge::onMonitorTestProfileChanged);
+        connect(monitor, &HeadsetControlMonitor::headsetDataUpdated,
+                this, [this](const QList<HeadsetControlDevice>&) {
+                    HeadsetControlMonitor* monitor = findMonitor();
+                    if (monitor) {
+                        queueCacheRefresh(monitor);
+                    }
+                });
 
         int fetchRateSeconds = UserSettings::instance()->headsetcontrolFetchRate();
         int fetchRateMs = fetchRateSeconds * 1000;
@@ -82,16 +89,7 @@ void HeadsetControlBridge::connectToMonitor()
             QMetaObject::invokeMethod(monitor, "startMonitoring", Qt::QueuedConnection);
         }
 
-        emit capabilitiesChanged();
-        emit deviceNameChanged();
-        emit batteryStatusChanged();
-        emit batteryLevelChanged();
-        emit batteryIconChanged();
-        emit chatMixChanged();
-        emit equalizerPresetNamesChanged();
-        emit anyDeviceFoundChanged();
-        emit testModeEnabledChanged();
-        emit testProfileChanged();
+        queueCacheRefresh(monitor);
     } else {
         QTimer::singleShot(200, this, &HeadsetControlBridge::connectToMonitor);
     }
@@ -183,62 +181,52 @@ void HeadsetControlBridge::refreshNow()
 
 bool HeadsetControlBridge::hasSidetoneCapability() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->hasSidetoneCapability() : false;
+    return m_cachedState.hasSidetoneCapability;
 }
 
 bool HeadsetControlBridge::hasLightsCapability() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->hasLightsCapability() : false;
+    return m_cachedState.hasLightsCapability;
 }
 
 bool HeadsetControlBridge::hasRotateToMuteCapability() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->hasRotateToMuteCapability() : false;
+    return m_cachedState.hasRotateToMuteCapability;
 }
 
 bool HeadsetControlBridge::hasChatMixCapability() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->hasChatMixCapability() : false;
+    return m_cachedState.hasChatMixCapability;
 }
 
 bool HeadsetControlBridge::hasVoicePromptsCapability() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->hasVoicePromptsCapability() : false;
+    return m_cachedState.hasVoicePromptsCapability;
 }
 
 bool HeadsetControlBridge::hasEqualizerPresetsCapability() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->hasEqualizerPresetsCapability() : false;
+    return m_cachedState.hasEqualizerPresetsCapability;
 }
 
 bool HeadsetControlBridge::hasInactiveTimeCapability() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->hasInactiveTimeCapability() : false;
+    return m_cachedState.hasInactiveTimeCapability;
 }
 
 QString HeadsetControlBridge::deviceName() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->deviceName() : QString();
+    return m_cachedState.deviceName;
 }
 
 QString HeadsetControlBridge::batteryStatus() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->batteryStatus() : QString("BATTERY_UNAVAILABLE");
+    return m_cachedState.batteryStatus;
 }
 
 int HeadsetControlBridge::batteryLevel() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->batteryLevel() : -1;
+    return m_cachedState.batteryLevel;
 }
 
 QString HeadsetControlBridge::batteryIcon() const
@@ -262,74 +250,97 @@ QString HeadsetControlBridge::batteryIcon() const
 
 int HeadsetControlBridge::chatMix() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->chatMix() : -1;
+    return m_cachedState.chatMix;
 }
 
 QStringList HeadsetControlBridge::equalizerPresetNames() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->equalizerPresetNames() : QStringList();
+    return m_cachedState.equalizerPresetNames;
 }
 
 bool HeadsetControlBridge::anyDeviceFound() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->anyDeviceFound() : false;
+    return m_cachedState.anyDeviceFound;
 }
 
 bool HeadsetControlBridge::testModeEnabled() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->testModeEnabled() : false;
+    return m_cachedState.testModeEnabled;
 }
 
 int HeadsetControlBridge::testProfile() const
 {
-    HeadsetControlMonitor* monitor = findMonitor();
-    return monitor ? monitor->testProfile() : 1;
+    return m_cachedState.testProfile;
 }
 
 void HeadsetControlBridge::onMonitorCapabilitiesChanged()
 {
-    emit capabilitiesChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::onMonitorDeviceNameChanged()
 {
-    emit deviceNameChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::onMonitorBatteryStatusChanged()
 {
-    emit batteryStatusChanged();
-    emit batteryIconChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::onMonitorBatteryLevelChanged()
 {
-    updateLowBatteryNotificationState();
-    emit batteryLevelChanged();
-    emit batteryIconChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::onMonitorChatMixChanged()
 {
-    emit chatMixChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::onMonitorEqualizerPresetNamesChanged()
 {
-    emit equalizerPresetNamesChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::onMonitorAnyDeviceFoundChanged()
 {
-    if (!anyDeviceFound()) {
-        m_lowBatteryNotificationSent = false;
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
     }
-
-    emit anyDeviceFoundChanged();
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::updateLowBatteryNotificationState()
@@ -350,12 +361,148 @@ void HeadsetControlBridge::updateLowBatteryNotificationState()
 
 void HeadsetControlBridge::onMonitorTestModeEnabledChanged()
 {
-    emit testModeEnabledChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
 }
 
 void HeadsetControlBridge::onMonitorTestProfileChanged()
 {
-    emit testProfileChanged();
+    HeadsetControlMonitor* monitor = findMonitor();
+    if (monitor) {
+        queueCacheRefresh(monitor);
+        return;
+    }
+    resetCachedStateToDefaults();
+}
+
+void HeadsetControlBridge::queueCacheRefresh(HeadsetControlMonitor* monitor)
+{
+    if (!monitor) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(
+        monitor,
+        [this, monitor]() {
+            CachedState state;
+            state.hasSidetoneCapability = monitor->hasSidetoneCapability();
+            state.hasLightsCapability = monitor->hasLightsCapability();
+            state.hasRotateToMuteCapability = monitor->hasRotateToMuteCapability();
+            state.hasChatMixCapability = monitor->hasChatMixCapability();
+            state.hasVoicePromptsCapability = monitor->hasVoicePromptsCapability();
+            state.hasEqualizerPresetsCapability = monitor->hasEqualizerPresetsCapability();
+            state.hasInactiveTimeCapability = monitor->hasInactiveTimeCapability();
+            state.deviceName = monitor->deviceName();
+            state.batteryStatus = monitor->batteryStatus();
+            state.batteryLevel = monitor->batteryLevel();
+            state.chatMix = monitor->chatMix();
+            state.equalizerPresetNames = monitor->equalizerPresetNames();
+            state.anyDeviceFound = monitor->anyDeviceFound();
+            state.testModeEnabled = monitor->testModeEnabled();
+            state.testProfile = monitor->testProfile();
+
+            QMetaObject::invokeMethod(this, [this, state]() {
+                const CachedState previous = m_cachedState;
+                m_cachedState = state;
+
+                const bool capabilitiesChangedNow =
+                    previous.hasSidetoneCapability != m_cachedState.hasSidetoneCapability ||
+                    previous.hasLightsCapability != m_cachedState.hasLightsCapability ||
+                    previous.hasRotateToMuteCapability != m_cachedState.hasRotateToMuteCapability ||
+                    previous.hasChatMixCapability != m_cachedState.hasChatMixCapability ||
+                    previous.hasVoicePromptsCapability != m_cachedState.hasVoicePromptsCapability ||
+                    previous.hasEqualizerPresetsCapability != m_cachedState.hasEqualizerPresetsCapability ||
+                    previous.hasInactiveTimeCapability != m_cachedState.hasInactiveTimeCapability;
+
+                if (capabilitiesChangedNow) {
+                    emit capabilitiesChanged();
+                }
+                if (previous.deviceName != m_cachedState.deviceName) {
+                    emit deviceNameChanged();
+                }
+                if (previous.batteryStatus != m_cachedState.batteryStatus) {
+                    emit batteryStatusChanged();
+                    emit batteryIconChanged();
+                }
+                if (previous.batteryLevel != m_cachedState.batteryLevel) {
+                    updateLowBatteryNotificationState();
+                    emit batteryLevelChanged();
+                    emit batteryIconChanged();
+                }
+                if (previous.chatMix != m_cachedState.chatMix) {
+                    emit chatMixChanged();
+                }
+                if (previous.equalizerPresetNames != m_cachedState.equalizerPresetNames) {
+                    emit equalizerPresetNamesChanged();
+                }
+                if (previous.anyDeviceFound != m_cachedState.anyDeviceFound) {
+                    if (!m_cachedState.anyDeviceFound) {
+                        m_lowBatteryNotificationSent = false;
+                    }
+                    emit anyDeviceFoundChanged();
+                }
+                if (previous.testModeEnabled != m_cachedState.testModeEnabled) {
+                    emit testModeEnabledChanged();
+                }
+                if (previous.testProfile != m_cachedState.testProfile) {
+                    emit testProfileChanged();
+                }
+            }, Qt::QueuedConnection);
+        },
+        Qt::QueuedConnection);
+}
+
+void HeadsetControlBridge::resetCachedStateToDefaults()
+{
+    const CachedState previous = m_cachedState;
+    m_cachedState = CachedState{};
+
+    const bool capabilitiesChangedNow =
+        previous.hasSidetoneCapability != m_cachedState.hasSidetoneCapability ||
+        previous.hasLightsCapability != m_cachedState.hasLightsCapability ||
+        previous.hasRotateToMuteCapability != m_cachedState.hasRotateToMuteCapability ||
+        previous.hasChatMixCapability != m_cachedState.hasChatMixCapability ||
+        previous.hasVoicePromptsCapability != m_cachedState.hasVoicePromptsCapability ||
+        previous.hasEqualizerPresetsCapability != m_cachedState.hasEqualizerPresetsCapability ||
+        previous.hasInactiveTimeCapability != m_cachedState.hasInactiveTimeCapability;
+
+    if (capabilitiesChangedNow) {
+        emit capabilitiesChanged();
+    }
+    if (previous.deviceName != m_cachedState.deviceName) {
+        emit deviceNameChanged();
+    }
+    if (previous.batteryStatus != m_cachedState.batteryStatus) {
+        emit batteryStatusChanged();
+        emit batteryIconChanged();
+    }
+    if (previous.batteryLevel != m_cachedState.batteryLevel) {
+        updateLowBatteryNotificationState();
+        emit batteryLevelChanged();
+        emit batteryIconChanged();
+    }
+    if (previous.chatMix != m_cachedState.chatMix) {
+        emit chatMixChanged();
+    }
+    if (previous.equalizerPresetNames != m_cachedState.equalizerPresetNames) {
+        emit equalizerPresetNamesChanged();
+    }
+    if (previous.anyDeviceFound != m_cachedState.anyDeviceFound) {
+        if (!m_cachedState.anyDeviceFound) {
+            m_lowBatteryNotificationSent = false;
+        }
+        emit anyDeviceFoundChanged();
+    }
+    if (previous.testModeEnabled != m_cachedState.testModeEnabled) {
+        emit testModeEnabledChanged();
+    }
+    if (previous.testProfile != m_cachedState.testProfile) {
+        emit testProfileChanged();
+    }
 }
 
 void HeadsetControlBridge::setFetchRate(int seconds)

--- a/src/headsetcontrolbridge.cpp
+++ b/src/headsetcontrolbridge.cpp
@@ -2,6 +2,7 @@
 #include "headsetcontrolmonitor.h"
 #include "audiomanager.h"
 #include "usersettings.h"
+#include <QPointer>
 #include <QTimer>
 
 HeadsetControlBridge* HeadsetControlBridge::m_instance = nullptr;
@@ -385,9 +386,14 @@ void HeadsetControlBridge::queueCacheRefresh(HeadsetControlMonitor* monitor)
         return;
     }
 
+    QPointer<HeadsetControlBridge> bridge(this);
     QMetaObject::invokeMethod(
         monitor,
-        [this, monitor]() {
+        [bridge, monitor]() {
+            if (!bridge) {
+                return;
+            }
+
             CachedState state;
             state.hasSidetoneCapability = monitor->hasSidetoneCapability();
             state.hasLightsCapability = monitor->hasLightsCapability();
@@ -405,51 +411,55 @@ void HeadsetControlBridge::queueCacheRefresh(HeadsetControlMonitor* monitor)
             state.testModeEnabled = monitor->testModeEnabled();
             state.testProfile = monitor->testProfile();
 
-            QMetaObject::invokeMethod(this, [this, state]() {
-                const CachedState previous = m_cachedState;
-                m_cachedState = state;
+            QMetaObject::invokeMethod(bridge.data(), [bridge, state]() {
+                if (!bridge) {
+                    return;
+                }
+
+                const CachedState previous = bridge->m_cachedState;
+                bridge->m_cachedState = state;
 
                 const bool capabilitiesChangedNow =
-                    previous.hasSidetoneCapability != m_cachedState.hasSidetoneCapability ||
-                    previous.hasLightsCapability != m_cachedState.hasLightsCapability ||
-                    previous.hasRotateToMuteCapability != m_cachedState.hasRotateToMuteCapability ||
-                    previous.hasChatMixCapability != m_cachedState.hasChatMixCapability ||
-                    previous.hasVoicePromptsCapability != m_cachedState.hasVoicePromptsCapability ||
-                    previous.hasEqualizerPresetsCapability != m_cachedState.hasEqualizerPresetsCapability ||
-                    previous.hasInactiveTimeCapability != m_cachedState.hasInactiveTimeCapability;
+                    previous.hasSidetoneCapability != bridge->m_cachedState.hasSidetoneCapability ||
+                    previous.hasLightsCapability != bridge->m_cachedState.hasLightsCapability ||
+                    previous.hasRotateToMuteCapability != bridge->m_cachedState.hasRotateToMuteCapability ||
+                    previous.hasChatMixCapability != bridge->m_cachedState.hasChatMixCapability ||
+                    previous.hasVoicePromptsCapability != bridge->m_cachedState.hasVoicePromptsCapability ||
+                    previous.hasEqualizerPresetsCapability != bridge->m_cachedState.hasEqualizerPresetsCapability ||
+                    previous.hasInactiveTimeCapability != bridge->m_cachedState.hasInactiveTimeCapability;
 
                 if (capabilitiesChangedNow) {
-                    emit capabilitiesChanged();
+                    emit bridge->capabilitiesChanged();
                 }
-                if (previous.deviceName != m_cachedState.deviceName) {
-                    emit deviceNameChanged();
+                if (previous.deviceName != bridge->m_cachedState.deviceName) {
+                    emit bridge->deviceNameChanged();
                 }
-                if (previous.batteryStatus != m_cachedState.batteryStatus) {
-                    emit batteryStatusChanged();
-                    emit batteryIconChanged();
+                if (previous.batteryStatus != bridge->m_cachedState.batteryStatus) {
+                    emit bridge->batteryStatusChanged();
+                    emit bridge->batteryIconChanged();
                 }
-                if (previous.batteryLevel != m_cachedState.batteryLevel) {
-                    updateLowBatteryNotificationState();
-                    emit batteryLevelChanged();
-                    emit batteryIconChanged();
+                if (previous.batteryLevel != bridge->m_cachedState.batteryLevel) {
+                    bridge->updateLowBatteryNotificationState();
+                    emit bridge->batteryLevelChanged();
+                    emit bridge->batteryIconChanged();
                 }
-                if (previous.chatMix != m_cachedState.chatMix) {
-                    emit chatMixChanged();
+                if (previous.chatMix != bridge->m_cachedState.chatMix) {
+                    emit bridge->chatMixChanged();
                 }
-                if (previous.equalizerPresetNames != m_cachedState.equalizerPresetNames) {
-                    emit equalizerPresetNamesChanged();
+                if (previous.equalizerPresetNames != bridge->m_cachedState.equalizerPresetNames) {
+                    emit bridge->equalizerPresetNamesChanged();
                 }
-                if (previous.anyDeviceFound != m_cachedState.anyDeviceFound) {
-                    if (!m_cachedState.anyDeviceFound) {
-                        m_lowBatteryNotificationSent = false;
+                if (previous.anyDeviceFound != bridge->m_cachedState.anyDeviceFound) {
+                    if (!bridge->m_cachedState.anyDeviceFound) {
+                        bridge->m_lowBatteryNotificationSent = false;
                     }
-                    emit anyDeviceFoundChanged();
+                    emit bridge->anyDeviceFoundChanged();
                 }
-                if (previous.testModeEnabled != m_cachedState.testModeEnabled) {
-                    emit testModeEnabledChanged();
+                if (previous.testModeEnabled != bridge->m_cachedState.testModeEnabled) {
+                    emit bridge->testModeEnabledChanged();
                 }
-                if (previous.testProfile != m_cachedState.testProfile) {
-                    emit testProfileChanged();
+                if (previous.testProfile != bridge->m_cachedState.testProfile) {
+                    emit bridge->testProfileChanged();
                 }
             }, Qt::QueuedConnection);
         },

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -391,7 +391,16 @@ void HeadsetControlMonitor::fetchHeadsetInfoInternal(bool bypassRecentFetch)
 
 void HeadsetControlMonitor::requestRefresh()
 {
-    fetchHeadsetInfoInternal(!m_anyDeviceFound);
+    fetchHeadsetInfoInternal(shouldBypassRecentFetchForManualRequest());
+}
+
+bool HeadsetControlMonitor::shouldBypassRecentFetchForManualRequest() const
+{
+    return !m_anyDeviceFound
+        || m_batteryLevel < 0
+        || m_batteryStatus == "BATTERY_UNAVAILABLE"
+        || m_batteryStatus == "BATTERY_HIDERROR"
+        || m_batteryStatus == "BATTERY_TIMEOUT";
 }
 
 void HeadsetControlMonitor::updateDeviceCache()

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -33,7 +33,7 @@ HeadsetControlMonitor::HeadsetControlMonitor(QObject *parent)
                                         .arg(QString::fromStdString(std::string(headsetcontrol::version()))));
 
     m_fetchTimer->setInterval(m_fetchIntervalMs);
-    m_fetchTimer->setSingleShot(false);
+    m_fetchTimer->setSingleShot(true);
 
     connect(m_fetchTimer, &QTimer::timeout, this, &HeadsetControlMonitor::fetchHeadsetInfo);
 }
@@ -57,9 +57,9 @@ void HeadsetControlMonitor::startMonitoring()
                                     QString("Starting headset monitoring (fetch interval: %1ms)").arg(m_fetchIntervalMs));
 
     m_isMonitoring = true;
+    m_lastFetchCompleted = QElapsedTimer();
     applyTestDeviceConfiguration();
-    m_fetchTimer->start();
-    fetchHeadsetInfo();
+    fetchHeadsetInfoInternal(true);
 
     emit monitoringStateChanged(true);
 }
@@ -302,7 +302,7 @@ void HeadsetControlMonitor::setInactiveTime(int value)
 
 void HeadsetControlMonitor::fetchHeadsetInfo()
 {
-    fetchHeadsetInfoInternal(false);
+    fetchHeadsetInfoInternal(true);
 }
 
 void HeadsetControlMonitor::fetchHeadsetInfoInternal(bool bypassRecentFetch)
@@ -324,6 +324,7 @@ void HeadsetControlMonitor::fetchHeadsetInfoInternal(bool bypassRecentFetch)
     }
 
     m_isFetching = true;
+    m_fetchTimer->stop();
     LOG_INFO("HeadsetControlManager",
              "Starting headset polling");
 
@@ -368,6 +369,7 @@ void HeadsetControlMonitor::fetchHeadsetInfoInternal(bool bypassRecentFetch)
             updateFetchTimerInterval(false);
             m_lastFetchCompleted.start();
             m_isFetching = false;
+            scheduleNextFetch();
             return;
         }
 
@@ -387,6 +389,7 @@ void HeadsetControlMonitor::fetchHeadsetInfoInternal(bool bypassRecentFetch)
 
     m_lastFetchCompleted.start();
     m_isFetching = false;
+    scheduleNextFetch();
 }
 
 void HeadsetControlMonitor::requestRefresh()
@@ -401,6 +404,13 @@ bool HeadsetControlMonitor::shouldBypassRecentFetchForManualRequest() const
         || m_batteryStatus == "BATTERY_UNAVAILABLE"
         || m_batteryStatus == "BATTERY_HIDERROR"
         || m_batteryStatus == "BATTERY_TIMEOUT";
+}
+
+void HeadsetControlMonitor::scheduleNextFetch()
+{
+    if (m_isMonitoring) {
+        m_fetchTimer->start();
+    }
 }
 
 void HeadsetControlMonitor::updateDeviceCache()

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -302,6 +302,11 @@ void HeadsetControlMonitor::setInactiveTime(int value)
 
 void HeadsetControlMonitor::fetchHeadsetInfo()
 {
+    fetchHeadsetInfo(false);
+}
+
+void HeadsetControlMonitor::fetchHeadsetInfo(bool bypassRecentFetch)
+{
     if (!m_isMonitoring) {
         return;
     }
@@ -312,9 +317,9 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
         return;
     }
 
-    if (m_lastSuccessfulFetch.isValid() && m_lastSuccessfulFetch.elapsed() < kMinimumFetchIntervalMs) {
+    if (!bypassRecentFetch && m_lastFetchCompleted.isValid() && m_lastFetchCompleted.elapsed() < kMinimumFetchIntervalMs) {
         LOG_INFO("HeadsetControlManager",
-                 "Headset data was already fetched during the last 60 seconds, skipping polling request");
+                 "Headset polling completed during the last 60 seconds, skipping polling request");
         return;
     }
 
@@ -361,7 +366,7 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
             }
             emit headsetDataUpdated(m_cachedDevices);
             updateFetchTimerInterval(false);
-            m_lastSuccessfulFetch.start();
+            m_lastFetchCompleted.start();
             m_isFetching = false;
             return;
         }
@@ -372,7 +377,6 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
                                         QString("Found %1 headset device(s)").arg(m_headsets.size()));
 
         updateDeviceCache();
-        m_lastSuccessfulFetch.start();
 
     } catch (const std::exception& e) {
         LOG_CRITICAL("HeadsetControlManager",
@@ -381,12 +385,13 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
         emit headsetDataUpdated(m_cachedDevices);
     }
 
+    m_lastFetchCompleted.start();
     m_isFetching = false;
 }
 
 void HeadsetControlMonitor::requestRefresh()
 {
-    fetchHeadsetInfo();
+    fetchHeadsetInfo(!m_anyDeviceFound);
 }
 
 void HeadsetControlMonitor::updateDeviceCache()
@@ -661,7 +666,7 @@ void HeadsetControlMonitor::setTestModeEnabled(bool enabled)
     emit testModeEnabledChanged();
 
     if (m_isMonitoring) {
-        fetchHeadsetInfo();
+        fetchHeadsetInfo(true);
     }
 }
 
@@ -677,7 +682,7 @@ void HeadsetControlMonitor::setTestProfile(int profile)
     emit testProfileChanged();
 
     if (m_testModeEnabled && m_isMonitoring) {
-        fetchHeadsetInfo();
+        fetchHeadsetInfo(true);
     }
 }
 

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -4,6 +4,7 @@
 
 namespace {
 constexpr int kDisconnectedFetchIntervalMs = 60000;
+constexpr int kMinimumFetchIntervalMs = 60000;
 }
 
 HeadsetControlMonitor::HeadsetControlMonitor(QObject *parent)
@@ -311,6 +312,12 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
         return;
     }
 
+    if (m_lastSuccessfulFetch.isValid() && m_lastSuccessfulFetch.elapsed() < kMinimumFetchIntervalMs) {
+        LOG_INFO("HeadsetControlManager",
+                 "Headset data was already fetched during the last 60 seconds, skipping polling request");
+        return;
+    }
+
     m_isFetching = true;
     LOG_INFO("HeadsetControlManager",
              "Starting headset polling");
@@ -354,6 +361,7 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
             }
             emit headsetDataUpdated(m_cachedDevices);
             updateFetchTimerInterval(false);
+            m_lastSuccessfulFetch.start();
             m_isFetching = false;
             return;
         }
@@ -364,6 +372,7 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
                                         QString("Found %1 headset device(s)").arg(m_headsets.size()));
 
         updateDeviceCache();
+        m_lastSuccessfulFetch.start();
 
     } catch (const std::exception& e) {
         LOG_CRITICAL("HeadsetControlManager",
@@ -623,7 +632,7 @@ QStringList HeadsetControlMonitor::getCapabilityList(const headsetcontrol::Heads
 
 void HeadsetControlMonitor::setFetchInterval(int intervalMs)
 {
-    m_fetchIntervalMs = intervalMs;
+    m_fetchIntervalMs = qMax(kMinimumFetchIntervalMs, intervalMs);
     updateFetchTimerInterval(m_anyDeviceFound);
 
     LOG_INFO("HeadsetControlManager",

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -312,6 +312,8 @@ void HeadsetControlMonitor::fetchHeadsetInfo()
     }
 
     m_isFetching = true;
+    LOG_INFO("HeadsetControlManager",
+             "Starting headset polling");
 
     try {
         applyTestDeviceConfiguration();

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -302,10 +302,10 @@ void HeadsetControlMonitor::setInactiveTime(int value)
 
 void HeadsetControlMonitor::fetchHeadsetInfo()
 {
-    fetchHeadsetInfo(false);
+    fetchHeadsetInfoInternal(false);
 }
 
-void HeadsetControlMonitor::fetchHeadsetInfo(bool bypassRecentFetch)
+void HeadsetControlMonitor::fetchHeadsetInfoInternal(bool bypassRecentFetch)
 {
     if (!m_isMonitoring) {
         return;
@@ -391,7 +391,7 @@ void HeadsetControlMonitor::fetchHeadsetInfo(bool bypassRecentFetch)
 
 void HeadsetControlMonitor::requestRefresh()
 {
-    fetchHeadsetInfo(!m_anyDeviceFound);
+    fetchHeadsetInfoInternal(!m_anyDeviceFound);
 }
 
 void HeadsetControlMonitor::updateDeviceCache()
@@ -666,7 +666,7 @@ void HeadsetControlMonitor::setTestModeEnabled(bool enabled)
     emit testModeEnabledChanged();
 
     if (m_isMonitoring) {
-        fetchHeadsetInfo(true);
+        fetchHeadsetInfoInternal(true);
     }
 }
 
@@ -682,7 +682,7 @@ void HeadsetControlMonitor::setTestProfile(int profile)
     emit testProfileChanged();
 
     if (m_testModeEnabled && m_isMonitoring) {
-        fetchHeadsetInfo(true);
+        fetchHeadsetInfoInternal(true);
     }
 }
 

--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -399,7 +399,8 @@ void HeadsetControlMonitor::requestRefresh()
 
 bool HeadsetControlMonitor::shouldBypassRecentFetchForManualRequest() const
 {
-    return !m_anyDeviceFound
+    return m_testModeEnabled
+        || !m_anyDeviceFound
         || m_batteryLevel < 0
         || m_batteryStatus == "BATTERY_UNAVAILABLE"
         || m_batteryStatus == "BATTERY_HIDERROR"

--- a/src/usersettings.cpp
+++ b/src/usersettings.cpp
@@ -5,6 +5,7 @@ namespace {
 constexpr int kMaxSettingsStartupPage = 11;
 constexpr int kMinHeadsetcontrolLowBatteryThreshold = 1;
 constexpr int kMaxHeadsetcontrolLowBatteryThreshold = 30;
+constexpr int kMinHeadsetcontrolFetchRate = 60;
 }
 
 UserSettings* UserSettings::m_instance = nullptr;
@@ -90,7 +91,7 @@ void UserSettings::initProperties()
     m_ddcciBrightness = settings.value("ddcciBrightness", 100).toInt();
     m_displayBatteryFooter = settings.value("displayBatteryFooter", true).toBool();
     m_panelStyle = settings.value("panelStyle", 0).toInt();
-    m_headsetcontrolFetchRate = settings.value("headsetcontrolFetchRate", 20).toInt();
+    m_headsetcontrolFetchRate = qMax(kMinHeadsetcontrolFetchRate, settings.value("headsetcontrolFetchRate", kMinHeadsetcontrolFetchRate).toInt());
     m_enableNotifications = settings.value("enableNotifications", false).toBool();
     m_headsetcontrolLowBatteryThreshold = qBound(
         kMinHeadsetcontrolLowBatteryThreshold,
@@ -509,6 +510,7 @@ void UserSettings::setPanelStyle(int value)
 
 void UserSettings::setHeadsetcontrolFetchRate(int value)
 {
+    value = qMax(kMinHeadsetcontrolFetchRate, value);
     if (m_headsetcontrolFetchRate != value) {
         m_headsetcontrolFetchRate = value;
         saveValue("headsetcontrolFetchRate", value);


### PR DESCRIPTION
Enforces a 60-second minimum polling interval for headset information to optimize resource usage and prevent excessive requests.

Key changes include:
- A new internal fetch method allows bypassing the minimum interval for critical scenarios, such as manual refresh requests when battery data is invalid or unavailable, or when in test mode.
- The user interface and settings are updated to reflect the new minimum fetch rate.
- Logging is added to indicate when headset polling is initiated.
- Bumps the application version to 1.16.1.