### PR TITLE
Log HeadsetControl commit hash on initialization

### DIFF
--- a/src/headsetcontrolmonitor.cpp
+++ b/src/headsetcontrolmonitor.cpp
@@ -1,6 +1,7 @@
 #include "headsetcontrolmonitor.h"
 #include "logmanager.h"
 #include "usersettings.h"
+#include "version.h"
 
 namespace {
 constexpr int kDisconnectedFetchIntervalMs = 60000;
@@ -31,8 +32,9 @@ HeadsetControlMonitor::HeadsetControlMonitor(QObject *parent)
     , m_testProfile(3)
 {
     LOG_INFO("HeadsetControlManager",
-                                    QString("HeadsetControlMonitor initialized - Library version: %1")
-                                        .arg(QString::fromStdString(std::string(headsetcontrol::version()))));
+                                    QString("HeadsetControlMonitor initialized - HeadsetControl commit: %1 (library version: %2)")
+                                        .arg(QString(HEADSETCONTROL_GIT_COMMIT_HASH),
+                                             QString::fromStdString(std::string(headsetcontrol::version()))));
 
     m_fetchTimer->setInterval(m_fetchIntervalMs);
     m_fetchTimer->setSingleShot(true);


### PR DESCRIPTION
### Motivation
- Surface the exact HeadsetControl library commit hash in the startup log to improve tracing and debugging of library versions.

### Description
- Add `#include "version.h"` and update the initialization log in `src/headsetcontrolmonitor.cpp` to include `HEADSETCONTROL_GIT_COMMIT_HASH` together with `headsetcontrol::version()`.

### Testing
- Performed an automated build and executed the project's test suite; the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1932cdba14832792509485e3e815d0)