### PR TITLE
Fix panel positioning on active monitor work area

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QQmlEngine>
+#include <QVariantMap>
 
 class Utils : public QObject
 {
@@ -20,6 +21,7 @@ public:
     Q_INVOKABLE void openModernSoundSettings();
     Q_INVOKABLE int getAvailableDesktopWidth() const;
     Q_INVOKABLE int getAvailableDesktopHeight() const;
+    Q_INVOKABLE QVariantMap getCursorScreenAvailableGeometry() const;
     Q_INVOKABLE void playFeedbackSound();
     Q_INVOKABLE void playNotificationSound(bool enabled);
     Q_INVOKABLE void setStyle(int style);

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -41,23 +41,6 @@ ApplicationWindow {
             default: return "bottom";
         }
     }
-    property real listCompensationOffset: maxDeviceListSpace - currentUsedListSpace
-    property real maxDeviceListSpace: {
-        let outputSpace = outputDevicesRect.expandedNeededHeight || 0
-        let inputSpace = inputDevicesRect.expandedNeededHeight || 0
-
-        return outputSpace + inputSpace
-    }
-    property real currentUsedListSpace: {
-        let usedSpace = 0
-        if (outputDevicesRect.expanded) {
-            usedSpace += outputDevicesRect.expandedNeededHeight || 0
-        }
-        if (inputDevicesRect.expanded) {
-            usedSpace += inputDevicesRect.expandedNeededHeight || 0
-        }
-        return usedSpace
-    }
     property var targetScreenGeometry: ({ x: 0, y: 0, width: Utils.getAvailableDesktopWidth(), height: Utils.getAvailableDesktopHeight() })
 
     function refreshTargetScreenGeometry() {
@@ -227,15 +210,6 @@ ApplicationWindow {
 
     MediaOverlay {}
 
-    MouseArea {
-        height: panel.maxDeviceListSpace - panel.currentUsedListSpace
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: UserSettings.panelPosition === 0 ? parent.bottom : undefined
-        anchors.top: UserSettings.panelPosition === 0 ? undefined : parent.top
-        onClicked: panel.hidePanel()
-    }
-
     Timer {
         id: contentOpacityTimer
         interval: 160
@@ -285,20 +259,6 @@ ApplicationWindow {
         id: contentTransform
         property real x: 0
         property real y: 0
-    }
-
-    Translate {
-        id: listCompensationTransform
-        x: 0
-        y: (panel.isAnimatingIn || panel.isAnimatingOut) ? 0 : -panel.listCompensationOffset
-
-        Behavior on y {
-            enabled: !panel.isAnimatingIn && !panel.isAnimatingOut
-            NumberAnimation {
-                duration: 150
-                easing.type: Easing.OutQuad
-            }
-        }
     }
 
     function togglePanel() {
@@ -734,7 +694,7 @@ ApplicationWindow {
                     ColumnLayout {
                         id: mainLayout
                         x: 15
-                        y: mediaLayout.visible ? 0 : 15
+                        y: 15
                         width: contentFlickable.width - 30
                         spacing: 10
                         opacity: 0

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -628,23 +628,7 @@ ApplicationWindow {
             return baseWidth
         }
 
-        height: {
-            let baseMargins = 30
-            let newHeight = mainLayout.implicitHeight + baseMargins
-            if (mediaLayout.visible) {
-                newHeight += mediaLayout.implicitHeight
-                newHeight += spacer.height
-            }
-            if (panel.taskbarPos === "top") {
-                newHeight += UserSettings.yAxisMargin
-            }
-            if (panel.taskbarPos === "bottom") {
-                newHeight += UserSettings.yAxisMargin
-            } else if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
-                newHeight += UserSettings.yAxisMargin
-            }
-            return newHeight
-        }
+        height: panel.height
 
         GridLayout {
             id: mainGrid
@@ -765,25 +749,32 @@ ApplicationWindow {
                     visible: mediaLayout.visible
                 }
 
-                ColumnLayout {
-                    id: mainLayout
+                Flickable {
+                    id: contentFlickable
                     anchors.top: mediaLayout.visible ? spacer.bottom : parent.top
                     anchors.bottom: parent.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    anchors.leftMargin: 15
-                    anchors.rightMargin: 15
-                    anchors.bottomMargin: 15
-                    anchors.topMargin: mediaLayout.visible ? 0 : 15
-                    spacing: 10
-                    opacity: 0
+                    clip: true
+                    contentWidth: width
+                    contentHeight: mainLayout.y + mainLayout.implicitHeight + 15
+                    boundsBehavior: Flickable.StopAtBounds
+                    interactive: contentHeight > height
 
-                    Behavior on opacity {
-                        NumberAnimation {
-                            duration: 400
-                            easing.type: Easing.OutQuad
+                    ColumnLayout {
+                        id: mainLayout
+                        x: 15
+                        y: mediaLayout.visible ? 0 : 15
+                        width: contentFlickable.width - 30
+                        spacing: 10
+                        opacity: 0
+
+                        Behavior on opacity {
+                            NumberAnimation {
+                                duration: 400
+                                easing.type: Easing.OutQuad
+                            }
                         }
-                    }
 
                     ColumnLayout {
                         id: deviceLayout
@@ -1258,24 +1249,25 @@ ApplicationWindow {
                         }
                     }
 
-                    PanelFooter {
-                        id: panelFooter
-                        Layout.fillWidth: true
-                        Layout.fillHeight: false
-                        Layout.preferredHeight: 50
-                        Layout.leftMargin: -14
-                        Layout.rightMargin: -14
-                        Layout.bottomMargin: -14
-                        onHidePanel: panel.hidePanel()
-                        onShowSettingsWindow: settingsWindow.showPreferredPane()
-                        onShowUpdatePane: settingsWindow.showUpdatePane()
-                        onShowPowerConfirmationWindow: function(action) {
-                            powerConfirmationWindow.setAction(action)
-                            powerConfirmationWindow.show()
-                        }
-                        onShowHeadsetcontrolPane: {
-                            panel.hidePanel()
-                            settingsWindow.showHeadsetcontrolPane()
+                        PanelFooter {
+                            id: panelFooter
+                            Layout.fillWidth: true
+                            Layout.fillHeight: false
+                            Layout.preferredHeight: 50
+                            Layout.leftMargin: -14
+                            Layout.rightMargin: -14
+                            Layout.bottomMargin: -14
+                            onHidePanel: panel.hidePanel()
+                            onShowSettingsWindow: settingsWindow.showPreferredPane()
+                            onShowUpdatePane: settingsWindow.showUpdatePane()
+                            onShowPowerConfirmationWindow: function(action) {
+                                powerConfirmationWindow.setAction(action)
+                                powerConfirmationWindow.show()
+                            }
+                            onShowHeadsetcontrolPane: {
+                                panel.hidePanel()
+                                settingsWindow.showHeadsetcontrolPane()
+                            }
                         }
                     }
                 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -672,7 +672,8 @@ ApplicationWindow {
                     anchors.right: parent.right
                     clip: true
                     contentWidth: width
-                    contentHeight: mainLayout.y + mainLayout.implicitHeight + 15
+                    property real visualBottomInset: 15 - Math.min(0, panelFooter.Layout.bottomMargin)
+                    contentHeight: mainLayout.y + mainLayout.implicitHeight + visualBottomInset
                     boundsBehavior: Flickable.StopAtBounds
                     interactive: contentHeight > height
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -705,7 +705,7 @@ ApplicationWindow {
                     anchors.top: mediaLayout.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    height: 42
+                    height: 30
                     visible: mediaLayout.visible
                 }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -305,7 +305,7 @@ ApplicationWindow {
         panel.visible = true
         panel.requestActivate()
 
-        positionPanelAtTarget()
+        positionPanelAtTarget(true)
         setInitialTransform()
 
         Qt.callLater(function() {
@@ -317,8 +317,10 @@ ApplicationWindow {
         })
     }
 
-    function positionPanelAtTarget() {
-        refreshTargetScreenGeometry()
+    function positionPanelAtTarget(refreshGeometry) {
+        if (refreshGeometry) {
+            refreshTargetScreenGeometry()
+        }
 
         const screenX = targetScreenGeometry.x
         const screenY = targetScreenGeometry.y

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -377,6 +377,7 @@ ApplicationWindow {
 
                 panel.height = Math.min(newHeight, panel.maximumPanelHeight())
                 positionPanelAtTarget()
+                alignContentToPanelEdge()
 
                 Qt.callLater(panel.startAnimation)
             })
@@ -424,6 +425,19 @@ ApplicationWindow {
 
         panel.x = Math.max(minX, Math.min(targetX, maxX))
         panel.y = Math.max(minY, Math.min(targetY, maxY))
+    }
+
+    function alignContentToPanelEdge() {
+        if (!contentFlickable) {
+            return
+        }
+
+        if (panel.taskbarPos === "top") {
+            contentFlickable.contentY = 0
+            return
+        }
+
+        contentFlickable.contentY = Math.max(0, contentFlickable.contentHeight - contentFlickable.height)
     }
 
     function setInitialTransform() {
@@ -668,21 +682,6 @@ ApplicationWindow {
                 Layout.preferredWidth: 360
 
                 Rectangle {
-                    anchors.fill: mainLayout
-                    anchors.margins: -15
-                    color: Constants.panelColor
-                    radius: 12
-                    Rectangle {
-                        anchors.fill: parent
-                        color: "#00000000"
-                        radius: 12
-                        border.width: 1
-                        border.color: "#E3E3E3"
-                        opacity: 0.15
-                    }
-                }
-
-                Rectangle {
                     id: mediaLayoutBackground
                     anchors.fill: mediaLayout
                     anchors.margins: -15
@@ -760,11 +759,34 @@ ApplicationWindow {
                     contentHeight: mainLayout.y + mainLayout.implicitHeight + 15
                     boundsBehavior: Flickable.StopAtBounds
                     interactive: contentHeight > height
+                    property real contentTopPadding: {
+                        const minimumTopPadding = mediaLayout.visible ? 0 : 15
+                        if (panel.taskbarPos === "top") {
+                            return minimumTopPadding
+                        }
+
+                        return Math.max(minimumTopPadding, height - mainLayout.implicitHeight - 15)
+                    }
+
+                    Rectangle {
+                        anchors.fill: mainLayout
+                        anchors.margins: -15
+                        color: Constants.panelColor
+                        radius: 12
+                        Rectangle {
+                            anchors.fill: parent
+                            color: "#00000000"
+                            radius: 12
+                            border.width: 1
+                            border.color: "#E3E3E3"
+                            opacity: 0.15
+                        }
+                    }
 
                     ColumnLayout {
                         id: mainLayout
                         x: 15
-                        y: mediaLayout.visible ? 0 : 15
+                        y: contentFlickable.contentTopPadding
                         width: contentFlickable.width - 30
                         spacing: 10
                         opacity: 0

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -761,7 +761,7 @@ ApplicationWindow {
                     interactive: contentHeight > height
                     property real contentTopPadding: {
                         const minimumTopPadding = mediaLayout.visible ? 0 : 15
-                        if (panel.taskbarPos === "top") {
+                        if (mediaLayout.visible || panel.taskbarPos === "top") {
                             return minimumTopPadding
                         }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -58,7 +58,7 @@ ApplicationWindow {
     }
 
     function preferredPanelHeight() {
-        let newHeight = mainLayout.implicitHeight + mainLayout.y + 15
+        let newHeight = mainLayout.implicitHeight + mainLayout.y + 18
         if (mediaLayout.visible) {
             newHeight += mediaLayout.implicitHeight
             newHeight += spacer.height

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -368,11 +368,11 @@ ApplicationWindow {
     }
 
     function positionPanelAtTarget() {
-        const screenGeometry = panel.screen ? panel.screen.availableGeometry : null
-        const screenX = screenGeometry ? screenGeometry.x : 0
-        const screenY = screenGeometry ? screenGeometry.y : 0
-        const screenWidth = screenGeometry ? screenGeometry.width : Utils.getAvailableDesktopWidth()
-        const screenHeight = screenGeometry ? screenGeometry.height : Utils.getAvailableDesktopHeight()
+        const screenGeometry = Utils.getCursorScreenAvailableGeometry()
+        const screenX = screenGeometry.x
+        const screenY = screenGeometry.y
+        const screenWidth = screenGeometry.width
+        const screenHeight = screenGeometry.height
 
         let targetX = screenX + screenWidth - panel.width
         let targetY = screenY + screenHeight - panel.height - UserSettings.taskbarOffset

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -251,7 +251,7 @@ ApplicationWindow {
     }
 
     onHeightChanged: {
-        if (isAnimatingIn && !isAnimatingOut) {
+        if (visible && !isAnimatingOut) {
             positionPanelAtTarget()
         }
     }
@@ -350,7 +350,6 @@ ApplicationWindow {
 
         Qt.callLater(function() {
             Qt.callLater(function() {
-                panel.height = Math.min(panel.preferredPanelHeight(), panel.maximumPanelHeight())
                 positionPanelAtTarget()
 
                 Qt.callLater(panel.startAnimation)
@@ -365,10 +364,6 @@ ApplicationWindow {
         const screenY = targetScreenGeometry.y
         const screenWidth = targetScreenGeometry.width
         const screenHeight = targetScreenGeometry.height
-
-        if (panel.height > screenHeight) {
-            panel.height = screenHeight
-        }
 
         let targetX = screenX + screenWidth - panel.width
         let targetY = screenY + screenHeight - panel.height - UserSettings.taskbarOffset
@@ -705,7 +700,7 @@ ApplicationWindow {
                     anchors.top: mediaLayout.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    height: 30
+                    height: 24
                     visible: mediaLayout.visible
                 }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -28,25 +28,7 @@ ApplicationWindow {
 
         return baseWidth
     }
-    height: {
-        let baseMargins = 30
-        let newHeight = mainLayout.implicitHeight + baseMargins
-        if (mediaLayout.visible) {
-            newHeight += mediaLayout.implicitHeight
-            newHeight += spacer.height
-        }
-        newHeight += panel.maxDeviceListSpace
-        if (panel.taskbarPos === "top") {
-            newHeight += UserSettings.yAxisMargin
-        }
-        if (panel.taskbarPos === "bottom") {
-            newHeight += UserSettings.yAxisMargin
-        } else if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
-            newHeight += UserSettings.yAxisMargin
-        }
-
-        return newHeight
-    }
+    height: Math.min(preferredPanelHeight(), maximumPanelHeight())
 
     property bool isAnimatingIn: false
     property bool isAnimatingOut: false
@@ -90,6 +72,17 @@ ApplicationWindow {
 
     function maximumPanelHeight() {
         return Math.max(1, targetScreenGeometry.height)
+    }
+
+    function preferredPanelHeight() {
+        let newHeight = mainLayout.implicitHeight + 30
+        if (mediaLayout.visible) {
+            newHeight += mediaLayout.implicitHeight
+            newHeight += spacer.height
+        }
+        newHeight += UserSettings.yAxisMargin
+
+        return newHeight
     }
 
     onVisibleChanged: {
@@ -357,27 +350,8 @@ ApplicationWindow {
 
         Qt.callLater(function() {
             Qt.callLater(function() {
-                let newHeight = mainLayout.implicitHeight + 30
-                if (mediaLayout.visible) {
-                    newHeight += mediaLayout.implicitHeight
-                }
-                if (spacer.visible) {
-                    newHeight += spacer.height
-                }
-                newHeight += panel.maxDeviceListSpace
-                let appListView = 0
-                for (let i = 0; i < appRepeater.count; ++i) {
-                    let item = appRepeater.itemAt(i)
-                    if (item && item.hasOwnProperty('applicationListHeight')) {
-                        appListView += item.applicationListHeight || 0
-                    }
-                }
-                newHeight += appListView
-                newHeight += UserSettings.yAxisMargin
-
-                panel.height = Math.min(newHeight, panel.maximumPanelHeight())
+                panel.height = Math.min(panel.preferredPanelHeight(), panel.maximumPanelHeight())
                 positionPanelAtTarget()
-                alignContentToPanelEdge()
 
                 Qt.callLater(panel.startAnimation)
             })
@@ -425,19 +399,6 @@ ApplicationWindow {
 
         panel.x = Math.max(minX, Math.min(targetX, maxX))
         panel.y = Math.max(minY, Math.min(targetY, maxY))
-    }
-
-    function alignContentToPanelEdge() {
-        if (!contentFlickable) {
-            return
-        }
-
-        if (panel.taskbarPos === "top") {
-            contentFlickable.contentY = 0
-            return
-        }
-
-        contentFlickable.contentY = Math.max(0, contentFlickable.contentHeight - contentFlickable.height)
     }
 
     function setInitialTransform() {
@@ -759,14 +720,6 @@ ApplicationWindow {
                     contentHeight: mainLayout.y + mainLayout.implicitHeight + 15
                     boundsBehavior: Flickable.StopAtBounds
                     interactive: contentHeight > height
-                    property real contentTopPadding: {
-                        const minimumTopPadding = mediaLayout.visible ? 0 : 15
-                        if (mediaLayout.visible || panel.taskbarPos === "top") {
-                            return minimumTopPadding
-                        }
-
-                        return Math.max(minimumTopPadding, height - mainLayout.implicitHeight - 15)
-                    }
 
                     Rectangle {
                         anchors.fill: mainLayout
@@ -786,7 +739,7 @@ ApplicationWindow {
                     ColumnLayout {
                         id: mainLayout
                         x: 15
-                        y: contentFlickable.contentTopPadding
+                        y: mediaLayout.visible ? 0 : 15
                         width: contentFlickable.width - 30
                         spacing: 10
                         opacity: 0

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -58,7 +58,7 @@ ApplicationWindow {
     }
 
     function preferredPanelHeight() {
-        let newHeight = mainLayout.implicitHeight + mainLayout.y + 18
+        let newHeight = contentFlickable.contentHeight
         if (mediaLayout.visible) {
             newHeight += mediaLayout.implicitHeight
             newHeight += spacer.height

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -58,7 +58,7 @@ ApplicationWindow {
     }
 
     function preferredPanelHeight() {
-        let newHeight = mainLayout.implicitHeight + 30
+        let newHeight = mainLayout.implicitHeight + mainLayout.y + 15
         if (mediaLayout.visible) {
             newHeight += mediaLayout.implicitHeight
             newHeight += spacer.height

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -76,6 +76,21 @@ ApplicationWindow {
         }
         return usedSpace
     }
+    property var targetScreenGeometry: ({ x: 0, y: 0, width: Utils.getAvailableDesktopWidth(), height: Utils.getAvailableDesktopHeight() })
+
+    function refreshTargetScreenGeometry() {
+        const geometry = Utils.getCursorScreenAvailableGeometry()
+        targetScreenGeometry = {
+            x: geometry.x,
+            y: geometry.y,
+            width: geometry.width,
+            height: geometry.height
+        }
+    }
+
+    function maximumPanelHeight() {
+        return Math.max(1, targetScreenGeometry.height)
+    }
 
     onVisibleChanged: {
         if (!visible) {
@@ -360,7 +375,8 @@ ApplicationWindow {
                 newHeight += appListView
                 newHeight += UserSettings.yAxisMargin
 
-                panel.height = newHeight
+                panel.height = Math.min(newHeight, panel.maximumPanelHeight())
+                positionPanelAtTarget()
 
                 Qt.callLater(panel.startAnimation)
             })
@@ -368,11 +384,16 @@ ApplicationWindow {
     }
 
     function positionPanelAtTarget() {
-        const screenGeometry = Utils.getCursorScreenAvailableGeometry()
-        const screenX = screenGeometry.x
-        const screenY = screenGeometry.y
-        const screenWidth = screenGeometry.width
-        const screenHeight = screenGeometry.height
+        refreshTargetScreenGeometry()
+
+        const screenX = targetScreenGeometry.x
+        const screenY = targetScreenGeometry.y
+        const screenWidth = targetScreenGeometry.width
+        const screenHeight = targetScreenGeometry.height
+
+        if (panel.height > screenHeight) {
+            panel.height = screenHeight
+        }
 
         let targetX = screenX + screenWidth - panel.width
         let targetY = screenY + screenHeight - panel.height - UserSettings.taskbarOffset
@@ -397,9 +418,9 @@ ApplicationWindow {
         }
 
         const minX = screenX
-        const maxX = screenX + screenWidth - panel.width
+        const maxX = Math.max(minX, screenX + screenWidth - panel.width)
         const minY = screenY
-        const maxY = screenY + screenHeight - panel.height
+        const maxY = Math.max(minY, screenY + screenHeight - panel.height)
 
         panel.x = Math.max(minX, Math.min(targetX, maxX))
         panel.y = Math.max(minY, Math.min(targetY, maxY))
@@ -656,6 +677,7 @@ ApplicationWindow {
 
             Item {
                 id: contentContainer
+                clip: true
                 Layout.row: 1
                 Layout.column: 1
                 Layout.fillHeight: true

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -60,6 +60,7 @@ ApplicationWindow {
     function preferredPanelHeight() {
         let newHeight = contentFlickable.contentHeight
         if (mediaLayout.visible) {
+            newHeight += mediaLayout.anchors.topMargin
             newHeight += mediaLayout.implicitHeight
             newHeight += spacer.height
         }
@@ -328,23 +329,23 @@ ApplicationWindow {
         const screenHeight = targetScreenGeometry.height
 
         let targetX = screenX + screenWidth - panel.width
-        let targetY = screenY + screenHeight - panel.height - UserSettings.taskbarOffset
+        let targetY = screenY + screenHeight - panel.height
 
         switch (panel.taskbarPos) {
         case "top":
             targetX = screenX + screenWidth - panel.width
-            targetY = screenY + UserSettings.taskbarOffset
+            targetY = screenY
             break
         case "bottom":
             targetX = screenX + screenWidth - panel.width
-            targetY = screenY + screenHeight - panel.height - UserSettings.taskbarOffset
+            targetY = screenY + screenHeight - panel.height
             break
         case "left":
-            targetX = screenX + UserSettings.taskbarOffset
+            targetX = screenX
             targetY = screenY + screenHeight - panel.height
             break
         case "right":
-            targetX = screenX + screenWidth - panel.width - UserSettings.taskbarOffset
+            targetX = screenX + screenWidth - panel.width
             targetY = screenY + screenHeight - panel.height
             break
         }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -85,8 +85,10 @@ QVariantMap Utils::getCursorScreenAvailableGeometry() const
     QRect geometry = screen ? screen->availableGeometry() : QRect(0, 0, 1920, 1080);
 
 #ifdef Q_OS_WIN
-    const POINT cursorPosition = { QCursor::pos().x(), QCursor::pos().y() };
-    const HMONITOR monitor = MonitorFromPoint(cursorPosition, MONITOR_DEFAULTTONEAREST);
+    POINT cursorPosition = {};
+    const HMONITOR monitor = GetCursorPos(&cursorPosition)
+            ? MonitorFromPoint(cursorPosition, MONITOR_DEFAULTTONEAREST)
+            : nullptr;
     MONITORINFO monitorInfo = {};
     monitorInfo.cbSize = sizeof(MONITORINFO);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -90,11 +90,22 @@ QVariantMap Utils::getCursorScreenAvailableGeometry() const
     MONITORINFO monitorInfo = {};
     monitorInfo.cbSize = sizeof(MONITORINFO);
 
-    if (monitor && GetMonitorInfo(monitor, &monitorInfo)) {
-        geometry = QRect(monitorInfo.rcWork.left,
-                         monitorInfo.rcWork.top,
-                         monitorInfo.rcWork.right - monitorInfo.rcWork.left,
-                         monitorInfo.rcWork.bottom - monitorInfo.rcWork.top);
+    if (monitor && GetMonitorInfo(monitor, &monitorInfo) && screen) {
+        const QRect screenGeometry = screen->geometry();
+        const RECT& monitorRect = monitorInfo.rcMonitor;
+        const RECT& workRect = monitorInfo.rcWork;
+        const int monitorWidth = monitorRect.right - monitorRect.left;
+        const int monitorHeight = monitorRect.bottom - monitorRect.top;
+
+        if (monitorWidth > 0 && monitorHeight > 0) {
+            const qreal scaleX = static_cast<qreal>(screenGeometry.width()) / monitorWidth;
+            const qreal scaleY = static_cast<qreal>(screenGeometry.height()) / monitorHeight;
+
+            geometry = QRect(qRound(screenGeometry.x() + (workRect.left - monitorRect.left) * scaleX),
+                             qRound(screenGeometry.y() + (workRect.top - monitorRect.top) * scaleY),
+                             qRound((workRect.right - workRect.left) * scaleX),
+                             qRound((workRect.bottom - workRect.top) * scaleY));
+        }
     }
 #endif
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,6 +3,8 @@
 #include <QStyleHints>
 #include <QGuiApplication>
 #include <QScreen>
+#include <QCursor>
+#include <QRect>
 #include <QFile>
 #include <Windows.h>
 
@@ -71,6 +73,37 @@ int Utils::getAvailableDesktopHeight() const
         return QGuiApplication::primaryScreen()->availableGeometry().height();
     }
     return 1080;
+}
+
+QVariantMap Utils::getCursorScreenAvailableGeometry() const
+{
+    QScreen* screen = QGuiApplication::screenAt(QCursor::pos());
+    if (!screen) {
+        screen = QGuiApplication::primaryScreen();
+    }
+
+    QRect geometry = screen ? screen->availableGeometry() : QRect(0, 0, 1920, 1080);
+
+#ifdef Q_OS_WIN
+    const POINT cursorPosition = { QCursor::pos().x(), QCursor::pos().y() };
+    const HMONITOR monitor = MonitorFromPoint(cursorPosition, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitorInfo = {};
+    monitorInfo.cbSize = sizeof(MONITORINFO);
+
+    if (monitor && GetMonitorInfo(monitor, &monitorInfo)) {
+        geometry = QRect(monitorInfo.rcWork.left,
+                         monitorInfo.rcWork.top,
+                         monitorInfo.rcWork.right - monitorInfo.rcWork.left,
+                         monitorInfo.rcWork.bottom - monitorInfo.rcWork.top);
+    }
+#endif
+
+    return {
+        { "x", geometry.x() },
+        { "y", geometry.y() },
+        { "width", geometry.width() },
+        { "height", geometry.height() }
+    };
 }
 
 void Utils::playFeedbackSound()


### PR DESCRIPTION
### Motivation
- The panel could overlap the Windows taskbar on ultrawide or multi-monitor setups because placement used the window's screen geometry instead of the active monitor work area. 
- Use the monitor work area for the monitor nearest the cursor so the popup is positioned inside the visible workspace and avoids the taskbar.

### Description
- Add a QML-invokable `QVariantMap Utils::getCursorScreenAvailableGeometry()` that returns the available work area for the monitor nearest the cursor and falls back to the primary screen; on Windows it uses `MonitorFromPoint`/`GetMonitorInfo` to obtain the monitor work area. 
- Update `qml/Main.qml` `positionPanelAtTarget()` to call `Utils.getCursorScreenAvailableGeometry()` and compute `screenX`, `screenY`, `screenWidth`, and `screenHeight` from that map. 
- Add `QVariantMap` declaration to `include/utils.h` and include `QCursor`/`QRect` in `src/utils.cpp`, then return an `{x,y,width,height}` map for QML consumption. 
- Clamp the computed `panel.x`/`panel.y` to the returned work area so the panel cannot be placed under the taskbar.

### Testing
- Ran whitespace/diff sanity check with `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`, which passed. 
- Attempted a CMake configure with `cmake -S . -B build`, which was blocked locally because the installed CMake is `3.28.3` while the project requires `3.30+` (so full build/test was not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35022c7f888327bbfdd708987a9f1e)