### PR TITLE
[codex] Centralize Qt Renovate configuration

### DIFF
--- a/.github/workflows/compile_translations.yml
+++ b/.github/workflows/compile_translations.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 env:
-  QT_VERSION: "6.10.1"
+  QT_VERSION: "6.11.1"
   COMPILED_TRANSLATIONS_DIR: "i18n_compiled"
 
 jobs:

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,5 @@
 {
-  "extends": ["github>ChrisLauinger77/ChrisLauinger77//renovate-config/default"]
+  "extends": [
+    "github>ChrisLauinger77/ChrisLauinger77//renovate-config/qontrolpanel"
+  ]
 }


### PR DESCRIPTION
## Summary

- use the centralized QontrolPanel Renovate preset
- update the translation workflow from Qt 6.10.1 to 6.11.1
- preserve the workflow's CRLF line endings

## Dependency

Merge ChrisLauinger77/ChrisLauinger77#1 first so the referenced preset is available on the default branch.

## Validation

- Renovate configuration validation passes
- all five managed Qt references resolve to 6.11.1
- CRLF line endings are preserved