### PR TITLE
Split main panel into acrylic windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ set(QML_FILES
     qml/SettingsWindow.qml
 
     qml/MediaFlyoutContent.qml
+    qml/MainMediaWindow.qml
     qml/IntroWindow.qml
     qml/DonatePopup.qml
     qml/ConfirmPowerActionDialog.qml

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ The first process creates `PanelEngine`, which:
 - loads the `ChrisLauinger77.QontrolPanel` QML module and `Main.qml`;
 - registers a tray icon image provider;
 - listens for single-instance messages through `QLocalServer`;
-- installs a Windows foreground-window event hook while the panel is visible so the panel can hide when focus moves elsewhere.
+- installs a Windows foreground-window event hook while the panel is visible so the panel can hide when focus moves outside its grouped native surfaces.
 
 The UI is QML-first. Native behavior enters QML through C++ classes marked with `QML_ELEMENT` and, for app-wide state, `QML_SINGLETON`.
 
@@ -38,7 +38,7 @@ The UI is QML-first. Native behavior enters QML through C++ classes marked with 
 
 ### Panel and Application Lifecycle
 
-- `PanelEngine` owns the QML engine and top-level panel window.
+- `PanelEngine` owns the QML engine and coordinates the main controls and media panel windows as one focus group.
 - `SystemTray.qml` and related tray icon support expose the app as a tray utility.
 - `StartupShortcutBridge` manages startup shortcut behavior.
 - `LanguageBridge` applies the selected Qt translation and asks the QML engine to retranslate.
@@ -118,7 +118,7 @@ qt_add_qml_module(QontrolPanel
 
 Most UI is organized as:
 
-- top-level surfaces: `Main.qml`, `SettingsWindow.qml`, `MediaOverlay.qml`, `PowerMenu.qml`;
+- top-level surfaces: `Main.qml`, `MainMediaWindow.qml`, `SettingsWindow.qml`, `MediaOverlay.qml`, `PowerMenu.qml`;
 - settings panes under `qml/SettingsPane/`;
 - shared controls under `qml/Common/`;
 - QML singletons under `qml/Singletons/`.

--- a/include/panelengine.h
+++ b/include/panelengine.h
@@ -25,11 +25,13 @@ private slots:
 private:
     QQmlApplicationEngine* engine;
     QWindow* panelWindow;
+    QWindow* mediaPanelWindow;
 
     void initializeQMLEngine();
     void destroyQMLEngine();
     void showPanel();
     void hidePanel();
+    bool isPanelWindow(HWND windowHandle) const;
 
     // Focus monitoring using Windows Event Hook
     void startFocusMonitoring();

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -234,6 +234,7 @@ ApplicationWindow {
 
     MainMediaWindow {
         id: mediaPanelWindow
+        transientParent: panel
 
         onAvailableChanged: panel.handleMediaAvailabilityChanged()
         onHideRequested: panel.hidePanel()

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -461,6 +461,7 @@ ApplicationWindow {
         resetWindowPositions()
         const verticalDistance = panel.height
                 + (mediaPanelWindow.available ? mediaPanelWindow.height + panelGap : 0)
+                + UserSettings.yAxisMargin
         const horizontalDistance = panel.width + UserSettings.xAxisMargin
 
         switch (panel.taskbarPos) {
@@ -573,6 +574,7 @@ ApplicationWindow {
         const propertyName = animationProperty()
         const verticalDistance = panel.height
                 + (mediaPanelWindow.available ? mediaPanelWindow.height + panelGap : 0)
+                + UserSettings.yAxisMargin
         const horizontalDistance = panel.width + UserSettings.xAxisMargin
 
         mainHideAnimation.property = propertyName

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -13,25 +13,19 @@ ApplicationWindow {
     visible: false
     flags: Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
     color: "#00000000"
-    width: {
-        let baseWidth = 360
-        if (panel.taskbarPos === "left") {
-            baseWidth += UserSettings.xAxisMargin
-        }
-        if (panel.taskbarPos === "top" || panel.taskbarPos === "bottom" || panel.taskbarPos === "right") {
-            if (panel.taskbarPos === "right") {
-                baseWidth += UserSettings.xAxisMargin
-            } else {
-                baseWidth += UserSettings.xAxisMargin
-            }
-        }
-
-        return baseWidth
-    }
-    height: Math.min(preferredPanelHeight(), maximumPanelHeight())
+    width: 360
+    height: Math.max(1, Math.min(preferredPanelHeight(), maximumPanelHeight()))
 
     property bool isAnimatingIn: false
     property bool isAnimatingOut: false
+    property bool nativeBackdropActive: false
+    property real restingX: 0
+    property real restingY: 0
+    property real mediaRestingX: 0
+    property real mediaRestingY: 0
+    property alias mediaSurfaceWindow: mediaPanelWindow
+    // Preserve the original 24px spacer after the media content's 15px outer inset.
+    readonly property real panelGap: 9
     property string taskbarPos: {
         switch (UserSettings.panelPosition) {
             case 0: return "top";
@@ -54,19 +48,15 @@ ApplicationWindow {
     }
 
     function maximumPanelHeight() {
-        return Math.max(1, targetScreenGeometry.height)
+        let reservedHeight = UserSettings.yAxisMargin
+        if (mediaPanelWindow.available) {
+            reservedHeight += mediaPanelWindow.height + panelGap
+        }
+        return Math.max(1, targetScreenGeometry.height - reservedHeight)
     }
 
     function preferredPanelHeight() {
-        let newHeight = contentFlickable.contentHeight
-        if (mediaLayout.visible) {
-            newHeight += mediaLayout.anchors.topMargin
-            newHeight += mediaLayout.implicitHeight
-            newHeight += spacer.height
-        }
-        newHeight += UserSettings.yAxisMargin
-
-        return newHeight
+        return contentFlickable.contentHeight
     }
 
     onVisibleChanged: {
@@ -89,6 +79,19 @@ ApplicationWindow {
 
     Component.onCompleted: {
         Utils.setStyle(UserSettings.panelStyle)
+        updateNativeBackdrop()
+    }
+
+    function updateNativeBackdrop() {
+        nativeBackdropActive = WindowsBackdrop.applyTransientBackdrop(panel)
+    }
+
+    Connections {
+        target: Qt.application.styleHints
+
+        function onColorSchemeChanged() {
+            panel.updateNativeBackdrop()
+        }
     }
 
     PowerConfirmationWindow {
@@ -109,6 +112,24 @@ ApplicationWindow {
 
     Connections {
         target: UserSettings
+        function onPanelPositionChanged() {
+            if (panel.visible) {
+                panel.repositionWindows()
+            }
+        }
+
+        function onXAxisMarginChanged() {
+            if (panel.visible) {
+                panel.repositionWindows()
+            }
+        }
+
+        function onYAxisMarginChanged() {
+            if (panel.visible) {
+                panel.repositionWindows()
+            }
+        }
+
         function onEnableMediaSessionManagerChanged() {
             if (UserSettings.enableMediaSessionManager) {
                 MediaSessionBridge.startMediaMonitoring()
@@ -211,6 +232,13 @@ ApplicationWindow {
 
     MediaOverlay {}
 
+    MainMediaWindow {
+        id: mediaPanelWindow
+
+        onAvailableChanged: panel.handleMediaAvailabilityChanged()
+        onHideRequested: panel.hidePanel()
+    }
+
     Timer {
         id: contentOpacityTimer
         interval: 160
@@ -222,20 +250,32 @@ ApplicationWindow {
         id: flyoutOpacityTimer
         interval: 160
         repeat: false
-        onTriggered: mediaLayout.opacity = 1
+        onTriggered: mediaPanelWindow.contentOpacity = 1
     }
 
     onHeightChanged: {
-        if (visible && !isAnimatingOut) {
-            positionPanelAtTarget()
+        if (visible) {
+            repositionWindows()
         }
     }
 
-    PropertyAnimation {
+    ParallelAnimation {
         id: showAnimation
-        target: contentTransform
-        duration: 300
-        easing.type: Easing.OutCubic
+
+        PropertyAnimation {
+            id: mainShowAnimation
+            target: panel
+            duration: 300
+            easing.type: Easing.OutCubic
+        }
+
+        PropertyAnimation {
+            id: mediaShowAnimation
+            target: mediaPanelWindow
+            duration: 300
+            easing.type: Easing.OutCubic
+        }
+
         onStarted: {
             contentOpacityTimer.start()
             flyoutOpacityTimer.start()
@@ -245,21 +285,44 @@ ApplicationWindow {
         }
     }
 
-    PropertyAnimation {
+    ParallelAnimation {
         id: hideAnimation
-        target: contentTransform
-        duration: 300
-        easing.type: Easing.InCubic
+
+        PropertyAnimation {
+            id: mainHideAnimation
+            target: panel
+            duration: 300
+            easing.type: Easing.InCubic
+        }
+
+        PropertyAnimation {
+            id: mediaHideAnimation
+            target: mediaPanelWindow
+            duration: 300
+            easing.type: Easing.InCubic
+        }
+
         onFinished: {
             panel.visible = false
+            mediaPanelWindow.visible = false
             panel.isAnimatingOut = false
+            panel.resetWindowPositions()
         }
     }
 
-    Translate {
-        id: contentTransform
-        property real x: 0
-        property real y: 0
+    function animationProperty() {
+        return panel.taskbarPos === "left" || panel.taskbarPos === "right" ? "x" : "y"
+    }
+
+    function showAnimationProgress() {
+        const currentPosition = mainShowAnimation.property === "x" ? panel.x : panel.y
+        const totalDistance = Math.abs(mainShowAnimation.to - mainShowAnimation.from)
+        if (totalDistance <= 0) {
+            return 1
+        }
+
+        return Math.max(0, Math.min(1,
+                                    1 - Math.abs(mainShowAnimation.to - currentPosition) / totalDistance))
     }
 
     function togglePanel() {
@@ -272,20 +335,8 @@ ApplicationWindow {
             isAnimatingIn = false
             closeAllMenusAndCollapse()
 
-            // Calculate progress and adjust hide animation duration
-            let progress = 0
-            if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.x)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            } else {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.y)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            }
-
-            let adjustedDuration = Math.max(50, Math.round(progress * 300))
-            hideAnimation.duration = adjustedDuration
+            const adjustedDuration = Math.max(50, Math.round(showAnimationProgress() * 300))
+            setHideDuration(adjustedDuration)
             startHideAnimation()
             return
         }
@@ -303,22 +354,24 @@ ApplicationWindow {
         }
 
         isAnimatingIn = true
+        positionWindowsAtTarget(true)
+        setInitialWindowPositions()
+
+        mediaPanelWindow.visible = mediaPanelWindow.available
         panel.visible = true
         panel.requestActivate()
 
-        positionPanelAtTarget(true)
-        setInitialTransform()
-
         Qt.callLater(function() {
             Qt.callLater(function() {
-                positionPanelAtTarget()
+                positionWindowsAtTarget()
+                setInitialWindowPositions()
 
                 Qt.callLater(panel.startAnimation)
             })
         })
     }
 
-    function positionPanelAtTarget(refreshGeometry) {
+    function positionWindowsAtTarget(refreshGeometry) {
         if (refreshGeometry) {
             refreshTargetScreenGeometry()
         }
@@ -328,58 +381,100 @@ ApplicationWindow {
         const screenWidth = targetScreenGeometry.width
         const screenHeight = targetScreenGeometry.height
 
-        let targetX = screenX + screenWidth - panel.width
-        let targetY = screenY + screenHeight - panel.height
+        const marginX = UserSettings.xAxisMargin
+        const marginY = UserSettings.yAxisMargin
 
-        switch (panel.taskbarPos) {
-        case "top":
-            targetX = screenX + screenWidth - panel.width
-            targetY = screenY
-            break
-        case "bottom":
-            targetX = screenX + screenWidth - panel.width
-            targetY = screenY + screenHeight - panel.height
-            break
-        case "left":
-            targetX = screenX
-            targetY = screenY + screenHeight - panel.height
-            break
-        case "right":
-            targetX = screenX + screenWidth - panel.width
-            targetY = screenY + screenHeight - panel.height
-            break
-        }
+        const targetX = panel.taskbarPos === "left"
+                ? screenX + marginX
+                : screenX + screenWidth - panel.width - marginX
+        restingX = Math.max(screenX,
+                            Math.min(targetX, screenX + screenWidth - panel.width))
+        restingY = panel.taskbarPos === "top"
+                ? screenY + marginY
+                  + (mediaPanelWindow.available ? mediaPanelWindow.height + panelGap : 0)
+                : screenY + screenHeight - panel.height - marginY
 
-        const minX = screenX
-        const maxX = Math.max(minX, screenX + screenWidth - panel.width)
-        const minY = screenY
-        const maxY = Math.max(minY, screenY + screenHeight - panel.height)
+        mediaRestingX = restingX
+        mediaRestingY = panel.taskbarPos === "top"
+                ? screenY + marginY
+                : restingY - mediaPanelWindow.height - panelGap
 
-        panel.x = Math.max(minX, Math.min(targetX, maxX))
-        panel.y = Math.max(minY, Math.min(targetY, maxY))
+        resetWindowPositions()
     }
 
-    function setInitialTransform() {
+    function resetWindowPositions() {
+        panel.x = restingX
+        panel.y = restingY
+        mediaPanelWindow.x = mediaRestingX
+        mediaPanelWindow.y = mediaRestingY
+    }
+
+    function repositionWindows() {
+        const wasAnimatingIn = showAnimation.running
+        const wasAnimatingOut = hideAnimation.running
+        const currentPanelX = panel.x
+        const currentPanelY = panel.y
+        const currentMediaX = mediaPanelWindow.x
+        const currentMediaY = mediaPanelWindow.y
+
+        if (wasAnimatingIn) {
+            showAnimation.stop()
+        } else if (wasAnimatingOut) {
+            hideAnimation.stop()
+        }
+
+        positionWindowsAtTarget()
+
+        if (!wasAnimatingIn && !wasAnimatingOut) {
+            return
+        }
+
+        if (animationProperty() === "x") {
+            panel.x = currentPanelX
+            panel.y = restingY
+            mediaPanelWindow.x = currentMediaX
+            mediaPanelWindow.y = mediaRestingY
+        } else {
+            panel.x = restingX
+            panel.y = currentPanelY
+            mediaPanelWindow.x = mediaRestingX
+            mediaPanelWindow.y = currentMediaY
+        }
+
+        if (wasAnimatingIn) {
+            startAnimation()
+        } else {
+            configureHideAnimation()
+            hideAnimation.start()
+        }
+    }
+
+    function setInitialWindowPositions() {
+        resetWindowPositions()
+        const verticalDistance = panel.height
+                + (mediaPanelWindow.available ? mediaPanelWindow.height + panelGap : 0)
+        const horizontalDistance = panel.width + UserSettings.xAxisMargin
+
         switch (panel.taskbarPos) {
         case "top":
-            contentTransform.y = -cont.height
-            contentTransform.x = 0
+            panel.y -= verticalDistance
+            mediaPanelWindow.y -= verticalDistance
             break
         case "bottom":
-            contentTransform.y = cont.height
-            contentTransform.x = 0
+            panel.y += verticalDistance
+            mediaPanelWindow.y += verticalDistance
             break
         case "left":
-            contentTransform.x = -cont.width
-            contentTransform.y = 0
+            panel.x -= horizontalDistance
+            mediaPanelWindow.x -= horizontalDistance
             break
         case "right":
-            contentTransform.x = cont.width
-            contentTransform.y = 0
+            panel.x += horizontalDistance
+            mediaPanelWindow.x += horizontalDistance
             break
         default:
-            contentTransform.y = cont.height
-            contentTransform.x = 0
+            panel.y += verticalDistance
+            mediaPanelWindow.y += verticalDistance
             break
         }
     }
@@ -387,9 +482,13 @@ ApplicationWindow {
     function startAnimation() {
         if (!isAnimatingIn) return
 
-        showAnimation.properties = panel.taskbarPos === "left" || panel.taskbarPos === "right" ? "x" : "y"
-        showAnimation.from = panel.taskbarPos === "left" || panel.taskbarPos === "right" ? contentTransform.x : contentTransform.y
-        showAnimation.to = 0
+        const propertyName = animationProperty()
+        mainShowAnimation.property = propertyName
+        mainShowAnimation.from = propertyName === "x" ? panel.x : panel.y
+        mainShowAnimation.to = propertyName === "x" ? restingX : restingY
+        mediaShowAnimation.property = propertyName
+        mediaShowAnimation.from = propertyName === "x" ? mediaPanelWindow.x : mediaPanelWindow.y
+        mediaShowAnimation.to = propertyName === "x" ? mediaRestingX : mediaRestingY
         showAnimation.start()
     }
 
@@ -402,22 +501,10 @@ ApplicationWindow {
             showAnimation.stop()
             isAnimatingIn = false
 
-            // Calculate progress and adjust hide animation duration
-            let progress = 0
-            if (panel.taskbarPos === "left" || panel.taskbarPos === "right") {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.x)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            } else {
-                let initialOffset = Math.abs(showAnimation.from)
-                let currentOffset = Math.abs(contentTransform.y)
-                progress = initialOffset > 0 ? (initialOffset - currentOffset) / initialOffset : 1
-            }
-
-            let adjustedDuration = Math.max(50, Math.round(progress * 300))
-            hideAnimation.duration = adjustedDuration
+            const adjustedDuration = Math.max(50, Math.round(showAnimationProgress() * 300))
+            setHideDuration(adjustedDuration)
         } else {
-            hideAnimation.duration = 300
+            setHideDuration(300)
         }
 
         closeAllMenusAndCollapse()
@@ -465,36 +552,58 @@ ApplicationWindow {
 
     function startHideAnimation() {
         isAnimatingOut = true
+        configureHideAnimation()
+        hideAnimation.start()
+    }
+
+    function setHideDuration(duration) {
+        mainHideAnimation.duration = duration
+        mediaHideAnimation.duration = duration
+    }
+
+    function configureHideAnimation() {
+        const propertyName = animationProperty()
+        const verticalDistance = panel.height
+                + (mediaPanelWindow.available ? mediaPanelWindow.height + panelGap : 0)
+        const horizontalDistance = panel.width + UserSettings.xAxisMargin
+
+        mainHideAnimation.property = propertyName
+        mainHideAnimation.from = propertyName === "x" ? panel.x : panel.y
+        mediaHideAnimation.property = propertyName
+        mediaHideAnimation.from = propertyName === "x" ? mediaPanelWindow.x : mediaPanelWindow.y
 
         switch (panel.taskbarPos) {
         case "top":
-            hideAnimation.properties = "y"
-            hideAnimation.from = contentTransform.y
-            hideAnimation.to = -height
+            mainHideAnimation.to = restingY - verticalDistance
+            mediaHideAnimation.to = mediaRestingY - verticalDistance
             break
         case "bottom":
-            hideAnimation.properties = "y"
-            hideAnimation.from = contentTransform.y
-            hideAnimation.to = height
+            mainHideAnimation.to = restingY + verticalDistance
+            mediaHideAnimation.to = mediaRestingY + verticalDistance
             break
         case "left":
-            hideAnimation.properties = "x"
-            hideAnimation.from = contentTransform.x
-            hideAnimation.to = -width
+            mainHideAnimation.to = restingX - horizontalDistance
+            mediaHideAnimation.to = mediaRestingX - horizontalDistance
             break
         case "right":
-            hideAnimation.properties = "x"
-            hideAnimation.from = contentTransform.x
-            hideAnimation.to = width
+            mainHideAnimation.to = restingX + horizontalDistance
+            mediaHideAnimation.to = mediaRestingX + horizontalDistance
             break
         default:
-            hideAnimation.properties = "y"
-            hideAnimation.from = contentTransform.y
-            hideAnimation.to = height
+            mainHideAnimation.to = restingY + verticalDistance
+            mediaHideAnimation.to = mediaRestingY + verticalDistance
             break
         }
+    }
 
-        hideAnimation.start()
+    function handleMediaAvailabilityChanged() {
+        if (!visible) {
+            mediaPanelWindow.visible = false
+            return
+        }
+
+        mediaPanelWindow.visible = mediaPanelWindow.available
+        repositionWindows()
     }
 
     function shouldShowSeparator(currentLayoutIndex) {
@@ -541,135 +650,28 @@ ApplicationWindow {
         anchors.top: UserSettings.panelPosition === 0 ? parent.top : undefined
         anchors.right: parent.right
         anchors.left: parent.left
-        transform: Translate {
-            x: contentTransform.x
-            y: contentTransform.y
-        }
-
-        width: {
-            let baseWidth = 360 + 30
-            if (panel.taskbarPos === "left") {
-                baseWidth += UserSettings.xAxisMargin + UserSettings.taskbarOffset
-            }
-            if (panel.taskbarPos === "top" || panel.taskbarPos === "bottom" || panel.taskbarPos === "right") {
-                if (panel.taskbarPos === "right") {
-                    baseWidth += UserSettings.xAxisMargin + UserSettings.taskbarOffset
-                } else {
-                    baseWidth += UserSettings.xAxisMargin
-                }
-            }
-            return baseWidth
-        }
 
         height: panel.height
 
         GridLayout {
             id: mainGrid
             anchors.fill: parent
-            columns: 3
-            rows: 3
+            columns: 1
+            rows: 1
             columnSpacing: 0
             rowSpacing: 0
-
-            PanelSpacer {
-                id: topSpacer
-                Layout.row: 0
-                Layout.column: 0
-                Layout.columnSpan: 3
-                Layout.fillWidth: true
-                Layout.preferredHeight: (panel.taskbarPos === "top") ? UserSettings.yAxisMargin : 0
-                visible: panel.taskbarPos === "top"
-                onClicked: panel.hidePanel()
-            }
-
-            PanelSpacer {
-                id: leftSpacer
-                Layout.row: 1
-                Layout.column: 0
-                Layout.fillHeight: true
-                Layout.preferredWidth: (panel.taskbarPos === "left") ? UserSettings.xAxisMargin : 0
-                visible: panel.taskbarPos === "left"
-                onClicked: panel.hidePanel()
-            }
 
             Item {
                 id: contentContainer
                 clip: true
-                Layout.row: 1
-                Layout.column: 1
+                Layout.row: 0
+                Layout.column: 0
                 Layout.fillHeight: true
                 Layout.preferredWidth: 360
 
-                Rectangle {
-                    id: mediaLayoutBackground
-                    anchors.fill: mediaLayout
-                    anchors.margins: -15
-                    color: Constants.panelColor
-                    visible: mediaLayout.visible
-                    radius: 12
-                    opacity: 0
-                    onVisibleChanged: {
-                        if (visible) {
-                            fadeInAnimation.start()
-                        } else {
-                            fadeOutAnimation.start()
-                        }
-                    }
-
-                    PropertyAnimation {
-                        id: fadeInAnimation
-                        target: mediaLayoutBackground
-                        property: "opacity"
-                        from: 0
-                        to: 1
-                        duration: 400
-                        easing.type: Easing.OutQuad
-                    }
-
-                    PropertyAnimation {
-                        id: fadeOutAnimation
-                        target: mediaLayoutBackground
-                        property: "opacity"
-                        from: 1
-                        to: 0
-                        duration: 400
-                        easing.type: Easing.OutQuad
-                    }
-
-                    Rectangle {
-                        anchors.fill: parent
-                        color: "#00000000"
-                        radius: 12
-                        border.width: 1
-                        border.color: "#E3E3E3"
-                        opacity: 0.2
-                    }
-                }
-
-                MediaFlyoutContent {
-                    id: mediaLayout
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.topMargin: 15
-                    anchors.leftMargin: 15
-                    anchors.rightMargin: 15
-                    anchors.bottomMargin: 0
-                    visible: UserSettings.enableMediaSessionManager && (MediaSessionBridge.mediaTitle !== "")
-                }
-
-                Item {
-                    id: spacer
-                    anchors.top: mediaLayout.bottom
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    height: 24
-                    visible: mediaLayout.visible
-                }
-
                 Flickable {
                     id: contentFlickable
-                    anchors.top: mediaLayout.visible ? spacer.bottom : parent.top
+                    anchors.top: parent.top
                     anchors.bottom: parent.bottom
                     anchors.left: parent.left
                     anchors.right: parent.right
@@ -683,7 +685,7 @@ ApplicationWindow {
                     Rectangle {
                         anchors.fill: mainLayout
                         anchors.margins: -15
-                        color: Constants.panelColor
+                        color: panel.nativeBackdropActive ? "transparent" : Constants.panelColor
                         radius: 12
                         Rectangle {
                             anchors.fill: parent
@@ -1207,38 +1209,6 @@ ApplicationWindow {
                 }
             }
 
-            PanelSpacer {
-                id: rightSpacer
-                Layout.row: 1
-                Layout.column: 2
-                Layout.fillHeight: true
-                Layout.preferredWidth: {
-                    if (panel.taskbarPos === "top" || panel.taskbarPos === "bottom" || panel.taskbarPos === "right") {
-                        return UserSettings.xAxisMargin
-                    } else {
-                        return 0
-                    }
-                }
-                visible: panel.taskbarPos === "top" || panel.taskbarPos === "bottom" || panel.taskbarPos === "right"
-                onClicked: panel.hidePanel()
-            }
-
-            PanelSpacer {
-                id: bottomSpacer
-                Layout.row: 2
-                Layout.column: 0
-                Layout.columnSpan: 3
-                Layout.fillWidth: true
-                Layout.preferredHeight: {
-                    if (panel.taskbarPos === "bottom" || panel.taskbarPos === "left" || panel.taskbarPos === "right") {
-                        return UserSettings.yAxisMargin
-                    } else {
-                        return 0
-                    }
-                }
-                visible: panel.taskbarPos === "bottom" || panel.taskbarPos === "left" || panel.taskbarPos === "right"
-                onClicked: panel.hidePanel()
-            }
         }
     }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -77,6 +77,13 @@ ApplicationWindow {
         }
     }
 
+    onClosing: function(close) {
+        if (visible) {
+            close.accepted = false
+            hidePanel()
+        }
+    }
+
     Component.onCompleted: {
         Utils.setStyle(UserSettings.panelStyle)
         updateNativeBackdrop()

--- a/qml/MainMediaWindow.qml
+++ b/qml/MainMediaWindow.qml
@@ -21,6 +21,13 @@ ApplicationWindow {
 
     Component.onCompleted: updateNativeBackdrop()
 
+    onClosing: function(close) {
+        if (visible) {
+            close.accepted = false
+            hideRequested()
+        }
+    }
+
     function updateNativeBackdrop() {
         nativeBackdropActive = WindowsBackdrop.applyTransientBackdrop(mediaPanelWindow)
     }

--- a/qml/MainMediaWindow.qml
+++ b/qml/MainMediaWindow.qml
@@ -1,0 +1,61 @@
+import QtQuick
+import QtQuick.Controls.FluentWinUI3
+import QtQuick.Window
+import ChrisLauinger77.QontrolPanel
+
+ApplicationWindow {
+    id: mediaPanelWindow
+    objectName: "mainMediaWindow"
+    width: 360
+    height: mediaContent.implicitHeight + 30
+    visible: false
+    flags: Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
+    color: "#00000000"
+    transientParent: null
+
+    readonly property bool available: UserSettings.enableMediaSessionManager
+                                      && MediaSessionBridge.mediaTitle !== ""
+    property bool nativeBackdropActive: false
+    property alias contentOpacity: mediaContent.opacity
+    signal hideRequested()
+
+    Component.onCompleted: updateNativeBackdrop()
+
+    function updateNativeBackdrop() {
+        nativeBackdropActive = WindowsBackdrop.applyTransientBackdrop(mediaPanelWindow)
+    }
+
+    Connections {
+        target: Qt.application.styleHints
+
+        function onColorSchemeChanged() {
+            mediaPanelWindow.updateNativeBackdrop()
+        }
+    }
+
+    Shortcut {
+        sequences: [StandardKey.Cancel]
+        onActivated: mediaPanelWindow.hideRequested()
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: mediaPanelWindow.nativeBackdropActive ? "transparent" : Constants.panelColor
+        radius: 12
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#00000000"
+            radius: 12
+            border.width: 1
+            border.color: "#E3E3E3"
+            opacity: 0.2
+        }
+    }
+
+    MediaFlyoutContent {
+        id: mediaContent
+        anchors.fill: parent
+        anchors.margins: 15
+    }
+}

--- a/src/panelengine.cpp
+++ b/src/panelengine.cpp
@@ -11,6 +11,7 @@
 #include <QQmlContext>
 #include <QTimer>
 #include <QFontMetrics>
+#include <QVariant>
 #include <Windows.h>
 #include <QProcess>
 
@@ -21,6 +22,7 @@ PanelEngine::PanelEngine(QWidget *parent)
     : QWidget(parent)
     , engine(nullptr)
     , panelWindow(nullptr)
+    , mediaPanelWindow(nullptr)
     , localServer(nullptr)
 {
     UserSettings::instance();
@@ -63,6 +65,11 @@ void PanelEngine::initializeQMLEngine()
     if (!engine->rootObjects().isEmpty()) {
         panelWindow = qobject_cast<QWindow*>(engine->rootObjects().constFirst());
         if (panelWindow) {
+            QObject* mediaWindowObject = panelWindow->property("mediaSurfaceWindow").value<QObject*>();
+            mediaPanelWindow = qobject_cast<QWindow*>(mediaWindowObject);
+            if (!mediaPanelWindow) {
+                qWarning() << "Main media panel window was not found";
+            }
             connect(panelWindow, &QWindow::visibleChanged,
                     this, &PanelEngine::onPanelVisibilityChanged);
         }
@@ -87,6 +94,17 @@ void PanelEngine::destroyQMLEngine()
         engine = nullptr;
     }
     panelWindow = nullptr;
+    mediaPanelWindow = nullptr;
+}
+
+bool PanelEngine::isPanelWindow(HWND windowHandle) const
+{
+    if (panelWindow && windowHandle == reinterpret_cast<HWND>(panelWindow->winId())) {
+        return true;
+    }
+
+    return mediaPanelWindow
+        && windowHandle == reinterpret_cast<HWND>(mediaPanelWindow->winId());
 }
 
 void PanelEngine::startFocusMonitoring()
@@ -120,9 +138,7 @@ void CALLBACK PanelEngine::WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event
     Q_UNUSED(dwmsEventTime)
 
     if (event == EVENT_SYSTEM_FOREGROUND && instance && instance->panelWindow && instance->isPanelVisible) {
-        HWND panelWindow = (HWND)instance->panelWindow->winId();
-
-        if (hwnd != panelWindow) {
+        if (!instance->isPanelWindow(hwnd)) {
             instance->stopFocusMonitoring();
             QMetaObject::invokeMethod(instance->panelWindow, "hidePanel");
         }


### PR DESCRIPTION
## Summary
- split the embedded media card from the main controls into its own exact-size native window
- apply the merged Windows Desktop Acrylic bridge independently to both card HWNDs with the existing solid fallback
- animate both native windows together and treat them as one focus group
- preserve the original screen margins and nine-pixel inter-card gap as real desktop space
- preserve Escape dismissal and dynamic media availability across the window split

## Validation
- static QML brace/reference validation and git diff checks pass locally
- CRLF line endings are preserved in the Windows/QML sources
- local Windows/Qt builds are unavailable in this workspace; GitHub CI is the build authority

## Windows manual checks
- verify both cards sample the desktop independently and the gap/margins remain fully transparent
- verify switching focus between media controls and the main panel does not dismiss either window
- verify clicks in the real gap/margins dismiss the panel through foreground-window monitoring
- verify show/hide and interrupted animations stay synchronized for all four taskbar positions
- verify media-session appearance/disappearance, light/dark changes, mixed DPI, and Windows 10 fallback behavior