### PR TITLE
Fix settings page slide transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.18.3 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.19.0 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -211,6 +211,7 @@ ApplicationWindow {
             readonly property bool settingsPageTransitionsEnabled: UserSettings.settingsAnimationsEnabled
             readonly property int settingsPageFadeDuration: UserSettings.settingsAnimationsEnabled ? 150 : 0
             readonly property int settingsPageSlideDuration: UserSettings.settingsAnimationsEnabled ? 300 : 0
+            readonly property real settingsPageSlideDistance: Math.min(32, stackView.width * 0.3)
 
             popEnter: Transition {
                 enabled: stackView.settingsPageTransitionsEnabled
@@ -224,8 +225,8 @@ ApplicationWindow {
                         easing.type: Easing.InQuint
                     }
                     NumberAnimation {
-                        property: "y"
-                        from: (stackView.mirrored ? -0.3 : 0.3) * -stackView.width
+                        property: "x"
+                        from: (stackView.mirrored ? 1 : -1) * stackView.settingsPageSlideDistance
                         to: 0
                         duration: stackView.settingsPageSlideDuration
                         easing.type: Easing.OutCubic
@@ -245,8 +246,8 @@ ApplicationWindow {
                         easing.type: Easing.InQuint
                     }
                     NumberAnimation {
-                        property: "y"
-                        from: (stackView.mirrored ? -0.3 : 0.3) * stackView.width
+                        property: "x"
+                        from: (stackView.mirrored ? -1 : 1) * stackView.settingsPageSlideDistance
                         to: 0
                         duration: stackView.settingsPageSlideDuration
                         easing.type: Easing.OutCubic
@@ -290,8 +291,8 @@ ApplicationWindow {
                         easing.type: Easing.InQuint
                     }
                     NumberAnimation {
-                        property: "y"
-                        from: (stackView.mirrored ? -0.3 : 0.3) * stackView.width
+                        property: "x"
+                        from: (stackView.mirrored ? -1 : 1) * stackView.settingsPageSlideDistance
                         to: 0
                         duration: stackView.settingsPageSlideDuration
                         easing.type: Easing.OutCubic
@@ -302,12 +303,21 @@ ApplicationWindow {
             replaceExit: Transition {
                 enabled: stackView.settingsPageTransitionsEnabled
 
-                NumberAnimation {
-                    property: "opacity"
-                    from: 1
-                    to: 0
-                    duration: stackView.settingsPageFadeDuration
-                    easing.type: Easing.OutQuint
+                ParallelAnimation {
+                    NumberAnimation {
+                        property: "opacity"
+                        from: 1
+                        to: 0
+                        duration: stackView.settingsPageFadeDuration
+                        easing.type: Easing.OutQuint
+                    }
+                    NumberAnimation {
+                        property: "x"
+                        from: 0
+                        to: (stackView.mirrored ? 1 : -1) * stackView.settingsPageSlideDistance
+                        duration: stackView.settingsPageSlideDuration
+                        easing.type: Easing.InCubic
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- animate settings page slide transitions along the horizontal `x` axis instead of `y`
- cap slide travel at 32 pixels while deriving it from the current `StackView` width
- add a matching horizontal slide to `replaceExit` while preserving the short opacity fade
- preserve mirrored direction handling for right-to-left layouts
- bump the application version from 1.18.3 to 1.19.0

## Why

The existing transitions animated `y` using a distance calculated from `stackView.width`, mixing vertical movement with a horizontal dimension. Moving the transition to `x` directly addresses that mismatch and uses a smaller travel distance for a subtler page change.

## Impact

Settings navigation now slides horizontally with a restrained 32-pixel maximum movement. Replace transitions animate both the incoming and outgoing pages, and disabling settings animations continues to reduce durations to zero.

## Validation

- `git -c core.whitespace=cr-at-eol diff --check`
- confirmed all settings page slide animations target `x`
- confirmed `SettingsWindow.qml` retains CRLF line endings
- CMake configure was attempted but could not run on macOS because the project expects the Windows vcpkg toolchain at `c:/vcpkg/scripts/buildsystems/vcpkg.cmake`