### PR TITLE
Fetches all HeadsetControl tags for accurate versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,16 @@ jobs:
         run: |
           git submodule sync --recursive
           git submodule update --init --recursive --remote --checkout
+          $headsetControlIsShallow = git -C dependencies/headsetcontrol rev-parse --is-shallow-repository
+          if ($headsetControlIsShallow -eq "true") {
+              git -C dependencies/headsetcontrol fetch --unshallow --tags
+          } else {
+              git -C dependencies/headsetcontrol fetch --tags
+          }
           $headsetControlCommit = git -C dependencies/headsetcontrol rev-parse HEAD
+          $headsetControlVersion = git -C dependencies/headsetcontrol describe --tags --dirty=-modified
           Write-Host "HeadsetControl submodule updated to $headsetControlCommit"
+          Write-Host "HeadsetControl version: $headsetControlVersion"
       - name: Get version from CMake
         id: cmake_version
         shell: pwsh


### PR DESCRIPTION
Updates the CI build workflow to guarantee accurate versioning for the `headsetcontrol` submodule. This change ensures that all Git tags are fetched, which is crucial for commands like `git describe` to correctly determine the submodule's version, especially when a shallow clone occurs in CI environments.

The modifications introduce a conditional fetch for the `headsetcontrol` submodule:
- It first checks if the submodule repository is shallow.
- If shallow, it performs an `unshallow` fetch to retrieve the full history and all associated tags.
- It then proceeds to fetch all tags, ensuring complete versioning information is available.
- Finally, the workflow captures and logs the precise `headsetcontrol` version using `git describe --tags --dirty=-modified`, enhancing build transparency.

**Breaking Changes**
None.

**Review Focus**
Verifies that the `headsetcontrol` submodule consistently reports its correct version in CI logs, particularly in scenarios involving shallow clones.