### PR TITLE
Displays HeadsetControl Library Version in UI

### DIFF
--- a/i18n/QontrolPanel_de.ts
+++ b/i18n/QontrolPanel_de.ts
@@ -870,8 +870,8 @@ Wenn Sie meine Arbeit unterstützen möchten, freue ich mich über jeden Beitrag
         <translation>Abrufen</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>Commit</translation>
+        <source>Version</source>
+        <translation>Version</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_en.ts
+++ b/i18n/QontrolPanel_en.ts
@@ -926,8 +926,8 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation type="unfinished">Commit</translation>
+        <source>Version</source>
+        <translation type="unfinished">Version</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_es.ts
+++ b/i18n/QontrolPanel_es.ts
@@ -926,8 +926,8 @@ Si quieres apoyar mi trabajo, cualquier contribución será muy apreciada.</tran
         <translation>Obtener</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>Commit</translation>
+        <source>Version</source>
+        <translation>Versión</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_fr.ts
+++ b/i18n/QontrolPanel_fr.ts
@@ -880,8 +880,8 @@ Si vous souhaitez soutenir mon travail, toute contribution serait grandement app
         <translation>Récupérer</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>Commit</translation>
+        <source>Version</source>
+        <translation>Version</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_it.ts
+++ b/i18n/QontrolPanel_it.ts
@@ -870,8 +870,8 @@ Se vuoi supportare il mio lavoro, qualsiasi contributo sarebbe molto apprezzato!
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation type="unfinished">Commit</translation>
+        <source>Version</source>
+        <translation type="unfinished">Versione</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_ja.ts
+++ b/i18n/QontrolPanel_ja.ts
@@ -870,8 +870,8 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>取得</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>コミット</translation>
+        <source>Version</source>
+        <translation>バージョン</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_ko.ts
+++ b/i18n/QontrolPanel_ko.ts
@@ -926,8 +926,8 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>가져오기</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>커밋</translation>
+        <source>Version</source>
+        <translation>버전</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_pl.ts
+++ b/i18n/QontrolPanel_pl.ts
@@ -920,8 +920,8 @@ Możesz ją włączyć w zakładce Komponenty.</translation>
         <translation>Predefiniowane Korektora</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>Zatwierdzenie</translation>
+        <source>Version</source>
+        <translation>Wersja</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_pt_BR.ts
+++ b/i18n/QontrolPanel_pt_BR.ts
@@ -871,8 +871,8 @@ Se você quiser apoiar meu trabalho, qualquer contribuição será muito bem-vin
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation type="unfinished">Commit</translation>
+        <source>Version</source>
+        <translation type="unfinished">Versão</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_ru.ts
+++ b/i18n/QontrolPanel_ru.ts
@@ -870,8 +870,8 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>Получить</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>Коммит</translation>
+        <source>Version</source>
+        <translation>Версия</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_sl.ts
+++ b/i18n/QontrolPanel_sl.ts
@@ -869,8 +869,8 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation type="unfinished">Commit</translation>
+        <source>Version</source>
+        <translation type="unfinished">Različica</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/i18n/QontrolPanel_zh_CN.ts
+++ b/i18n/QontrolPanel_zh_CN.ts
@@ -869,8 +869,8 @@ If you&apos;d like to support my work, any contribution would be greatly appreci
         <translation>获取</translation>
     </message>
     <message>
-        <source>Commit</source>
-        <translation>提交</translation>
+        <source>Version</source>
+        <translation>版本</translation>
     </message>
     <message>
         <source>GitHub repository</source>

--- a/include/updater.h
+++ b/include/updater.h
@@ -41,6 +41,7 @@ public:
     Q_INVOKABLE QString getQtVersion() const;
     Q_INVOKABLE QString getCommitHash() const;
     Q_INVOKABLE QString getHeadsetControlCommitHash() const;
+    Q_INVOKABLE QString getHeadsetControlVersion() const;
     Q_INVOKABLE QString getBuildTimestamp() const;
 
     bool updateAvailable() const { return m_updateAvailable; }

--- a/qml/SettingsPane/HeadsetControlPane.qml
+++ b/qml/SettingsPane/HeadsetControlPane.qml
@@ -305,11 +305,11 @@ ColumnLayout {
                 Card {
                     visible: UserSettings.headsetcontrolMonitoring
                     Layout.fillWidth: true
-                    title: qsTr("Commit")
+                    title: qsTr("Version")
                     description: ""
 
                     additionalControl: Label {
-                        text: Updater.getHeadsetControlCommitHash()
+                        text: Updater.getHeadsetControlVersion()
                         opacity: 0.5
                     }
                 }

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -13,6 +13,8 @@
 #include <QTimeZone>
 #include <QUrl>
 #include <QDebug>
+#include <headsetcontrol.hpp>
+#include <string>
 #include "version.h"
 #include "logmanager.h"
 #include "languages.h"
@@ -661,6 +663,11 @@ QString Updater::getCommitHash() const
 QString Updater::getHeadsetControlCommitHash() const
 {
     return QString(HEADSETCONTROL_GIT_COMMIT_HASH);
+}
+
+QString Updater::getHeadsetControlVersion() const
+{
+    return QString::fromStdString(std::string(headsetcontrol::version()));
 }
 
 QString Updater::getBuildTimestamp() const


### PR DESCRIPTION
This enhancement improves user clarity by displaying the `headsetcontrol` library's semantic version in the UI, replacing the less descriptive Git commit hash. Presenting the library version provides more meaningful information to users about the specific build of the underlying `headsetcontrol` dependency.

**Key Changes:**
- Introduces a new `getHeadsetControlVersion()` method in the `Updater` class to retrieve the `headsetcontrol` library's semantic version string.
- Updates the QML "HeadsetControlPane" to use the new `getHeadsetControlVersion()` method for its display and changes the associated label from "Commit" to "Version".
- Modifies all internationalization `.ts` files to reflect the translation of "Commit" to "Version" across supported languages.

**Breaking Changes:**
None. This change is additive and modifies existing display logic without introducing breaking API changes.

**Review Focus:**
- Verification that the correct `headsetcontrol` library version is accurately displayed in the UI.
- Confirmation of correct localization for the "Version" string in all updated translation files.