### PR TITLE
[codex] Upgrade CI to Qt 6.11.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,8 @@ jobs:
         with:
           version: ${{ env.QT_VERSION }}
           arch: "win64_msvc2022_64"
+          # aqtinstall 3.3.0 cannot resolve Qt 6.11+ Windows repositories.
+          aqtsource: "git+https://github.com/miurahr/aqtinstall.git@8c3695d4a4e1ceabf6a74dc6c79681656dc6b74b"
           add-tools-to-path: true
           cache: true
       - name: Generate and Build with CMake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ permissions:
   contents: write
   pull-requests: write
 env:
-  QT_VERSION: "6.10.1"
+  QT_VERSION: "6.11.1"
   VCPKG_ROOT: "C:/vcpkg"
 jobs:
   build:

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -15,7 +15,7 @@ QontrolPanel is a Windows desktop application built with Qt 6, CMake, MSVC, vcpk
   - `hidapi:x64-windows`
   - `getopt-win32:x64-windows` for the vendored HeadsetControl build.
 
-The CI workflow uses Qt `6.10.1` on the `windows-2025-vs2026` runner. Visual Studio 2026 hosts the build, while its MSVC 2022-compatible `v143` toolset matches the supported Qt binary kit.
+The CI workflow uses Qt `6.11.1` on the `windows-2025-vs2026` runner. Visual Studio 2026 hosts the build, while its MSVC 2022-compatible `v143` toolset matches the supported Qt binary kit.
 
 ## Clone
 
@@ -63,7 +63,7 @@ Useful optional arguments:
 
 ```pwsh
 -DCMAKE_BUILD_TYPE=Release
--DCMAKE_PREFIX_PATH=C:/Qt/6.10.1/msvc2022_64
+-DCMAKE_PREFIX_PATH=C:/Qt/6.11.1/msvc2022_64
 ```
 
 When using a multi-config generator such as Visual Studio, pass the build configuration during build and install instead of relying on `CMAKE_BUILD_TYPE`.
@@ -128,7 +128,7 @@ Set `CMAKE_PREFIX_PATH` to the Qt MSVC kit, or configure from Qt Creator:
 ```pwsh
 cmake -S . -B build `
   -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
-  -DCMAKE_PREFIX_PATH=C:/Qt/6.10.1/msvc2022_64
+  -DCMAKE_PREFIX_PATH=C:/Qt/6.11.1/msvc2022_64
 ```
 
 ### The app starts but immediately exits


### PR DESCRIPTION
## Summary

- update the Windows CI Qt version from 6.10.1 to 6.11.1
- update the matching paths and CI version in the build guide
- pin the merged upstream aqtinstall fix needed to resolve Qt 6.11+ Windows repositories
- keep the supported CMake minimum at Qt 6.9

## Validation

- GitHub Actions workflow dispatch: https://github.com/ChrisLauinger77/QontrolPanel/actions/runs/28808521966
- Qt 6.11.1 installation passed with `win64_msvc2022_64`
- Visual Studio 2026/v143 Release configure, build, and install passed
- ZIP artifact and Inno Setup installer were built and uploaded
- no translation source changes were generated

## Installer compatibility

aqtinstall 3.3.0 constructs an outdated repository path for Qt 6.11+ on Windows. The workflow pins merged upstream fix https://github.com/miurahr/aqtinstall/pull/1000 by immutable commit until a released aqtinstall version includes it.
