### PR TITLE
Use activation-aware Windows material for Settings

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,6 +131,8 @@ QML should call C++ through bridge methods and properties rather than duplicatin
 
 The acrylic path is dispatcher-free and does not require the Windows App Runtime. This avoids coupling Qt's window lifecycle to CoreMessaging. If the compatibility API is unavailable, `WindowsBackdrop` uses the documented DWM transient system backdrop instead.
 
+The settings window uses the documented DWM main-window backdrop instead of the transient acrylic path. This gives the long-lived, activatable window Windows' Mica treatment, including the system-managed wallpaper tint while active and neutral appearance while inactive. Its setting cards use translucent layer fills so they remain distinct without hiding the material. If the main-window backdrop is unavailable, `WindowsBackdrop` falls back to the dispatcher-free acrylic material.
+
 ## Build and Deployment
 
 The app targets Windows with Qt 6 and the MSVC `v143` toolset. CI hosts that toolset on Visual Studio 2026. The CMake build:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,7 @@ QML should call C++ through bridge methods and properties rather than duplicatin
 
 The acrylic path is dispatcher-free and does not require the Windows App Runtime. This avoids coupling Qt's window lifecycle to CoreMessaging. If the compatibility API is unavailable, `WindowsBackdrop` uses the documented DWM transient system backdrop instead.
 
-The settings window uses the same dispatcher-free native acrylic mechanism with activation-aware presentation. While focused, the material retains the live desktop hue; while unfocused, QML paints the neutral panel surface used by Windows for inactive settings windows. Its setting cards use a single translucent layer fill so they remain distinct without hiding the material. If native acrylic is unavailable, the window stays on its opaque panel-color fallback.
+The settings window uses the same dispatcher-free native acrylic mechanism with activation-aware presentation. While focused, the material retains the live desktop hue; while unfocused, QML paints the neutral panel surface used by Windows for inactive settings windows. Activation changes recheck the native result so an enable-time failure retains the opaque fallback. Its setting cards use a single translucent layer fill so they remain distinct without hiding the material.
 
 ## Build and Deployment
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,7 @@ QML should call C++ through bridge methods and properties rather than duplicatin
 
 The acrylic path is dispatcher-free and does not require the Windows App Runtime. This avoids coupling Qt's window lifecycle to CoreMessaging. If the compatibility API is unavailable, `WindowsBackdrop` uses the documented DWM transient system backdrop instead.
 
-The settings window uses the documented DWM main-window backdrop instead of the transient acrylic path. This gives the long-lived, activatable window Windows' Mica treatment, including the system-managed wallpaper tint while active and neutral appearance while inactive. Its setting cards use translucent layer fills so they remain distinct without hiding the material. If the main-window backdrop is unavailable, `WindowsBackdrop` falls back to the dispatcher-free acrylic material.
+The settings window uses the same dispatcher-free native acrylic mechanism with activation-aware presentation. While focused, the material retains the live desktop hue; while unfocused, QML paints the neutral panel surface used by Windows for inactive settings windows. Its setting cards use a single translucent layer fill so they remain distinct without hiding the material. If native acrylic is unavailable, the window stays on its opaque panel-color fallback.
 
 ## Build and Deployment
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,7 @@ QML should call C++ through bridge methods and properties rather than duplicatin
 
 The acrylic path is dispatcher-free and does not require the Windows App Runtime. This avoids coupling Qt's window lifecycle to CoreMessaging. If the compatibility API is unavailable, `WindowsBackdrop` uses the documented DWM transient system backdrop instead.
 
-The settings window uses the same dispatcher-free native acrylic mechanism with activation-aware presentation. While focused, the material retains the live desktop hue; while unfocused, QML paints the neutral panel surface used by Windows for inactive settings windows. Activation changes recheck the native result so an enable-time failure retains the opaque fallback. Its setting cards use a single translucent layer fill so they remain distinct without hiding the material.
+The settings window uses the same dispatcher-free native acrylic mechanism with activation-aware presentation. Its framed native window extends the DWM frame through the Qt client area so transparent pixels resolve against the Windows material. While focused, the material retains the live desktop hue; while unfocused, QML paints the neutral panel surface used by Windows for inactive settings windows. Activation changes recheck DWM composition, the Windows transparency-effects setting, and the native result so unavailable effects or an enable-time failure retain the opaque fallback. Its setting cards use a single translucent layer fill so they remain distinct without hiding the material.
 
 ## Build and Deployment
 

--- a/include/windowsbackdrop.h
+++ b/include/windowsbackdrop.h
@@ -20,10 +20,13 @@ public:
     static WindowsBackdrop* instance();
 
     Q_INVOKABLE bool applyTransientBackdrop(QObject* windowObject);
+    Q_INVOKABLE bool applyMainWindowBackdrop(QObject* windowObject);
     Q_INVOKABLE void removeBackdrop(QObject* windowObject);
 
 private:
     struct Impl;
+
+    bool applyBackdrop(QObject* windowObject, bool mainWindow);
 
     static WindowsBackdrop* m_instance;
     std::unique_ptr<Impl> m_impl;

--- a/qml/Common/Card.qml
+++ b/qml/Common/Card.qml
@@ -24,7 +24,7 @@ Rectangle {
     property bool show: true
 
     implicitHeight: 70
-    color: materialColor
+    color: "transparent"
     radius: 5
 
     // Animate opacity and transform

--- a/qml/Common/Card.qml
+++ b/qml/Common/Card.qml
@@ -15,12 +15,16 @@ Rectangle {
     property int iconHeight: 24
     property color iconColor
     property bool imageMode: false
+    readonly property color materialColor: Qt.rgba(Constants.cardColor.r,
+                                                   Constants.cardColor.g,
+                                                   Constants.cardColor.b,
+                                                   0.72)
 
     // Use a custom property instead of visible
     property bool show: true
 
     implicitHeight: 70
-    color: Constants.cardColor
+    color: materialColor
     radius: 5
 
     // Animate opacity and transform
@@ -73,7 +77,7 @@ Rectangle {
     Rectangle {
         anchors.fill: parent
         border.width: 1
-        color: Constants.cardColor
+        color: card.materialColor
         border.color: Constants.cardBorderColor
         opacity: 1
         radius: 5

--- a/qml/DonatePopup.qml
+++ b/qml/DonatePopup.qml
@@ -8,6 +8,12 @@ Dialog {
     width: 380
     focus: true
     title: qsTr("Found this app useful?")
+
+    SystemPalette {
+        id: activeSystemPalette
+        colorGroup: SystemPalette.Active
+    }
+
     Label {
         anchors.fill: parent
         text: qsTr("This app is made with care by an independent developer and is not financed by ad revenue.\nIf you'd like to support my work, any contribution would be greatly appreciated!")
@@ -22,6 +28,11 @@ Dialog {
             icon.width: 16
             icon.height: 16
             highlighted: true
+            palette.accent: activeSystemPalette.highlight
+            palette.button: activeSystemPalette.highlight
+            palette.highlight: activeSystemPalette.highlight
+            palette.buttonText: activeSystemPalette.highlightedText
+            palette.highlightedText: activeSystemPalette.highlightedText
             DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
             onClicked: {
                 Qt.openUrlExternally("https://github.com/sponsors/ChrisLauinger77")

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -14,8 +14,24 @@ ApplicationWindow {
     visible: false
     transientParent: null
     title: qsTr("QontrolPanel - Settings")
+    color: nativeBackdropActive ? "transparent" : Constants.panelColor
 
     readonly property int maxSettingsPageIndex: 11
+    property bool nativeBackdropActive: false
+
+    Component.onCompleted: Qt.callLater(updateNativeBackdrop)
+
+    function updateNativeBackdrop() {
+        nativeBackdropActive = WindowsBackdrop.applyMainWindowBackdrop(root)
+    }
+
+    Connections {
+        target: Qt.application.styleHints
+
+        function onColorSchemeChanged() {
+            root.updateNativeBackdrop()
+        }
+    }
 
     function pageComponentForIndex(index) {
         switch (index) {

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -14,7 +14,7 @@ ApplicationWindow {
     visible: false
     transientParent: null
     title: qsTr("QontrolPanel - Settings")
-    color: nativeBackdropActive ? "transparent" : Constants.panelColor
+    color: nativeBackdropActive && active ? "transparent" : Constants.panelColor
 
     readonly property int maxSettingsPageIndex: 11
     property bool nativeBackdropActive: false

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -20,6 +20,7 @@ ApplicationWindow {
     property bool nativeBackdropActive: false
 
     Component.onCompleted: Qt.callLater(updateNativeBackdrop)
+    onActiveChanged: updateNativeBackdrop()
 
     function updateNativeBackdrop() {
         nativeBackdropActive = WindowsBackdrop.applyMainWindowBackdrop(root)

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -4,6 +4,7 @@
 
 #include <QGuiApplication>
 #include <QPointer>
+#include <QSettings>
 #include <QStyleHints>
 #include <QWindow>
 
@@ -36,6 +37,25 @@ QWindow* windowFromObject(QObject* windowObject)
 bool usesDarkTheme()
 {
     return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+}
+
+bool transparencyEffectsEnabled()
+{
+    BOOL compositionEnabled = FALSE;
+    if (FAILED(DwmIsCompositionEnabled(&compositionEnabled)) || !compositionEnabled) {
+        return false;
+    }
+
+    QSettings personalizeSettings(
+        QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"),
+        QSettings::NativeFormat);
+    if (personalizeSettings.value(QStringLiteral("EnableTransparency"), 1).toInt() == 0) {
+        return false;
+    }
+
+    DWORD colorizationColor = 0;
+    BOOL opaqueBlend = FALSE;
+    return FAILED(DwmGetColorizationColor(&colorizationColor, &opaqueBlend)) || !opaqueBlend;
 }
 
 struct AccentPolicy
@@ -109,6 +129,19 @@ bool applyDwmFallback(HWND hwnd)
     return true;
 }
 
+bool extendFrameIntoClientArea(HWND hwnd, bool enabled)
+{
+    const MARGINS margins = enabled ? MARGINS{-1, -1, -1, -1} : MARGINS{};
+    const HRESULT result = DwmExtendFrameIntoClientArea(hwnd, &margins);
+    if (FAILED(result)) {
+        LOG_WARN(LogCategory,
+                 QString("Failed to update client-area frame extension: %1")
+                     .arg(formatHresult(result)));
+        return false;
+    }
+    return true;
+}
+
 void clearDwmBackdrop(HWND hwnd)
 {
     const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_NONE;
@@ -161,12 +194,25 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     applyCommonDwmAttributes(hwnd);
 
     if (kind == BackdropKind::MainWindow) {
+        if (!transparencyEffectsEnabled() || !extendFrameIntoClientArea(hwnd, true)) {
+            applyWindowAcrylic(hwnd, false);
+            extendFrameIntoClientArea(hwnd, false);
+            return false;
+        }
+
         if (window->isActive()) {
-            return applyWindowAcrylic(hwnd, true);
+            const bool acrylicApplied = applyWindowAcrylic(hwnd, true);
+            if (!acrylicApplied) {
+                extendFrameIntoClientArea(hwnd, false);
+            }
+            return acrylicApplied;
         }
 
         const bool acrylicAvailable = applyWindowAcrylic(hwnd, true);
         applyWindowAcrylic(hwnd, false);
+        if (!acrylicAvailable) {
+            extendFrameIntoClientArea(hwnd, false);
+        }
         return acrylicAvailable;
     }
 
@@ -184,6 +230,7 @@ void clearMaterial(QWindow* window)
     }
 
     applyWindowAcrylic(hwnd, false);
+    extendFrameIntoClientArea(hwnd, false);
     clearDwmBackdrop(hwnd);
 }
 }

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -161,7 +161,13 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     applyCommonDwmAttributes(hwnd);
 
     if (kind == BackdropKind::MainWindow) {
-        return applyWindowAcrylic(hwnd, window->isActive());
+        if (window->isActive()) {
+            return applyWindowAcrylic(hwnd, true);
+        }
+
+        const bool acrylicAvailable = applyWindowAcrylic(hwnd, true);
+        applyWindowAcrylic(hwnd, false);
+        return acrylicAvailable;
     }
 
     if (applyWindowAcrylic(hwnd, true)) {
@@ -188,7 +194,6 @@ struct WindowsBackdrop::Impl
     {
         QPointer<QWindow> window;
         BackdropKind kind = BackdropKind::Transient;
-        QMetaObject::Connection activeConnection;
         QMetaObject::Connection visibleConnection;
         QMetaObject::Connection destroyedConnection;
     };
@@ -203,7 +208,6 @@ struct WindowsBackdrop::Impl
             return;
         }
 
-        QObject::disconnect(iterator->second->activeConnection);
         QObject::disconnect(iterator->second->visibleConnection);
         QObject::disconnect(iterator->second->destroyedConnection);
         if (resetMaterial && iterator->second->window) {
@@ -296,17 +300,6 @@ bool WindowsBackdrop::applyBackdrop(QObject* windowObject, bool mainWindow)
     auto trackedWindow = std::make_unique<Impl::TrackedWindow>();
     trackedWindow->window = window;
     trackedWindow->kind = kind;
-    trackedWindow->activeConnection = connect(
-        window,
-        &QWindow::activeChanged,
-        this,
-        [this, window]() {
-            const auto trackedWindow = m_impl->windows.find(window);
-            if (trackedWindow != m_impl->windows.end()
-                && trackedWindow->second->kind == BackdropKind::MainWindow) {
-                applyMaterial(window, trackedWindow->second->kind);
-            }
-        });
     trackedWindow->visibleConnection = connect(
         window,
         &QWindow::visibleChanged,

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -109,23 +109,6 @@ bool applyDwmFallback(HWND hwnd)
     return true;
 }
 
-bool applyDwmMainWindowBackdrop(HWND hwnd)
-{
-    const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_MAINWINDOW;
-    const HRESULT result = DwmSetWindowAttribute(
-        hwnd,
-        DWMWA_SYSTEMBACKDROP_TYPE,
-        &backdropType,
-        sizeof(backdropType));
-    if (FAILED(result)) {
-        LOG_WARN(LogCategory,
-                 QString("Failed to apply main-window backdrop: %1")
-                     .arg(formatHresult(result)));
-        return false;
-    }
-    return true;
-}
-
 void clearDwmBackdrop(HWND hwnd)
 {
     const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_NONE;
@@ -178,11 +161,7 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     applyCommonDwmAttributes(hwnd);
 
     if (kind == BackdropKind::MainWindow) {
-        applyWindowAcrylic(hwnd, false);
-        if (applyDwmMainWindowBackdrop(hwnd)) {
-            return true;
-        }
-        return applyWindowAcrylic(hwnd, true);
+        return applyWindowAcrylic(hwnd, window->isActive());
     }
 
     if (applyWindowAcrylic(hwnd, true)) {
@@ -209,6 +188,7 @@ struct WindowsBackdrop::Impl
     {
         QPointer<QWindow> window;
         BackdropKind kind = BackdropKind::Transient;
+        QMetaObject::Connection activeConnection;
         QMetaObject::Connection visibleConnection;
         QMetaObject::Connection destroyedConnection;
     };
@@ -223,6 +203,7 @@ struct WindowsBackdrop::Impl
             return;
         }
 
+        QObject::disconnect(iterator->second->activeConnection);
         QObject::disconnect(iterator->second->visibleConnection);
         QObject::disconnect(iterator->second->destroyedConnection);
         if (resetMaterial && iterator->second->window) {
@@ -315,6 +296,17 @@ bool WindowsBackdrop::applyBackdrop(QObject* windowObject, bool mainWindow)
     auto trackedWindow = std::make_unique<Impl::TrackedWindow>();
     trackedWindow->window = window;
     trackedWindow->kind = kind;
+    trackedWindow->activeConnection = connect(
+        window,
+        &QWindow::activeChanged,
+        this,
+        [this, window]() {
+            const auto trackedWindow = m_impl->windows.find(window);
+            if (trackedWindow != m_impl->windows.end()
+                && trackedWindow->second->kind == BackdropKind::MainWindow) {
+                applyMaterial(window, trackedWindow->second->kind);
+            }
+        });
     trackedWindow->visibleConnection = connect(
         window,
         &QWindow::visibleChanged,
@@ -336,7 +328,7 @@ bool WindowsBackdrop::applyBackdrop(QObject* windowObject, bool mainWindow)
 
     LOG_INFO(LogCategory,
              kind == BackdropKind::MainWindow
-                 ? "Applied Windows main-window backdrop material"
+                 ? "Applied activation-aware Windows acrylic material"
                  : "Applied dispatcher-free Windows acrylic material");
     return true;
 }

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -16,6 +16,12 @@
 namespace {
 constexpr char LogCategory[] = "WindowsBackdrop";
 
+enum class BackdropKind
+{
+    Transient,
+    MainWindow,
+};
+
 QString formatHresult(HRESULT result)
 {
     return QStringLiteral("0x%1")
@@ -103,6 +109,38 @@ bool applyDwmFallback(HWND hwnd)
     return true;
 }
 
+bool applyDwmMainWindowBackdrop(HWND hwnd)
+{
+    const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_MAINWINDOW;
+    const HRESULT result = DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_SYSTEMBACKDROP_TYPE,
+        &backdropType,
+        sizeof(backdropType));
+    if (FAILED(result)) {
+        LOG_WARN(LogCategory,
+                 QString("Failed to apply main-window backdrop: %1")
+                     .arg(formatHresult(result)));
+        return false;
+    }
+    return true;
+}
+
+void clearDwmBackdrop(HWND hwnd)
+{
+    const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_NONE;
+    const HRESULT result = DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_SYSTEMBACKDROP_TYPE,
+        &backdropType,
+        sizeof(backdropType));
+    if (FAILED(result)) {
+        LOG_WARN(LogCategory,
+                 QString("Failed to remove system backdrop: %1")
+                     .arg(formatHresult(result)));
+    }
+}
+
 void applyCommonDwmAttributes(HWND hwnd)
 {
     const BOOL useDarkMode = usesDarkTheme();
@@ -130,7 +168,7 @@ void applyCommonDwmAttributes(HWND hwnd)
     }
 }
 
-bool applyMaterial(QWindow* window)
+bool applyMaterial(QWindow* window, BackdropKind kind)
 {
     const HWND hwnd = reinterpret_cast<HWND>(window->winId());
     if (!hwnd) {
@@ -138,6 +176,15 @@ bool applyMaterial(QWindow* window)
     }
 
     applyCommonDwmAttributes(hwnd);
+
+    if (kind == BackdropKind::MainWindow) {
+        applyWindowAcrylic(hwnd, false);
+        if (applyDwmMainWindowBackdrop(hwnd)) {
+            return true;
+        }
+        return applyWindowAcrylic(hwnd, true);
+    }
+
     if (applyWindowAcrylic(hwnd, true)) {
         return true;
     }
@@ -152,17 +199,7 @@ void clearMaterial(QWindow* window)
     }
 
     applyWindowAcrylic(hwnd, false);
-    const DWM_SYSTEMBACKDROP_TYPE backdropType = DWMSBT_NONE;
-    const HRESULT result = DwmSetWindowAttribute(
-        hwnd,
-        DWMWA_SYSTEMBACKDROP_TYPE,
-        &backdropType,
-        sizeof(backdropType));
-    if (FAILED(result)) {
-        LOG_WARN(LogCategory,
-                 QString("Failed to remove system backdrop: %1")
-                     .arg(formatHresult(result)));
-    }
+    clearDwmBackdrop(hwnd);
 }
 }
 
@@ -171,6 +208,7 @@ struct WindowsBackdrop::Impl
     struct TrackedWindow
     {
         QPointer<QWindow> window;
+        BackdropKind kind = BackdropKind::Transient;
         QMetaObject::Connection visibleConnection;
         QMetaObject::Connection destroyedConnection;
     };
@@ -208,7 +246,7 @@ WindowsBackdrop::WindowsBackdrop(QObject* parent)
             for (const auto& [window, trackedWindow] : m_impl->windows) {
                 Q_UNUSED(window)
                 if (trackedWindow->window) {
-                    applyMaterial(trackedWindow->window);
+                    applyMaterial(trackedWindow->window, trackedWindow->kind);
                 }
             }
         });
@@ -243,28 +281,50 @@ WindowsBackdrop* WindowsBackdrop::instance()
 
 bool WindowsBackdrop::applyTransientBackdrop(QObject* windowObject)
 {
+    return applyBackdrop(windowObject, false);
+}
+
+bool WindowsBackdrop::applyMainWindowBackdrop(QObject* windowObject)
+{
+    return applyBackdrop(windowObject, true);
+}
+
+bool WindowsBackdrop::applyBackdrop(QObject* windowObject, bool mainWindow)
+{
+    const BackdropKind kind =
+        mainWindow ? BackdropKind::MainWindow : BackdropKind::Transient;
     QWindow* window = windowFromObject(windowObject);
     if (!window) {
         LOG_WARN(LogCategory, "Cannot apply backdrop: object is not a window");
         return false;
     }
-    if (!applyMaterial(window)) {
+    const auto existingWindow = m_impl->windows.find(window);
+    if (existingWindow != m_impl->windows.end()
+        && existingWindow->second->kind != kind) {
+        clearMaterial(window);
+    }
+    if (!applyMaterial(window, kind)) {
         LOG_WARN(LogCategory, "Cannot apply backdrop: native material is unavailable");
         return false;
     }
-    if (m_impl->windows.contains(window)) {
+    if (existingWindow != m_impl->windows.end()) {
+        existingWindow->second->kind = kind;
         return true;
     }
 
     auto trackedWindow = std::make_unique<Impl::TrackedWindow>();
     trackedWindow->window = window;
+    trackedWindow->kind = kind;
     trackedWindow->visibleConnection = connect(
         window,
         &QWindow::visibleChanged,
         this,
-        [window](bool visible) {
+        [this, window](bool visible) {
             if (visible) {
-                applyMaterial(window);
+                const auto trackedWindow = m_impl->windows.find(window);
+                if (trackedWindow != m_impl->windows.end()) {
+                    applyMaterial(window, trackedWindow->second->kind);
+                }
             }
         });
     trackedWindow->destroyedConnection = connect(
@@ -274,7 +334,10 @@ bool WindowsBackdrop::applyTransientBackdrop(QObject* windowObject)
         [this, window]() { m_impl->remove(window, false); });
     m_impl->windows.emplace(window, std::move(trackedWindow));
 
-    LOG_INFO(LogCategory, "Applied dispatcher-free Windows acrylic material");
+    LOG_INFO(LogCategory,
+             kind == BackdropKind::MainWindow
+                 ? "Applied Windows main-window backdrop material"
+                 : "Applied dispatcher-free Windows acrylic material");
     return true;
 }
 


### PR DESCRIPTION
## Summary
- extend the DWM frame through the framed Qt Settings client area before enabling native acrylic
- apply the proven dispatcher-free Windows acrylic material while Settings is focused
- paint the neutral panel surface when Settings is unfocused, matching the Windows activation change
- use one translucent Settings card layer so the wallpaper tint remains visible without losing separation
- retain the opaque panel fallback when composition, Windows transparency effects, or acrylic is unavailable

## Runtime findings
The documented DWM main-window backdrop and the accent-policy call can return success in a VM without painting into an unextended framed Qt client area. The final implementation extends the native frame across the client area, rechecks capability on activation, and keeps QML opaque whenever the material cannot be used.

## Validation
- git diff whitespace check passed
- Windows build and runtime validation delegated to GitHub CI because this environment cannot build the Windows Qt application