### PR TITLE
Add Windows 11 acrylic backdrops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SOURCES
     src/languagebridge.cpp
     src/keyboardshortcutmanager.cpp
     src/trayiconprovider.cpp
+    src/windowsbackdrop.cpp
 )
 
 set(HEADERS
@@ -90,6 +91,7 @@ set(HEADERS
     include/languagebridge.h
     include/keyboardshortcutmanager.h
     include/trayiconprovider.h
+    include/windowsbackdrop.h
 )
 
 # Get git commit hash
@@ -232,6 +234,7 @@ target_link_libraries(QontrolPanel PRIVATE
     Wbemuuid
     Version
     Shell32
+    Dwmapi
 )
 
 target_compile_definitions(QontrolPanel PRIVATE

--- a/include/windowsbackdrop.h
+++ b/include/windowsbackdrop.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QtQml/qqmlregistration.h>
+
+class WindowsBackdrop : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+
+public:
+    explicit WindowsBackdrop(QObject* parent = nullptr);
+    ~WindowsBackdrop() override;
+
+    static WindowsBackdrop* create(QQmlEngine* qmlEngine, QJSEngine* jsEngine);
+    static WindowsBackdrop* instance();
+
+    Q_INVOKABLE bool applyTransientBackdrop(QObject* windowObject);
+    Q_INVOKABLE void removeBackdrop(QObject* windowObject);
+
+private:
+    static WindowsBackdrop* m_instance;
+};

--- a/qml/ChatMixNotification.qml
+++ b/qml/ChatMixNotification.qml
@@ -109,7 +109,8 @@ ApplicationWindow {
             notificationWindow.isAnimatingIn = true
             if (notificationWindow.nativeBackdropActive) {
                 notificationRect.opacity = 1
-            } else {
+            } else if (!contentOpacityAnimation.running && notificationRect.opacity < 1) {
+                contentOpacityAnimation.from = notificationRect.opacity
                 contentOpacityAnimation.start()
             }
         }
@@ -127,7 +128,9 @@ ApplicationWindow {
         easing.type: Easing.OutQuad
         onStarted: {
             notificationWindow.isAnimatingOut = true
-            if (!notificationWindow.nativeBackdropActive) {
+            if (!notificationWindow.nativeBackdropActive
+                    && !hideOpacityAnimation.running && notificationRect.opacity > 0) {
+                hideOpacityAnimation.from = notificationRect.opacity
                 hideOpacityAnimation.start()
             }
         }

--- a/qml/ChatMixNotification.qml
+++ b/qml/ChatMixNotification.qml
@@ -20,6 +20,7 @@ ApplicationWindow {
     property bool isMuted: false
     property bool chatMixEffectiveEnabled: false
     property bool nativeBackdropActive: false
+    property real restingY: 0
 
     transientParent: null
 
@@ -100,13 +101,17 @@ ApplicationWindow {
 
     PropertyAnimation {
         id: showAnimation
-        target: contentTransform
+        target: notificationWindow
         property: "y"
         duration: 300
         easing.type: Easing.OutQuad
         onStarted: {
             notificationWindow.isAnimatingIn = true
-            contentOpacityAnimation.start()
+            if (notificationWindow.nativeBackdropActive) {
+                notificationRect.opacity = 1
+            } else {
+                contentOpacityAnimation.start()
+            }
         }
         onFinished: {
             notificationWindow.isAnimatingIn = false
@@ -116,20 +121,20 @@ ApplicationWindow {
 
     PropertyAnimation {
         id: hideAnimation
-        target: contentTransform
+        target: notificationWindow
         property: "y"
         duration: 250
         easing.type: Easing.OutQuad
-        from: 0
-        to: -notificationWindow.height
         onStarted: {
             notificationWindow.isAnimatingOut = true
-            hideOpacityAnimation.start()
+            if (!notificationWindow.nativeBackdropActive) {
+                hideOpacityAnimation.start()
+            }
         }
         onFinished: {
             notificationWindow.visible = false
             notificationWindow.isAnimatingOut = false
-            contentTransform.y = -notificationWindow.height
+            notificationWindow.y = notificationWindow.restingY
         }
     }
 
@@ -151,12 +156,6 @@ ApplicationWindow {
         easing.type: Easing.InQuad
         from: 1
         to: 0
-    }
-
-    Translate {
-        id: contentTransform
-        x: 0
-        y: -notificationWindow.height
     }
 
     // Hidden measurement texts for all possible messages
@@ -196,34 +195,34 @@ ApplicationWindow {
     }
 
     function showNotification(text) {
-        if (visible || isAnimatingIn) {
+        if ((visible && !isAnimatingOut) || isAnimatingIn) {
             message = text
             autoHideTimer.restart()
             return
         }
 
         message = text
-        positionWindow()
-
         if (isAnimatingOut) {
+            const currentY = y
             hideAnimation.stop()
             hideOpacityAnimation.stop()
             isAnimatingOut = false
 
-            showAnimation.from = contentTransform.y
-            showAnimation.to = 0
+            showAnimation.from = currentY
+            showAnimation.to = restingY
 
-            let progress = Math.abs(contentTransform.y) / notificationWindow.height
+            let progress = Math.abs(currentY - restingY) / notificationWindow.height
             showAnimation.duration = Math.max(150, 300 * progress)
             showAnimation.start()
             return
         }
 
-        contentTransform.y = -notificationWindow.height
-        notificationRect.opacity = 0
+        positionWindow()
+        y = restingY - height
+        notificationRect.opacity = nativeBackdropActive ? 1 : 0
 
-        showAnimation.from = -notificationWindow.height
-        showAnimation.to = 0
+        showAnimation.from = y
+        showAnimation.to = restingY
         showAnimation.duration = 300
 
         visible = true
@@ -242,6 +241,8 @@ ApplicationWindow {
         }
 
         autoHideTimer.stop()
+        hideAnimation.from = y
+        hideAnimation.to = restingY - height
         hideAnimation.start()
     }
 
@@ -249,6 +250,7 @@ ApplicationWindow {
         const screenWidth = Utils.getAvailableDesktopWidth()
         x = (screenWidth - width) / 2
         y = UserSettings.panelPosition === 0 ? 60 : 12
+        restingY = y
     }
 
     Rectangle {
@@ -257,11 +259,6 @@ ApplicationWindow {
         color: notificationWindow.nativeBackdropActive ? "transparent" : Constants.panelColor
         radius: 5
         opacity: 0
-
-        transform: Translate {
-            x: contentTransform.x
-            y: contentTransform.y
-        }
 
         Rectangle {
             anchors.fill: parent

--- a/qml/ChatMixNotification.qml
+++ b/qml/ChatMixNotification.qml
@@ -19,6 +19,7 @@ ApplicationWindow {
     property string notificationType: "chatmix" // "chatmix" or "micmute"
     property bool isMuted: false
     property bool chatMixEffectiveEnabled: false
+    property bool nativeBackdropActive: false
 
     transientParent: null
 
@@ -37,6 +38,19 @@ ApplicationWindow {
 
     Component.onCompleted: {
         positionWindow()
+        updateNativeBackdrop()
+    }
+
+    function updateNativeBackdrop() {
+        nativeBackdropActive = WindowsBackdrop.applyTransientBackdrop(notificationWindow)
+    }
+
+    Connections {
+        target: Qt.application.styleHints
+
+        function onColorSchemeChanged() {
+            notificationWindow.updateNativeBackdrop()
+        }
     }
 
     Connections {
@@ -240,7 +254,7 @@ ApplicationWindow {
     Rectangle {
         id: notificationRect
         anchors.fill: parent
-        color: Constants.panelColor
+        color: notificationWindow.nativeBackdropActive ? "transparent" : Constants.panelColor
         radius: 5
         opacity: 0
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -32,9 +32,6 @@ ApplicationWindow {
 
     property bool isAnimatingIn: false
     property bool isAnimatingOut: false
-    property bool nativeBackdropActive: false
-    property real restingX: 0
-    property real restingY: 0
     property string taskbarPos: {
         switch (UserSettings.panelPosition) {
             case 0: return "top";
@@ -92,19 +89,6 @@ ApplicationWindow {
 
     Component.onCompleted: {
         Utils.setStyle(UserSettings.panelStyle)
-        updateNativeBackdrop()
-    }
-
-    function updateNativeBackdrop() {
-        nativeBackdropActive = WindowsBackdrop.applyTransientBackdrop(panel)
-    }
-
-    Connections {
-        target: Qt.application.styleHints
-
-        function onColorSchemeChanged() {
-            panel.updateNativeBackdrop()
-        }
     }
 
     PowerConfirmationWindow {
@@ -243,13 +227,13 @@ ApplicationWindow {
 
     onHeightChanged: {
         if (visible && !isAnimatingOut) {
-            repositionPanelAtTarget()
+            positionPanelAtTarget()
         }
     }
 
     PropertyAnimation {
         id: showAnimation
-        target: panel
+        target: contentTransform
         duration: 300
         easing.type: Easing.OutCubic
         onStarted: {
@@ -263,26 +247,19 @@ ApplicationWindow {
 
     PropertyAnimation {
         id: hideAnimation
-        target: panel
+        target: contentTransform
         duration: 300
         easing.type: Easing.InCubic
         onFinished: {
             panel.visible = false
             panel.isAnimatingOut = false
-            panel.x = panel.restingX
-            panel.y = panel.restingY
         }
     }
 
-    function showAnimationProgress() {
-        const currentPosition = showAnimation.property === "x" ? panel.x : panel.y
-        const totalDistance = Math.abs(showAnimation.to - showAnimation.from)
-        if (totalDistance <= 0) {
-            return 1
-        }
-
-        return Math.max(0, Math.min(1,
-                                    1 - Math.abs(showAnimation.to - currentPosition) / totalDistance))
+    Translate {
+        id: contentTransform
+        property real x: 0
+        property real y: 0
     }
 
     function togglePanel() {
@@ -295,7 +272,19 @@ ApplicationWindow {
             isAnimatingIn = false
             closeAllMenusAndCollapse()
 
-            const adjustedDuration = Math.max(50, Math.round(showAnimationProgress() * 300))
+            // Calculate progress and adjust hide animation duration
+            let progress = 0
+            if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
+                let initialOffset = Math.abs(showAnimation.from)
+                let currentOffset = Math.abs(contentTransform.x)
+                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
+            } else {
+                let initialOffset = Math.abs(showAnimation.from)
+                let currentOffset = Math.abs(contentTransform.y)
+                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
+            }
+
+            let adjustedDuration = Math.max(50, Math.round(progress * 300))
             hideAnimation.duration = adjustedDuration
             startHideAnimation()
             return
@@ -318,12 +307,11 @@ ApplicationWindow {
         panel.requestActivate()
 
         positionPanelAtTarget(true)
-        setInitialWindowPosition()
+        setInitialTransform()
 
         Qt.callLater(function() {
             Qt.callLater(function() {
                 positionPanelAtTarget()
-                setInitialWindowPosition()
 
                 Qt.callLater(panel.startAnimation)
             })
@@ -367,60 +355,31 @@ ApplicationWindow {
         const minY = screenY
         const maxY = Math.max(minY, screenY + screenHeight - panel.height)
 
-        restingX = Math.max(minX, Math.min(targetX, maxX))
-        restingY = Math.max(minY, Math.min(targetY, maxY))
-        panel.x = restingX
-        panel.y = restingY
+        panel.x = Math.max(minX, Math.min(targetX, maxX))
+        panel.y = Math.max(minY, Math.min(targetY, maxY))
     }
 
-    function repositionPanelAtTarget() {
-        const wasAnimatingIn = showAnimation.running
-        const currentX = panel.x
-        const currentY = panel.y
-
-        if (wasAnimatingIn) {
-            showAnimation.stop()
-        }
-
-        positionPanelAtTarget()
-
-        if (!wasAnimatingIn) {
-            return
-        }
-
-        if (animationProperty() === "x") {
-            panel.x = currentX
-            panel.y = restingY
-        } else {
-            panel.x = restingX
-            panel.y = currentY
-        }
-        startAnimation()
-    }
-
-    function animationProperty() {
-        return panel.taskbarPos === "left" || panel.taskbarPos === "right" ? "x" : "y"
-    }
-
-    function setInitialWindowPosition() {
-        panel.x = restingX
-        panel.y = restingY
-
+    function setInitialTransform() {
         switch (panel.taskbarPos) {
         case "top":
-            panel.y = restingY - panel.height
+            contentTransform.y = -cont.height
+            contentTransform.x = 0
             break
         case "bottom":
-            panel.y = restingY + panel.height
+            contentTransform.y = cont.height
+            contentTransform.x = 0
             break
         case "left":
-            panel.x = restingX - panel.width
+            contentTransform.x = -cont.width
+            contentTransform.y = 0
             break
         case "right":
-            panel.x = restingX + panel.width
+            contentTransform.x = cont.width
+            contentTransform.y = 0
             break
         default:
-            panel.y = restingY + panel.height
+            contentTransform.y = cont.height
+            contentTransform.x = 0
             break
         }
     }
@@ -428,9 +387,9 @@ ApplicationWindow {
     function startAnimation() {
         if (!isAnimatingIn) return
 
-        showAnimation.property = animationProperty()
-        showAnimation.from = showAnimation.property === "x" ? panel.x : panel.y
-        showAnimation.to = showAnimation.property === "x" ? restingX : restingY
+        showAnimation.properties = panel.taskbarPos === "left" || panel.taskbarPos === "right" ? "x" : "y"
+        showAnimation.from = panel.taskbarPos === "left" || panel.taskbarPos === "right" ? contentTransform.x : contentTransform.y
+        showAnimation.to = 0
         showAnimation.start()
     }
 
@@ -443,7 +402,19 @@ ApplicationWindow {
             showAnimation.stop()
             isAnimatingIn = false
 
-            const adjustedDuration = Math.max(50, Math.round(showAnimationProgress() * 300))
+            // Calculate progress and adjust hide animation duration
+            let progress = 0
+            if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
+                let initialOffset = Math.abs(showAnimation.from)
+                let currentOffset = Math.abs(contentTransform.x)
+                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
+            } else {
+                let initialOffset = Math.abs(showAnimation.from)
+                let currentOffset = Math.abs(contentTransform.y)
+                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
+            }
+
+            let adjustedDuration = Math.max(50, Math.round(progress * 300))
             hideAnimation.duration = adjustedDuration
         } else {
             hideAnimation.duration = 300
@@ -497,29 +468,29 @@ ApplicationWindow {
 
         switch (panel.taskbarPos) {
         case "top":
-            hideAnimation.property = "y"
-            hideAnimation.from = panel.y
-            hideAnimation.to = restingY - height
+            hideAnimation.properties = "y"
+            hideAnimation.from = contentTransform.y
+            hideAnimation.to = -height
             break
         case "bottom":
-            hideAnimation.property = "y"
-            hideAnimation.from = panel.y
-            hideAnimation.to = restingY + height
+            hideAnimation.properties = "y"
+            hideAnimation.from = contentTransform.y
+            hideAnimation.to = height
             break
         case "left":
-            hideAnimation.property = "x"
-            hideAnimation.from = panel.x
-            hideAnimation.to = restingX - width
+            hideAnimation.properties = "x"
+            hideAnimation.from = contentTransform.x
+            hideAnimation.to = -width
             break
         case "right":
-            hideAnimation.property = "x"
-            hideAnimation.from = panel.x
-            hideAnimation.to = restingX + width
+            hideAnimation.properties = "x"
+            hideAnimation.from = contentTransform.x
+            hideAnimation.to = width
             break
         default:
-            hideAnimation.property = "y"
-            hideAnimation.from = panel.y
-            hideAnimation.to = restingY + height
+            hideAnimation.properties = "y"
+            hideAnimation.from = contentTransform.y
+            hideAnimation.to = height
             break
         }
 
@@ -570,6 +541,11 @@ ApplicationWindow {
         anchors.top: UserSettings.panelPosition === 0 ? parent.top : undefined
         anchors.right: parent.right
         anchors.left: parent.left
+        transform: Translate {
+            x: contentTransform.x
+            y: contentTransform.y
+        }
+
         width: {
             let baseWidth = 360 + 30
             if (panel.taskbarPos === "left") {
@@ -628,7 +604,7 @@ ApplicationWindow {
                     id: mediaLayoutBackground
                     anchors.fill: mediaLayout
                     anchors.margins: -15
-                    color: panel.nativeBackdropActive ? "transparent" : Constants.panelColor
+                    color: Constants.panelColor
                     visible: mediaLayout.visible
                     radius: 12
                     opacity: 0
@@ -707,7 +683,7 @@ ApplicationWindow {
                     Rectangle {
                         anchors.fill: mainLayout
                         anchors.margins: -15
-                        color: panel.nativeBackdropActive ? "transparent" : Constants.panelColor
+                        color: Constants.panelColor
                         radius: 12
                         Rectangle {
                             anchors.fill: parent

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -32,6 +32,9 @@ ApplicationWindow {
 
     property bool isAnimatingIn: false
     property bool isAnimatingOut: false
+    property bool nativeBackdropActive: false
+    property real restingX: 0
+    property real restingY: 0
     property string taskbarPos: {
         switch (UserSettings.panelPosition) {
             case 0: return "top";
@@ -89,6 +92,19 @@ ApplicationWindow {
 
     Component.onCompleted: {
         Utils.setStyle(UserSettings.panelStyle)
+        updateNativeBackdrop()
+    }
+
+    function updateNativeBackdrop() {
+        nativeBackdropActive = WindowsBackdrop.applyTransientBackdrop(panel)
+    }
+
+    Connections {
+        target: Qt.application.styleHints
+
+        function onColorSchemeChanged() {
+            panel.updateNativeBackdrop()
+        }
     }
 
     PowerConfirmationWindow {
@@ -227,13 +243,13 @@ ApplicationWindow {
 
     onHeightChanged: {
         if (visible && !isAnimatingOut) {
-            positionPanelAtTarget()
+            repositionPanelAtTarget()
         }
     }
 
     PropertyAnimation {
         id: showAnimation
-        target: contentTransform
+        target: panel
         duration: 300
         easing.type: Easing.OutCubic
         onStarted: {
@@ -247,19 +263,26 @@ ApplicationWindow {
 
     PropertyAnimation {
         id: hideAnimation
-        target: contentTransform
+        target: panel
         duration: 300
         easing.type: Easing.InCubic
         onFinished: {
             panel.visible = false
             panel.isAnimatingOut = false
+            panel.x = panel.restingX
+            panel.y = panel.restingY
         }
     }
 
-    Translate {
-        id: contentTransform
-        property real x: 0
-        property real y: 0
+    function showAnimationProgress() {
+        const currentPosition = showAnimation.property === "x" ? panel.x : panel.y
+        const totalDistance = Math.abs(showAnimation.to - showAnimation.from)
+        if (totalDistance <= 0) {
+            return 1
+        }
+
+        return Math.max(0, Math.min(1,
+                                    1 - Math.abs(showAnimation.to - currentPosition) / totalDistance))
     }
 
     function togglePanel() {
@@ -272,19 +295,7 @@ ApplicationWindow {
             isAnimatingIn = false
             closeAllMenusAndCollapse()
 
-            // Calculate progress and adjust hide animation duration
-            let progress = 0
-            if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.x)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            } else {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.y)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            }
-
-            let adjustedDuration = Math.max(50, Math.round(progress * 300))
+            const adjustedDuration = Math.max(50, Math.round(showAnimationProgress() * 300))
             hideAnimation.duration = adjustedDuration
             startHideAnimation()
             return
@@ -307,11 +318,12 @@ ApplicationWindow {
         panel.requestActivate()
 
         positionPanelAtTarget(true)
-        setInitialTransform()
+        setInitialWindowPosition()
 
         Qt.callLater(function() {
             Qt.callLater(function() {
                 positionPanelAtTarget()
+                setInitialWindowPosition()
 
                 Qt.callLater(panel.startAnimation)
             })
@@ -355,31 +367,60 @@ ApplicationWindow {
         const minY = screenY
         const maxY = Math.max(minY, screenY + screenHeight - panel.height)
 
-        panel.x = Math.max(minX, Math.min(targetX, maxX))
-        panel.y = Math.max(minY, Math.min(targetY, maxY))
+        restingX = Math.max(minX, Math.min(targetX, maxX))
+        restingY = Math.max(minY, Math.min(targetY, maxY))
+        panel.x = restingX
+        panel.y = restingY
     }
 
-    function setInitialTransform() {
+    function repositionPanelAtTarget() {
+        const wasAnimatingIn = showAnimation.running
+        const currentX = panel.x
+        const currentY = panel.y
+
+        if (wasAnimatingIn) {
+            showAnimation.stop()
+        }
+
+        positionPanelAtTarget()
+
+        if (!wasAnimatingIn) {
+            return
+        }
+
+        if (animationProperty() === "x") {
+            panel.x = currentX
+            panel.y = restingY
+        } else {
+            panel.x = restingX
+            panel.y = currentY
+        }
+        startAnimation()
+    }
+
+    function animationProperty() {
+        return panel.taskbarPos === "left" || panel.taskbarPos === "right" ? "x" : "y"
+    }
+
+    function setInitialWindowPosition() {
+        panel.x = restingX
+        panel.y = restingY
+
         switch (panel.taskbarPos) {
         case "top":
-            contentTransform.y = -cont.height
-            contentTransform.x = 0
+            panel.y = restingY - panel.height
             break
         case "bottom":
-            contentTransform.y = cont.height
-            contentTransform.x = 0
+            panel.y = restingY + panel.height
             break
         case "left":
-            contentTransform.x = -cont.width
-            contentTransform.y = 0
+            panel.x = restingX - panel.width
             break
         case "right":
-            contentTransform.x = cont.width
-            contentTransform.y = 0
+            panel.x = restingX + panel.width
             break
         default:
-            contentTransform.y = cont.height
-            contentTransform.x = 0
+            panel.y = restingY + panel.height
             break
         }
     }
@@ -387,9 +428,9 @@ ApplicationWindow {
     function startAnimation() {
         if (!isAnimatingIn) return
 
-        showAnimation.properties = panel.taskbarPos === "left" || panel.taskbarPos === "right" ? "x" : "y"
-        showAnimation.from = panel.taskbarPos === "left" || panel.taskbarPos === "right" ? contentTransform.x : contentTransform.y
-        showAnimation.to = 0
+        showAnimation.property = animationProperty()
+        showAnimation.from = showAnimation.property === "x" ? panel.x : panel.y
+        showAnimation.to = showAnimation.property === "x" ? restingX : restingY
         showAnimation.start()
     }
 
@@ -402,19 +443,7 @@ ApplicationWindow {
             showAnimation.stop()
             isAnimatingIn = false
 
-            // Calculate progress and adjust hide animation duration
-            let progress = 0
-            if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.x)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            } else {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.y)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            }
-
-            let adjustedDuration = Math.max(50, Math.round(progress * 300))
+            const adjustedDuration = Math.max(50, Math.round(showAnimationProgress() * 300))
             hideAnimation.duration = adjustedDuration
         } else {
             hideAnimation.duration = 300
@@ -468,29 +497,29 @@ ApplicationWindow {
 
         switch (panel.taskbarPos) {
         case "top":
-            hideAnimation.properties = "y"
-            hideAnimation.from = contentTransform.y
-            hideAnimation.to = -height
+            hideAnimation.property = "y"
+            hideAnimation.from = panel.y
+            hideAnimation.to = restingY - height
             break
         case "bottom":
-            hideAnimation.properties = "y"
-            hideAnimation.from = contentTransform.y
-            hideAnimation.to = height
+            hideAnimation.property = "y"
+            hideAnimation.from = panel.y
+            hideAnimation.to = restingY + height
             break
         case "left":
-            hideAnimation.properties = "x"
-            hideAnimation.from = contentTransform.x
-            hideAnimation.to = -width
+            hideAnimation.property = "x"
+            hideAnimation.from = panel.x
+            hideAnimation.to = restingX - width
             break
         case "right":
-            hideAnimation.properties = "x"
-            hideAnimation.from = contentTransform.x
-            hideAnimation.to = width
+            hideAnimation.property = "x"
+            hideAnimation.from = panel.x
+            hideAnimation.to = restingX + width
             break
         default:
-            hideAnimation.properties = "y"
-            hideAnimation.from = contentTransform.y
-            hideAnimation.to = height
+            hideAnimation.property = "y"
+            hideAnimation.from = panel.y
+            hideAnimation.to = restingY + height
             break
         }
 
@@ -541,11 +570,6 @@ ApplicationWindow {
         anchors.top: UserSettings.panelPosition === 0 ? parent.top : undefined
         anchors.right: parent.right
         anchors.left: parent.left
-        transform: Translate {
-            x: contentTransform.x
-            y: contentTransform.y
-        }
-
         width: {
             let baseWidth = 360 + 30
             if (panel.taskbarPos === "left") {
@@ -604,7 +628,7 @@ ApplicationWindow {
                     id: mediaLayoutBackground
                     anchors.fill: mediaLayout
                     anchors.margins: -15
-                    color: Constants.panelColor
+                    color: panel.nativeBackdropActive ? "transparent" : Constants.panelColor
                     visible: mediaLayout.visible
                     radius: 12
                     opacity: 0
@@ -683,7 +707,7 @@ ApplicationWindow {
                     Rectangle {
                         anchors.fill: mainLayout
                         anchors.margins: -15
-                        color: Constants.panelColor
+                        color: panel.nativeBackdropActive ? "transparent" : Constants.panelColor
                         radius: 12
                         Rectangle {
                             anchors.fill: parent

--- a/qml/MediaOverlay.qml
+++ b/qml/MediaOverlay.qml
@@ -19,6 +19,8 @@ ApplicationWindow {
     property string previousArtist: ""
     property bool hasReceivedFirstUpdate: false
     property bool nativeBackdropActive: false
+    property real restingX: 0
+    property real restingY: 0
 
     transientParent: null
 
@@ -103,12 +105,16 @@ ApplicationWindow {
 
     PropertyAnimation {
         id: showAnimation
-        target: contentTransform
+        target: mediaOverlayWindow
         duration: 300
         easing.type: Easing.OutQuad
         onStarted: {
             mediaOverlayWindow.isAnimatingIn = true
-            contentOpacityAnimation.start()
+            if (mediaOverlayWindow.nativeBackdropActive) {
+                overlayRect.opacity = 1
+            } else {
+                contentOpacityAnimation.start()
+            }
         }
         onFinished: {
             mediaOverlayWindow.isAnimatingIn = false
@@ -118,17 +124,19 @@ ApplicationWindow {
 
     PropertyAnimation {
         id: hideAnimation
-        target: contentTransform
+        target: mediaOverlayWindow
         duration: 250
         easing.type: Easing.OutQuad
         onStarted: {
             mediaOverlayWindow.isAnimatingOut = true
-            hideOpacityAnimation.start()
+            if (!mediaOverlayWindow.nativeBackdropActive) {
+                hideOpacityAnimation.start()
+            }
         }
         onFinished: {
             mediaOverlayWindow.visible = false
             mediaOverlayWindow.isAnimatingOut = false
-            resetTransform()
+            resetWindowPosition()
         }
     }
 
@@ -152,34 +160,29 @@ ApplicationWindow {
         to: 0
     }
 
-    Translate {
-        id: contentTransform
-        x: 0
-        y: 0
-    }
-
     function showOverlay() {
-        if (visible || isAnimatingIn) {
+        if ((visible && !isAnimatingOut) || isAnimatingIn) {
             autoHideTimer.restart()
             return
         }
 
-        positionWindow()
-
         if (isAnimatingOut) {
+            const currentX = x
+            const currentY = y
             hideAnimation.stop()
             hideOpacityAnimation.stop()
             isAnimatingOut = false
 
-            animateFrom(contentTransform.x, contentTransform.y)
+            animateFrom(currentX, currentY)
             return
         }
 
-        setInitialTransform()
-        overlayRect.opacity = 0
+        positionWindow()
+        setInitialWindowPosition()
+        overlayRect.opacity = nativeBackdropActive ? 1 : 0
 
         visible = true
-        animateFrom(contentTransform.x, contentTransform.y)
+        animateFrom(x, y)
     }
 
     function hideOverlay() {
@@ -243,45 +246,46 @@ ApplicationWindow {
             y = taskbarOffset + margin
             break
         }
+
+        restingX = x
+        restingY = y
     }
 
-    function setInitialTransform() {
-        // Set initial transform based on position
+    function setInitialWindowPosition() {
+        x = restingX
+        y = restingY
+
         switch (UserSettings.mediaOverlayPosition) {
         case 0: // top-left
         case 1: // top-center
         case 2: // top-right
-            contentTransform.x = 0
-            contentTransform.y = -height
+            y = restingY - height
             break
         case 3: // left
-            contentTransform.x = -width
-            contentTransform.y = 0
+            x = restingX - width
             break
         case 4: // right
-            contentTransform.x = width
-            contentTransform.y = 0
+            x = restingX + width
             break
         case 5: // bottom-left
         case 6: // bottom-center
         case 7: // bottom-right
-            contentTransform.x = 0
-            contentTransform.y = height
+            y = restingY + height
             break
         }
     }
 
     function animateFrom(fromX, fromY) {
         showAnimation.property = getAnimationProperty()
-        showAnimation.from = getAnimationFrom()
-        showAnimation.to = 0
+        showAnimation.from = showAnimation.property === "x" ? fromX : fromY
+        showAnimation.to = showAnimation.property === "x" ? restingX : restingY
         showAnimation.start()
     }
 
     function animateToHide() {
         hideAnimation.property = getAnimationProperty()
-        hideAnimation.from = 0
-        hideAnimation.to = getAnimationTo()
+        hideAnimation.from = hideAnimation.property === "x" ? x : y
+        hideAnimation.to = getAnimationTarget()
     }
 
     function getAnimationProperty() {
@@ -300,30 +304,27 @@ ApplicationWindow {
         return "y"
     }
 
-    function getAnimationFrom() {
+    function getAnimationTarget() {
         switch (UserSettings.mediaOverlayPosition) {
         case 0: // top-left
         case 1: // top-center
         case 2: // top-right
-            return -height
+            return restingY - height
         case 3: // left
-            return -width
+            return restingX - width
         case 4: // right
-            return width
+            return restingX + width
         case 5: // bottom-left
         case 6: // bottom-center
         case 7: // bottom-right
-            return height
+            return restingY + height
         }
-        return -height
+        return restingY - height
     }
 
-    function getAnimationTo() {
-        return getAnimationFrom()
-    }
-
-    function resetTransform() {
-        setInitialTransform()
+    function resetWindowPosition() {
+        x = restingX
+        y = restingY
     }
 
     Rectangle {
@@ -332,11 +333,6 @@ ApplicationWindow {
         color: mediaOverlayWindow.nativeBackdropActive ? "transparent" : Constants.panelColor
         radius: 5
         opacity: 0
-
-        transform: Translate {
-            x: contentTransform.x
-            y: contentTransform.y
-        }
 
         Rectangle {
             anchors.fill: parent

--- a/qml/MediaOverlay.qml
+++ b/qml/MediaOverlay.qml
@@ -58,13 +58,13 @@ ApplicationWindow {
         target: UserSettings
 
         function onMediaOverlayPositionChanged() {
-            positionWindow()
+            repositionWindow()
         }
 
         function onMediaOverlaySizeChanged() {
             width = calculateWidth()
             height = calculateHeight()
-            positionWindow()
+            repositionWindow()
         }
     }
 
@@ -112,7 +112,8 @@ ApplicationWindow {
             mediaOverlayWindow.isAnimatingIn = true
             if (mediaOverlayWindow.nativeBackdropActive) {
                 overlayRect.opacity = 1
-            } else {
+            } else if (!contentOpacityAnimation.running && overlayRect.opacity < 1) {
+                contentOpacityAnimation.from = overlayRect.opacity
                 contentOpacityAnimation.start()
             }
         }
@@ -129,7 +130,9 @@ ApplicationWindow {
         easing.type: Easing.OutQuad
         onStarted: {
             mediaOverlayWindow.isAnimatingOut = true
-            if (!mediaOverlayWindow.nativeBackdropActive) {
+            if (!mediaOverlayWindow.nativeBackdropActive
+                    && !hideOpacityAnimation.running && overlayRect.opacity > 0) {
+                hideOpacityAnimation.from = overlayRect.opacity
                 hideOpacityAnimation.start()
             }
         }
@@ -249,6 +252,40 @@ ApplicationWindow {
 
         restingX = x
         restingY = y
+    }
+
+    function repositionWindow() {
+        const wasAnimatingIn = isAnimatingIn
+        const wasAnimatingOut = isAnimatingOut
+        const currentX = x
+        const currentY = y
+
+        if (wasAnimatingIn) {
+            showAnimation.stop()
+        } else if (wasAnimatingOut) {
+            hideAnimation.stop()
+        }
+
+        positionWindow()
+
+        if (!wasAnimatingIn && !wasAnimatingOut) {
+            return
+        }
+
+        if (getAnimationProperty() === "x") {
+            x = currentX
+            y = restingY
+        } else {
+            x = restingX
+            y = currentY
+        }
+
+        if (wasAnimatingIn) {
+            animateFrom(x, y)
+        } else {
+            animateToHide()
+            hideAnimation.start()
+        }
     }
 
     function setInitialWindowPosition() {

--- a/qml/MediaOverlay.qml
+++ b/qml/MediaOverlay.qml
@@ -18,6 +18,7 @@ ApplicationWindow {
     property string previousTitle: ""
     property string previousArtist: ""
     property bool hasReceivedFirstUpdate: false
+    property bool nativeBackdropActive: false
 
     transientParent: null
 
@@ -36,6 +37,19 @@ ApplicationWindow {
 
     Component.onCompleted: {
         positionWindow()
+        updateNativeBackdrop()
+    }
+
+    function updateNativeBackdrop() {
+        nativeBackdropActive = WindowsBackdrop.applyTransientBackdrop(mediaOverlayWindow)
+    }
+
+    Connections {
+        target: Qt.application.styleHints
+
+        function onColorSchemeChanged() {
+            mediaOverlayWindow.updateNativeBackdrop()
+        }
     }
 
     Connections {
@@ -315,7 +329,7 @@ ApplicationWindow {
     Rectangle {
         id: overlayRect
         anchors.fill: parent
-        color: Constants.panelColor
+        color: mediaOverlayWindow.nativeBackdropActive ? "transparent" : Constants.panelColor
         radius: 5
         opacity: 0
 

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -1,0 +1,134 @@
+#include "windowsbackdrop.h"
+
+#include "logmanager.h"
+
+#include <QGuiApplication>
+#include <QStyleHints>
+#include <QWindow>
+
+#include <windows.h>
+#include <dwmapi.h>
+
+namespace {
+constexpr char LogCategory[] = "WindowsBackdrop";
+
+QString formatHresult(HRESULT result)
+{
+    return QStringLiteral("0x%1")
+        .arg(static_cast<qulonglong>(static_cast<ULONG>(result)), 8, 16, QLatin1Char('0'));
+}
+
+QWindow* windowFromObject(QObject* windowObject)
+{
+    return qobject_cast<QWindow*>(windowObject);
+}
+}
+
+WindowsBackdrop* WindowsBackdrop::m_instance = nullptr;
+
+WindowsBackdrop::WindowsBackdrop(QObject* parent)
+    : QObject(parent)
+{
+}
+
+WindowsBackdrop::~WindowsBackdrop()
+{
+    if (m_instance == this) {
+        m_instance = nullptr;
+    }
+}
+
+WindowsBackdrop* WindowsBackdrop::create(QQmlEngine* qmlEngine, QJSEngine* jsEngine)
+{
+    Q_UNUSED(qmlEngine)
+    Q_UNUSED(jsEngine)
+
+    if (!m_instance) {
+        m_instance = new WindowsBackdrop();
+    }
+    return m_instance;
+}
+
+WindowsBackdrop* WindowsBackdrop::instance()
+{
+    return m_instance;
+}
+
+bool WindowsBackdrop::applyTransientBackdrop(QObject* windowObject)
+{
+    QWindow* window = windowFromObject(windowObject);
+    if (!window) {
+        LOG_WARN(LogCategory, "Cannot apply backdrop: object is not a window");
+        return false;
+    }
+
+    const HWND hwnd = reinterpret_cast<HWND>(window->winId());
+    if (!hwnd) {
+        LOG_WARN(LogCategory, "Cannot apply backdrop: native window handle is unavailable");
+        return false;
+    }
+
+    const BOOL useDarkMode = QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+    const HRESULT darkModeResult = DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_USE_IMMERSIVE_DARK_MODE,
+        &useDarkMode,
+        sizeof(useDarkMode));
+    if (FAILED(darkModeResult)) {
+        LOG_WARN(LogCategory,
+                 QString("Failed to update immersive dark mode: %1")
+                     .arg(formatHresult(darkModeResult)));
+    }
+
+    const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_TRANSIENTWINDOW;
+    const HRESULT backdropResult = DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_SYSTEMBACKDROP_TYPE,
+        &backdropType,
+        sizeof(backdropType));
+    if (FAILED(backdropResult)) {
+        LOG_WARN(LogCategory,
+                 QString("Failed to apply transient system backdrop: %1")
+                     .arg(formatHresult(backdropResult)));
+        return false;
+    }
+
+    const DWM_WINDOW_CORNER_PREFERENCE cornerPreference = DWMWCP_ROUND;
+    const HRESULT cornerResult = DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_WINDOW_CORNER_PREFERENCE,
+        &cornerPreference,
+        sizeof(cornerPreference));
+    if (FAILED(cornerResult)) {
+        LOG_WARN(LogCategory,
+                 QString("Failed to apply rounded window corners: %1")
+                     .arg(formatHresult(cornerResult)));
+    }
+
+    return true;
+}
+
+void WindowsBackdrop::removeBackdrop(QObject* windowObject)
+{
+    QWindow* window = windowFromObject(windowObject);
+    if (!window) {
+        return;
+    }
+
+    const HWND hwnd = reinterpret_cast<HWND>(window->winId());
+    if (!hwnd) {
+        return;
+    }
+
+    const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_NONE;
+    const HRESULT result = DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_SYSTEMBACKDROP_TYPE,
+        &backdropType,
+        sizeof(backdropType));
+    if (FAILED(result)) {
+        LOG_WARN(LogCategory,
+                 QString("Failed to remove system backdrop: %1")
+                     .arg(formatHresult(result)));
+    }
+}


### PR DESCRIPTION
## Summary

- add a QML singleton bridge for Windows DWM transient system backdrops
- use Desktop Acrylic for the media overlay and ChatMix/microphone notification
- preserve the existing solid QML color when DWM rejects the backdrop
- reapply dark/light mode and link against Dwmapi

## Scope

`Main.qml` is intentionally unchanged. Its single native window contains the media card, transparent spacing, the main panel, and outer animation margins. Applying a full-window DWM backdrop before Windows 11 visual validation could turn those transparent areas into one large acrylic rectangle.

## Validation

- `git -c core.whitespace=cr-at-eol diff --check`
- verified CMake source/header/link registrations
- verified behavior and availability against current Microsoft DWM documentation
- local build not run because this project targets Windows; GitHub Actions is the build validation path

## Windows follow-up

Use the CI artifact on Windows 11 build 22621+ to validate cool/warm wallpapers, transparency effects on/off, live light/dark switching, animation behavior, rounding, DPI, and multiple monitors. After that, test the main panel separately before deciding whether its surfaces need separate native windows.