### PR TITLE
Avoid headset polling when tray click hides panel

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -181,7 +181,13 @@ ApplicationWindow {
 
     SystemTray {
         id: systemTray
-        onTogglePanelRequested: trayToggleTimer.restart()
+        onTogglePanelRequested: {
+            if (panel.visible && !panel.isAnimatingOut) {
+                panel.hidePanel()
+            } else {
+                trayToggleTimer.restart()
+            }
+        }
         onSettingsWindowRequested: {
             trayToggleTimer.stop()
             settingsWindow.showPreferredPane()
@@ -194,6 +200,7 @@ ApplicationWindow {
         repeat: false
         onTriggered: {
             if (!panel.visible) {
+                HeadsetControlBridge.refreshNow()
                 panel.showPanel()
             }
         }

--- a/qml/SystemTray.qml
+++ b/qml/SystemTray.qml
@@ -19,7 +19,6 @@ Platform.SystemTrayIcon {
         }
 
         if (reason === Platform.SystemTrayIcon.Trigger) {
-            HeadsetControlBridge.refreshNow();
             systemTray.togglePanelRequested();
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent unnecessary headset polling when the tray icon is clicked to hide the panel, while preserving polling when the tray click actually shows the panel.
- Ensure other show paths are unchanged and avoid launching headset discovery on hide actions.

### Description
- Removed `HeadsetControlBridge.refreshNow()` from the tray icon activation handler in `qml/SystemTray.qml` so a tray click no longer immediately triggers polling.
- Modified `onTogglePanelRequested` in `qml/Main.qml` to hide the panel immediately when it is already visible instead of always restarting the tray timer.
- Added `HeadsetControlBridge.refreshNow()` to the tray-show path (`trayToggleTimer.onTriggered`) so polling only happens when the tray click results in showing the panel.

### Testing
- No automated tests were added or run for this UI-only change.
- Changes were verified by inspecting the updated `qml/SystemTray.qml` and `qml/Main.qml` to confirm the remove/add of the `refreshNow()` call and the updated toggle behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17dd8971fc8327ac0529c080c79844)