### PR TITLE
[codex] Skip builds for Renovate config changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - "dependencies/headsetcontrol/**"
       - "**/*.yml"
       - ".assets/**"
+      - "renovate.json"
 
   pull_request:
     branches:
@@ -23,6 +24,7 @@ on:
       - "dependencies/headsetcontrol/**"
       - "**/*.yml"
       - ".assets/**"
+      - "renovate.json"
 
   workflow_dispatch:
 permissions:


### PR DESCRIPTION
## Summary

- ignore root `renovate.json` changes in the Windows build workflow
- apply the filter to both `push` and `pull_request` events
- keep other JSON files build-relevant

## Validation

- workflow line endings remain LF
- `git diff --check` passes