### PR TITLE
Improve media artwork display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 1.20.2 LANGUAGES C CXX)
+project(QontrolPanel VERSION 1.21.0 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.FluentWinUI3
+import QtQuick.Controls.impl
 import ChrisLauinger77.QontrolPanel
 
 ColumnLayout {
@@ -16,9 +17,44 @@ ColumnLayout {
     }
 
     ColumnLayout {
+        Layout.fillWidth: true
+
         RowLayout {
             id: infosLyt
+            Layout.fillWidth: true
+            spacing: 10
+
+            Rectangle {
+                Layout.preferredWidth: 64
+                Layout.preferredHeight: 64
+                Layout.alignment: Qt.AlignVCenter
+                color: "#2a2a2a"
+                radius: 3
+
+                Image {
+                    anchors.fill: parent
+                    anchors.margins: 2
+                    source: MediaSessionBridge.mediaArt || ""
+                    fillMode: Image.PreserveAspectCrop
+                    visible: MediaSessionBridge.mediaArt !== ""
+                    smooth: true
+                }
+
+                IconImage {
+                    anchors.centerIn: parent
+                    source: "qrc:/icons/music.svg"
+                    sourceSize.width: 24
+                    sourceSize.height: 24
+                    color: palette.text
+                    opacity: 0.3
+                    visible: MediaSessionBridge.mediaArt === ""
+                }
+            }
+
             ColumnLayout {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignVCenter
+
                 Label {
                     text: MediaSessionBridge.mediaTitle || ""
                     font.pixelSize: 14
@@ -34,14 +70,6 @@ ColumnLayout {
                     elide: Text.ElideRight
                     Layout.fillWidth: true
                 }
-            }
-            Image {
-                Layout.preferredWidth: 64
-                Layout.preferredHeight: 64
-                Layout.alignment: Qt.AlignVCenter
-                source: MediaSessionBridge.mediaArt || ""
-                fillMode: Image.PreserveAspectCrop
-                visible: MediaSessionBridge.mediaArt !== ""
             }
         }
 

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -28,7 +28,7 @@ ColumnLayout {
                 Layout.preferredWidth: 64
                 Layout.preferredHeight: 64
                 Layout.alignment: Qt.AlignVCenter
-                color: "#2a2a2a"
+                color: Constants.cardColor
                 radius: 3
 
                 Image {


### PR DESCRIPTION
## Summary

- add a framed media artwork area to the media flyout
- show a music icon placeholder when artwork is unavailable
- let the media information layout fill the available width

## Why

The media flyout previously hid its artwork area entirely when a session had no artwork, leaving the layout visually inconsistent. The placeholder keeps the media information presentation stable and makes the empty-artwork state clear.

## Validation

- `git -c core.whitespace=cr-at-eol diff --cached --check`
- verified the branch is clean and synchronized with `origin`

Windows/Qt runtime validation was not available in the local Linux environment.
