### PR TITLE
Use frameless Mica for the Settings window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SOURCES
     src/keyboardshortcutmanager.cpp
     src/trayiconprovider.cpp
     src/windowsbackdrop.cpp
+    src/windowchrome.cpp
 )
 
 set(HEADERS
@@ -92,6 +93,7 @@ set(HEADERS
     include/keyboardshortcutmanager.h
     include/trayiconprovider.h
     include/windowsbackdrop.h
+    include/windowchrome.h
 )
 
 # Get git commit hash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 2.0.0 LANGUAGES C CXX)
+project(QontrolPanel VERSION 2.1.0 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,13 +125,15 @@ Most UI is organized as:
 
 QML should call C++ through bridge methods and properties rather than duplicating native logic.
 
-### Windows Acrylic Surfaces
+### Windows Backdrop Materials and Settings Chrome
 
 `WindowsBackdrop` owns the native material lifecycle for the main controls panel, its separate media card, `MediaOverlay`, and `ChatMixNotification`. It dynamically enables Windows' acrylic window accent policy on each exact-size Qt window, with a theme-aware translucent luminosity color that keeps the live desktop hue visible behind these non-activating tray surfaces. The material is reapplied when a window becomes visible or the system color scheme changes.
 
 The acrylic path is dispatcher-free and does not require the Windows App Runtime. This avoids coupling Qt's window lifecycle to CoreMessaging. If the compatibility API is unavailable, `WindowsBackdrop` uses the documented DWM transient system backdrop instead.
 
-The settings window requests the documented DWM main-window system backdrop (Mica) for its standard native title bar, matching the material intended for long-lived Windows settings surfaces. Qt Quick paints the client area with the neutral panel surface in both activation states because its decorated render surface does not expose the DWM backdrop through transparent pixels. Activation changes recheck High Contrast, DWM composition, the Windows transparency-effects setting, and the native result so unavailable effects retain the standard opaque title-bar fallback. Its setting cards use a single translucent layer fill so they remain distinct against the Windows Settings-style client surface.
+The settings window is a frameless transparent Qt window that requests the documented DWM main-window system backdrop (Mica), matching the material intended for long-lived Windows settings surfaces. `WindowChrome` owns its Windows native event handling and restores the expected move, resize, system-menu, minimize, maximize, title-bar double-click, and Snap Layout behavior. Closing the settings window, including through Alt+F4, hides the persistent QML window instead of destroying its HWND so this native chrome registration remains valid when the window is reopened.
+
+Mica is exposed through the transparent Qt client area when Windows accepts the backdrop request. Activation changes recheck High Contrast, DWM composition, the Windows transparency-effects setting, and the native result; unavailable effects retain the standard opaque `Constants.panelColor` fallback. DWM does not reliably retheme a visible Mica surface after a Qt application color-scheme change, so the settings window uses the correctly themed opaque fallback for the remainder of that visible session and retries Mica after the window is hidden and reopened. Its setting cards use a single translucent layer fill so they remain distinct against either surface.
 
 ## Build and Deployment
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -88,7 +88,7 @@ If running manually, close any already-running QontrolPanel instance first. The 
 cmake --install build --config Release
 ```
 
-The install step copies the executable, Qt runtime dependencies, QML dependencies, translations, and `hidapi.dll` when CMake can find it in the vcpkg installation. Native acrylic uses Windows APIs already provided by the operating system and does not require the Windows App Runtime.
+The install step copies the executable, Qt runtime dependencies, QML dependencies, translations, and `hidapi.dll` when CMake can find it in the vcpkg installation. Native acrylic and Mica use Windows APIs already provided by the operating system and do not require the Windows App Runtime.
 
 By default, this project sets:
 

--- a/include/windowchrome.h
+++ b/include/windowchrome.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QAbstractNativeEventFilter>
+#include <QObject>
+#include <QQmlEngine>
+#include <QtQml/qqmlregistration.h>
+
+#include <memory>
+
+class WindowChrome : public QObject, public QAbstractNativeEventFilter
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+    Q_PROPERTY(bool maximizeButtonHovered READ maximizeButtonHovered NOTIFY maximizeButtonHoveredChanged)
+    Q_PROPERTY(bool maximizeButtonPressed READ maximizeButtonPressed NOTIFY maximizeButtonPressedChanged)
+
+public:
+    explicit WindowChrome(QObject* parent = nullptr);
+    ~WindowChrome() override;
+
+    static WindowChrome* create(QQmlEngine* qmlEngine, QJSEngine* jsEngine);
+    static WindowChrome* instance();
+
+    bool maximizeButtonHovered() const;
+    bool maximizeButtonPressed() const;
+
+    Q_INVOKABLE bool installWindowChrome(
+        QObject* windowObject,
+        QObject* titleBarObject,
+        QObject* systemMenuObject,
+        QObject* minimizeButtonObject,
+        QObject* maximizeButtonObject,
+        QObject* closeButtonObject);
+    Q_INVOKABLE void removeWindowChrome(QObject* windowObject);
+
+    bool nativeEventFilter(
+        const QByteArray& eventType,
+        void* message,
+        qintptr* result) override;
+
+signals:
+    void maximizeButtonHoveredChanged();
+    void maximizeButtonPressedChanged();
+
+private:
+    struct Impl;
+
+    void setMaximizeButtonHovered(bool hovered);
+    void setMaximizeButtonPressed(bool pressed);
+
+    static WindowChrome* m_instance;
+    std::unique_ptr<Impl> m_impl;
+    bool m_maximizeButtonHovered = false;
+    bool m_maximizeButtonPressed = false;
+};

--- a/include/windowsbackdrop.h
+++ b/include/windowsbackdrop.h
@@ -21,7 +21,6 @@ public:
 
     Q_INVOKABLE bool applyTransientBackdrop(QObject* windowObject);
     Q_INVOKABLE bool applyMainWindowBackdrop(QObject* windowObject);
-    Q_INVOKABLE bool refreshMainWindowBackdrop(QObject* windowObject);
     Q_INVOKABLE void removeBackdrop(QObject* windowObject);
 
 private:

--- a/include/windowsbackdrop.h
+++ b/include/windowsbackdrop.h
@@ -21,6 +21,7 @@ public:
 
     Q_INVOKABLE bool applyTransientBackdrop(QObject* windowObject);
     Q_INVOKABLE bool applyMainWindowBackdrop(QObject* windowObject);
+    Q_INVOKABLE bool refreshMainWindowBackdrop(QObject* windowObject);
     Q_INVOKABLE void removeBackdrop(QObject* windowObject);
 
 private:

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -37,7 +37,15 @@ ApplicationWindow {
         target: Qt.application.styleHints
 
         function onColorSchemeChanged() {
-            root.updateNativeBackdrop()
+            // DWM coalesces an immediate Mica reset and reapply, leaving the
+            // old light material behind when Qt switches back to dark mode.
+            // Keep the client readable with the new opaque fallback for one
+            // event-loop turn, then create a fresh native material instance.
+            root.nativeBackdropActive = false
+            Qt.callLater(function () {
+                WindowsBackdrop.removeBackdrop(root)
+                Qt.callLater(root.updateNativeBackdrop)
+            })
         }
     }
 

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -10,7 +10,7 @@ ApplicationWindow {
     height: 617
     minimumHeight: 500
     width: 1100
-    minimumWidth: 500
+    minimumWidth: 1100
     visible: false
     transientParent: null
     flags: Qt.Window | Qt.FramelessWindowHint
@@ -27,6 +27,12 @@ ApplicationWindow {
     }
 
     Component.onCompleted: Qt.callLater(initializeNativeWindow)
+    onClosing: function(close) {
+        if (visible) {
+            close.accepted = false
+            hide()
+        }
+    }
     onActiveChanged: updateNativeBackdrop()
     onVisibleChanged: {
         if (visible) {

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -297,7 +297,12 @@ ApplicationWindow {
                     id: sidebarList
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    interactive: false
+                    clip: true
+                    interactive: contentHeight > height
+                    boundsBehavior: Flickable.StopAtBounds
+                    ScrollBar.vertical: ScrollBar {
+                        policy: ScrollBar.AsNeeded
+                    }
                     model: [
                         {
                             text: qsTr("General"),

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -5,9 +5,9 @@ import ChrisLauinger77.QontrolPanel
 ApplicationWindow {
     id: root
     height: 585
-    minimumHeight: 585
+    minimumHeight: 360
     width: 1100
-    minimumWidth: 1100
+    minimumWidth: 500
     visible: false
     transientParent: null
     flags: Qt.Window | Qt.FramelessWindowHint
@@ -20,7 +20,7 @@ ApplicationWindow {
         color: root.nativeBackdropActive ? "transparent" : Constants.panelColor
     }
 
-    Component.onCompleted: Qt.callLater(updateNativeBackdrop)
+    Component.onCompleted: Qt.callLater(initializeNativeWindow)
     onActiveChanged: updateNativeBackdrop()
     onVisibleChanged: {
         if (visible) {
@@ -38,6 +38,17 @@ ApplicationWindow {
 
     function updateNativeBackdrop() {
         nativeBackdropActive = WindowsBackdrop.applyMainWindowBackdrop(root)
+    }
+
+    function initializeNativeWindow() {
+        WindowChrome.installWindowChrome(
+                    root,
+                    titleBar,
+                    systemMenuButton,
+                    minimizeButton,
+                    maximizeButton,
+                    closeButton)
+        updateNativeBackdrop()
     }
 
     function showPrototype() {
@@ -59,10 +70,141 @@ ApplicationWindow {
         showPrototype()
     }
 
+    Item {
+        id: titleBar
+        z: 10
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 32
+
+        Item {
+            id: systemMenuButton
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            width: 42
+
+            Image {
+                anchors.centerIn: parent
+                width: 16
+                height: 16
+                source: "qrc:/icons/icon.png"
+                fillMode: Image.PreserveAspectFit
+            }
+        }
+
+        Label {
+            anchors.left: systemMenuButton.right
+            anchors.right: captionButtons.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: root.title
+            elide: Text.ElideRight
+            font.pixelSize: 12
+        }
+
+        Row {
+            id: captionButtons
+            anchors.top: parent.top
+            anchors.right: parent.right
+            height: parent.height
+
+            Item {
+                id: minimizeButton
+                width: 46
+                height: captionButtons.height
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: minimizeHover.hovered
+                           ? (Constants.darkMode
+                              ? Qt.rgba(1.0, 1.0, 1.0, 0.09)
+                              : Qt.rgba(0.0, 0.0, 0.0, 0.06))
+                           : "transparent"
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "\uE921"
+                    color: Constants.darkMode ? "white" : "black"
+                    font.family: "Segoe Fluent Icons"
+                    font.pixelSize: 10
+                }
+
+                HoverHandler {
+                    id: minimizeHover
+                }
+
+                TapHandler {
+                    onTapped: root.showMinimized()
+                }
+            }
+
+            Item {
+                id: maximizeButton
+                width: 46
+                height: captionButtons.height
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: WindowChrome.maximizeButtonPressed
+                           ? (Constants.darkMode
+                              ? Qt.rgba(1.0, 1.0, 1.0, 0.06)
+                              : Qt.rgba(0.0, 0.0, 0.0, 0.04))
+                           : WindowChrome.maximizeButtonHovered
+                             ? (Constants.darkMode
+                                ? Qt.rgba(1.0, 1.0, 1.0, 0.09)
+                                : Qt.rgba(0.0, 0.0, 0.0, 0.06))
+                             : "transparent"
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    text: root.visibility === Window.Maximized ? "\uE923" : "\uE922"
+                    color: Constants.darkMode ? "white" : "black"
+                    font.family: "Segoe Fluent Icons"
+                    font.pixelSize: 10
+                }
+            }
+
+            Item {
+                id: closeButton
+                width: 46
+                height: captionButtons.height
+
+                Rectangle {
+                    anchors.fill: parent
+                    color: closeTap.pressed ? "#a7190f"
+                                            : closeHover.hovered ? "#c42b1c"
+                                                                 : "transparent"
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    text: "\uE8BB"
+                    color: closeHover.hovered || closeTap.pressed
+                           ? "white"
+                           : Constants.darkMode ? "white" : "black"
+                    font.family: "Segoe Fluent Icons"
+                    font.pixelSize: 10
+                }
+
+                HoverHandler {
+                    id: closeHover
+                }
+
+                TapHandler {
+                    id: closeTap
+                    onTapped: root.close()
+                }
+            }
+        }
+    }
+
     Rectangle {
         anchors.centerIn: parent
         width: 520
-        height: 260
+        height: 220
         radius: 10
         color: Constants.darkMode ? Qt.rgba(0.16, 0.16, 0.16, 0.72)
                                   : Qt.rgba(1.0, 1.0, 1.0, 0.72)
@@ -75,7 +217,7 @@ ApplicationWindow {
 
             Label {
                 anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("Frameless Settings Mica proof")
+                text: qsTr("Frameless Settings chrome proof")
                 font.pixelSize: 24
                 font.weight: Font.DemiBold
             }
@@ -88,11 +230,6 @@ ApplicationWindow {
                 opacity: 0.8
             }
 
-            Button {
-                anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("Close")
-                onClicked: root.close()
-            }
         }
     }
 }

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -19,6 +19,7 @@ ApplicationWindow {
 
     readonly property int maxSettingsPageIndex: 11
     property bool nativeBackdropActive: false
+    property bool nativeBackdropSuppressed: false
     property int rowHeight: 35
 
     background: Rectangle {
@@ -30,6 +31,10 @@ ApplicationWindow {
     onVisibleChanged: {
         if (visible) {
             Qt.callLater(updateNativeBackdrop)
+        } else {
+            WindowsBackdrop.removeBackdrop(root)
+            nativeBackdropActive = false
+            nativeBackdropSuppressed = false
         }
     }
 
@@ -37,16 +42,19 @@ ApplicationWindow {
         target: Qt.application.styleHints
 
         function onColorSchemeChanged() {
-            // Keep the Qt client opaque while DWM recreates its Mica surface.
+            // DWM does not reliably retheme Mica on a visible Qt window.
+            // Keep this instance readable and retry after it is reopened.
+            root.nativeBackdropSuppressed = root.visible
             root.nativeBackdropActive = false
-            Qt.callLater(function () {
-                root.nativeBackdropActive
-                        = WindowsBackdrop.refreshMainWindowBackdrop(root)
-            })
+            WindowsBackdrop.removeBackdrop(root)
         }
     }
 
     function updateNativeBackdrop() {
+        if (!visible || nativeBackdropSuppressed) {
+            nativeBackdropActive = false
+            return
+        }
         nativeBackdropActive = WindowsBackdrop.applyMainWindowBackdrop(root)
     }
 

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -37,10 +37,12 @@ ApplicationWindow {
         target: Qt.application.styleHints
 
         function onColorSchemeChanged() {
-            // The native theme handler rebuilds the material. Keep the client
-            // opaque until that compositor refresh has completed.
+            // Keep the Qt client opaque while DWM recreates its Mica surface.
             root.nativeBackdropActive = false
-            Qt.callLater(root.updateNativeBackdrop)
+            Qt.callLater(function () {
+                root.nativeBackdropActive
+                        = WindowsBackdrop.refreshMainWindowBackdrop(root)
+            })
         }
     }
 

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -1,8 +1,5 @@
-pragma ComponentBehavior: Bound
-
-import QtQuick.Controls.FluentWinUI3
-import QtQuick.Layouts
 import QtQuick
+import QtQuick.Controls.FluentWinUI3
 import ChrisLauinger77.QontrolPanel
 
 ApplicationWindow {
@@ -13,21 +10,22 @@ ApplicationWindow {
     minimumWidth: 1100
     visible: false
     transientParent: null
+    flags: Qt.Window | Qt.FramelessWindowHint
     title: qsTr("QontrolPanel - Settings")
     color: "transparent"
 
-    background: Rectangle {
-        color: Constants.panelColor
-    }
-
-    readonly property int maxSettingsPageIndex: 11
     property bool nativeBackdropActive: false
+
+    background: Rectangle {
+        color: root.nativeBackdropActive ? "transparent" : Constants.panelColor
+    }
 
     Component.onCompleted: Qt.callLater(updateNativeBackdrop)
     onActiveChanged: updateNativeBackdrop()
-
-    function updateNativeBackdrop() {
-        nativeBackdropActive = WindowsBackdrop.applyMainWindowBackdrop(root)
+    onVisibleChanged: {
+        if (visible) {
+            Qt.callLater(updateNativeBackdrop)
+        }
     }
 
     Connections {
@@ -38,368 +36,62 @@ ApplicationWindow {
         }
     }
 
-    function pageComponentForIndex(index) {
-        switch (index) {
-        case 0:
-            return generalPaneComponent;
-        case 1:
-            return componentsPaneComponent;
-        case 2:
-            return appearancePaneComponent;
-        case 3:
-            return mediaOverlayPaneComponent;
-        case 4:
-            return commAppsPaneComponent;
-        case 5:
-            return shortcutsPaneComponent;
-        case 6:
-            return appHotkeysPaneComponent;
-        case 7:
-            return headsetControlPaneComponent;
-        case 8:
-            return deviceRenamingPaneComponent;
-        case 9:
-            return languagePaneComponent;
-        case 10:
-            return updatePaneComponent;
-        case 11:
-            return debugPaneComponent;
-        default:
-            return generalPaneComponent;
-        }
+    function updateNativeBackdrop() {
+        nativeBackdropActive = WindowsBackdrop.applyMainWindowBackdrop(root)
     }
 
-    function openPage(index, forceOpen) {
-        const safeIndex = Math.max(0, Math.min(index, maxSettingsPageIndex));
-        const component = pageComponentForIndex(safeIndex);
-        const shouldNavigate = forceOpen || sidebarList.currentIndex !== safeIndex || !stackView.currentItem;
-
-        sidebarList.currentIndex = safeIndex;
-
-        if (!shouldNavigate) {
-            return;
-        }
-
-        if (stackView.depth === 0) {
-            stackView.push(component);
-        } else {
-            stackView.replace(component);
-        }
+    function showPrototype() {
+        show()
+        raise()
+        requestActivate()
+        Qt.callLater(updateNativeBackdrop)
     }
 
     function showPreferredPane() {
-        show();
-        openPage(UserSettings.settingsStartupPage, true);
+        showPrototype()
     }
 
     function showUpdatePane() {
-        show();
-        openPage(10, true);
+        showPrototype()
     }
 
     function showHeadsetcontrolPane() {
-        show();
-        openPage(7, true);
+        showPrototype()
     }
 
-    property int rowHeight: 35
-
-    DonatePopup {
-        id: donatePopup
+    Rectangle {
         anchors.centerIn: parent
-    }
+        width: 520
+        height: 260
+        radius: 10
+        color: Constants.darkMode ? Qt.rgba(0.16, 0.16, 0.16, 0.72)
+                                  : Qt.rgba(1.0, 1.0, 1.0, 0.72)
+        border.color: Constants.darkMode ? Qt.rgba(1.0, 1.0, 1.0, 0.08)
+                                         : Qt.rgba(0.0, 0.0, 0.0, 0.08)
 
-    RowLayout {
-        anchors.fill: parent
-        anchors.margins: 15
-        spacing: 15
+        Column {
+            anchors.centerIn: parent
+            spacing: 16
 
-        Item {
-            Layout.preferredWidth: 200
-            Layout.preferredHeight: 35
-            Layout.fillHeight: true
-
-            ColumnLayout {
-                anchors.fill: parent
-                spacing: 10
-
-                ListView {
-                    id: sidebarList
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    interactive: false
-                    model: [
-                        {
-                            text: qsTr("General"),
-                            icon: "qrc:/icons/general.svg"
-                        },
-                        {
-                            text: qsTr("Components"),
-                            icon: "qrc:/icons/component.svg"
-                        },
-                        {
-                            text: qsTr("Appearance"),
-                            icon: "qrc:/icons/wand.svg"
-                        },
-                        {
-                            text: qsTr("Media Overlay"),
-                            icon: "qrc:/icons/music.svg"
-                        },
-                        {
-                            text: qsTr("ChatMix"),
-                            icon: "qrc:/icons/chatmix.svg"
-                        },
-                        {
-                            text: qsTr("Shortcuts"),
-                            icon: "qrc:/icons/keyboard.svg"
-                        },
-                        {
-                            text: qsTr("App Hotkeys"),
-                            icon: "qrc:/icons/panel_volume_66.svg"
-                        },
-                        {
-                            text: qsTr("HeadsetControl"),
-                            icon: "qrc:/icons/headsetcontrol.svg"
-                        },
-                        {
-                            text: qsTr("Renaming"),
-                            icon: "qrc:/icons/rename.svg"
-                        },
-                        {
-                            text: qsTr("Language"),
-                            icon: "qrc:/icons/language.svg"
-                        },
-                        {
-                            text: qsTr("Updates"),
-                            icon: "qrc:/icons/update.svg"
-                        },
-                        {
-                            text: qsTr("Debug"),
-                            icon: "qrc:/icons/chip.svg"
-                        }
-                    ]
-                    currentIndex: 0
-
-                    Connections {
-                        target: UserSettings
-
-                        function onLanguageIndexChanged() {
-                            Qt.callLater(function () {
-                                root.openPage(9, true);
-                            });
-                        }
-                    }
-
-                    delegate: ItemDelegate {
-                        id: del
-                        width: sidebarList.width
-                        height: 43
-                        spacing: 10
-                        required property var modelData
-                        required property int index
-
-                        highlighted: ListView.isCurrentItem
-                        icon.source: del.modelData.icon
-                        text: del.modelData.text
-                        icon.width: 18
-                        icon.height: 18
-                        opacity: text === qsTr("Debug") && !ListView.isCurrentItem ? 0.5 : 1
-                        onClicked: {
-                            root.openPage(index, false);
-                        }
-                    }
-                }
-
-                ItemDelegate {
-                    text: qsTr("Donate")
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 43
-                    spacing: 10
-                    icon.color: "#f05670"
-                    icon.source: "qrc:/icons/donate.svg"
-                    icon.width: 18
-                    icon.height: 18
-                    onClicked: donatePopup.open()
-                }
-            }
-        }
-
-        StackView {
-            id: stackView
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            initialItem: generalPaneComponent
-            readonly property bool settingsPageTransitionsEnabled: UserSettings.settingsAnimationsEnabled
-            readonly property int settingsPageFadeDuration: UserSettings.settingsAnimationsEnabled ? 150 : 0
-            readonly property int settingsPageSlideDuration: UserSettings.settingsAnimationsEnabled ? 300 : 0
-            readonly property real settingsPageSlideDistance: Math.min(32, stackView.width * 0.3)
-
-            popEnter: Transition {
-                enabled: stackView.settingsPageTransitionsEnabled
-
-                ParallelAnimation {
-                    NumberAnimation {
-                        property: "opacity"
-                        from: 0
-                        to: 1
-                        duration: stackView.settingsPageFadeDuration
-                        easing.type: Easing.InQuint
-                    }
-                    NumberAnimation {
-                        property: "x"
-                        from: (stackView.mirrored ? 1 : -1) * stackView.settingsPageSlideDistance
-                        to: 0
-                        duration: stackView.settingsPageSlideDuration
-                        easing.type: Easing.OutCubic
-                    }
-                }
+            Label {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Frameless Settings Mica proof")
+                font.pixelSize: 24
+                font.weight: Font.DemiBold
             }
 
-            pushEnter: Transition {
-                enabled: stackView.settingsPageTransitionsEnabled
-
-                ParallelAnimation {
-                    NumberAnimation {
-                        property: "opacity"
-                        from: 0
-                        to: 1
-                        duration: stackView.settingsPageFadeDuration
-                        easing.type: Easing.InQuint
-                    }
-                    NumberAnimation {
-                        property: "x"
-                        from: (stackView.mirrored ? -1 : 1) * stackView.settingsPageSlideDistance
-                        to: 0
-                        duration: stackView.settingsPageSlideDuration
-                        easing.type: Easing.OutCubic
-                    }
-                }
+            Label {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: root.nativeBackdropActive
+                      ? qsTr("Windows accepted the Mica backdrop request")
+                      : qsTr("Opaque fallback is active")
+                opacity: 0.8
             }
 
-            popExit: Transition {
-                enabled: stackView.settingsPageTransitionsEnabled
-
-                NumberAnimation {
-                    property: "opacity"
-                    from: 1
-                    to: 0
-                    duration: stackView.settingsPageFadeDuration
-                    easing.type: Easing.OutQuint
-                }
-            }
-
-            pushExit: Transition {
-                enabled: stackView.settingsPageTransitionsEnabled
-
-                NumberAnimation {
-                    property: "opacity"
-                    from: 1
-                    to: 0
-                    duration: stackView.settingsPageFadeDuration
-                    easing.type: Easing.OutQuint
-                }
-            }
-
-            replaceEnter: Transition {
-                enabled: stackView.settingsPageTransitionsEnabled
-
-                ParallelAnimation {
-                    NumberAnimation {
-                        property: "opacity"
-                        from: 0
-                        to: 1
-                        duration: stackView.settingsPageFadeDuration
-                        easing.type: Easing.InQuint
-                    }
-                    NumberAnimation {
-                        property: "x"
-                        from: (stackView.mirrored ? -1 : 1) * stackView.settingsPageSlideDistance
-                        to: 0
-                        duration: stackView.settingsPageSlideDuration
-                        easing.type: Easing.OutCubic
-                    }
-                }
-            }
-
-            replaceExit: Transition {
-                enabled: stackView.settingsPageTransitionsEnabled
-
-                ParallelAnimation {
-                    NumberAnimation {
-                        property: "opacity"
-                        from: 1
-                        to: 0
-                        duration: stackView.settingsPageFadeDuration
-                        easing.type: Easing.OutQuint
-                    }
-                    NumberAnimation {
-                        property: "x"
-                        from: 0
-                        to: (stackView.mirrored ? 1 : -1) * stackView.settingsPageSlideDistance
-                        duration: stackView.settingsPageSlideDuration
-                        easing.type: Easing.InCubic
-                    }
-                }
-            }
-
-            Component {
-                id: generalPaneComponent
-                GeneralPane {}
-            }
-
-            Component {
-                id: componentsPaneComponent
-                ComponentsPane {}
-            }
-
-            Component {
-                id: languagePaneComponent
-                LanguagePane {}
-            }
-
-            Component {
-                id: commAppsPaneComponent
-                CommAppsPane {}
-            }
-
-            Component {
-                id: shortcutsPaneComponent
-                ShortcutsPane {}
-            }
-
-            Component {
-                id: appHotkeysPaneComponent
-                AppHotkeysPane {}
-            }
-
-            Component {
-                id: appearancePaneComponent
-                AppearancePane {}
-            }
-
-            Component {
-                id: mediaOverlayPaneComponent
-                MediaOverlayPane {}
-            }
-
-            Component {
-                id: headsetControlPaneComponent
-                HeadsetControlPane {}
-            }
-
-            Component {
-                id: deviceRenamingPaneComponent
-                DeviceRenamingPane {}
-            }
-
-            Component {
-                id: updatePaneComponent
-                UpdatePane {}
-            }
-
-            Component {
-                id: debugPaneComponent
-                DebugPane {}
+            Button {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Close")
+                onClicked: root.close()
             }
         }
     }

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -1,11 +1,14 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls.FluentWinUI3
+import QtQuick.Layouts
 import ChrisLauinger77.QontrolPanel
 
 ApplicationWindow {
     id: root
-    height: 585
-    minimumHeight: 360
+    height: 617
+    minimumHeight: 500
     width: 1100
     minimumWidth: 500
     visible: false
@@ -14,7 +17,9 @@ ApplicationWindow {
     title: qsTr("QontrolPanel - Settings")
     color: "transparent"
 
+    readonly property int maxSettingsPageIndex: 11
     property bool nativeBackdropActive: false
+    property int rowHeight: 35
 
     background: Rectangle {
         color: root.nativeBackdropActive ? "transparent" : Constants.panelColor
@@ -51,23 +56,75 @@ ApplicationWindow {
         updateNativeBackdrop()
     }
 
-    function showPrototype() {
-        show()
-        raise()
-        requestActivate()
-        Qt.callLater(updateNativeBackdrop)
+    function pageComponentForIndex(index) {
+        switch (index) {
+        case 0:
+            return generalPaneComponent
+        case 1:
+            return componentsPaneComponent
+        case 2:
+            return appearancePaneComponent
+        case 3:
+            return mediaOverlayPaneComponent
+        case 4:
+            return commAppsPaneComponent
+        case 5:
+            return shortcutsPaneComponent
+        case 6:
+            return appHotkeysPaneComponent
+        case 7:
+            return headsetControlPaneComponent
+        case 8:
+            return deviceRenamingPaneComponent
+        case 9:
+            return languagePaneComponent
+        case 10:
+            return updatePaneComponent
+        case 11:
+            return debugPaneComponent
+        default:
+            return generalPaneComponent
+        }
+    }
+
+    function openPage(index, forceOpen) {
+        const safeIndex = Math.max(0, Math.min(index, maxSettingsPageIndex))
+        const component = pageComponentForIndex(safeIndex)
+        const shouldNavigate = forceOpen
+                || sidebarList.currentIndex !== safeIndex
+                || !stackView.currentItem
+
+        sidebarList.currentIndex = safeIndex
+        if (!shouldNavigate) {
+            return
+        }
+
+        if (stackView.depth === 0) {
+            stackView.push(component)
+        } else {
+            stackView.replace(component)
+        }
     }
 
     function showPreferredPane() {
-        showPrototype()
+        show()
+        openPage(UserSettings.settingsStartupPage, true)
+        raise()
+        requestActivate()
     }
 
     function showUpdatePane() {
-        showPrototype()
+        show()
+        openPage(10, true)
+        raise()
+        requestActivate()
     }
 
     function showHeadsetcontrolPane() {
-        showPrototype()
+        show()
+        openPage(7, true)
+        raise()
+        requestActivate()
     }
 
     Item {
@@ -201,35 +258,304 @@ ApplicationWindow {
         }
     }
 
-    Rectangle {
+    DonatePopup {
+        id: donatePopup
         anchors.centerIn: parent
-        width: 520
-        height: 220
-        radius: 10
-        color: Constants.darkMode ? Qt.rgba(0.16, 0.16, 0.16, 0.72)
-                                  : Qt.rgba(1.0, 1.0, 1.0, 0.72)
-        border.color: Constants.darkMode ? Qt.rgba(1.0, 1.0, 1.0, 0.08)
-                                         : Qt.rgba(0.0, 0.0, 0.0, 0.08)
+    }
 
-        Column {
-            anchors.centerIn: parent
-            spacing: 16
+    RowLayout {
+        anchors.top: titleBar.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 15
+        spacing: 15
 
-            Label {
-                anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("Frameless Settings chrome proof")
-                font.pixelSize: 24
-                font.weight: Font.DemiBold
+        Item {
+            Layout.preferredWidth: 200
+            Layout.preferredHeight: 35
+            Layout.fillHeight: true
+
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 10
+
+                ListView {
+                    id: sidebarList
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    interactive: false
+                    model: [
+                        {
+                            text: qsTr("General"),
+                            icon: "qrc:/icons/general.svg"
+                        },
+                        {
+                            text: qsTr("Components"),
+                            icon: "qrc:/icons/component.svg"
+                        },
+                        {
+                            text: qsTr("Appearance"),
+                            icon: "qrc:/icons/wand.svg"
+                        },
+                        {
+                            text: qsTr("Media Overlay"),
+                            icon: "qrc:/icons/music.svg"
+                        },
+                        {
+                            text: qsTr("ChatMix"),
+                            icon: "qrc:/icons/chatmix.svg"
+                        },
+                        {
+                            text: qsTr("Shortcuts"),
+                            icon: "qrc:/icons/keyboard.svg"
+                        },
+                        {
+                            text: qsTr("App Hotkeys"),
+                            icon: "qrc:/icons/panel_volume_66.svg"
+                        },
+                        {
+                            text: qsTr("HeadsetControl"),
+                            icon: "qrc:/icons/headsetcontrol.svg"
+                        },
+                        {
+                            text: qsTr("Renaming"),
+                            icon: "qrc:/icons/rename.svg"
+                        },
+                        {
+                            text: qsTr("Language"),
+                            icon: "qrc:/icons/language.svg"
+                        },
+                        {
+                            text: qsTr("Updates"),
+                            icon: "qrc:/icons/update.svg"
+                        },
+                        {
+                            text: qsTr("Debug"),
+                            icon: "qrc:/icons/chip.svg"
+                        }
+                    ]
+                    currentIndex: 0
+
+                    Connections {
+                        target: UserSettings
+
+                        function onLanguageIndexChanged() {
+                            Qt.callLater(function () {
+                                root.openPage(9, true)
+                            })
+                        }
+                    }
+
+                    delegate: ItemDelegate {
+                        id: del
+                        width: sidebarList.width
+                        height: 43
+                        spacing: 10
+                        required property var modelData
+                        required property int index
+
+                        highlighted: ListView.isCurrentItem
+                        icon.source: del.modelData.icon
+                        text: del.modelData.text
+                        icon.width: 18
+                        icon.height: 18
+                        opacity: text === qsTr("Debug") && !ListView.isCurrentItem ? 0.5 : 1
+                        onClicked: root.openPage(index, false)
+                    }
+                }
+
+                ItemDelegate {
+                    text: qsTr("Donate")
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 43
+                    spacing: 10
+                    icon.color: "#f05670"
+                    icon.source: "qrc:/icons/donate.svg"
+                    icon.width: 18
+                    icon.height: 18
+                    onClicked: donatePopup.open()
+                }
+            }
+        }
+
+        StackView {
+            id: stackView
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            initialItem: generalPaneComponent
+            readonly property bool settingsPageTransitionsEnabled: UserSettings.settingsAnimationsEnabled
+            readonly property int settingsPageFadeDuration: UserSettings.settingsAnimationsEnabled ? 150 : 0
+            readonly property int settingsPageSlideDuration: UserSettings.settingsAnimationsEnabled ? 300 : 0
+            readonly property real settingsPageSlideDistance: Math.min(32, stackView.width * 0.3)
+
+            popEnter: Transition {
+                enabled: stackView.settingsPageTransitionsEnabled
+
+                ParallelAnimation {
+                    NumberAnimation {
+                        property: "opacity"
+                        from: 0
+                        to: 1
+                        duration: stackView.settingsPageFadeDuration
+                        easing.type: Easing.InQuint
+                    }
+                    NumberAnimation {
+                        property: "x"
+                        from: (stackView.mirrored ? 1 : -1) * stackView.settingsPageSlideDistance
+                        to: 0
+                        duration: stackView.settingsPageSlideDuration
+                        easing.type: Easing.OutCubic
+                    }
+                }
             }
 
-            Label {
-                anchors.horizontalCenter: parent.horizontalCenter
-                text: root.nativeBackdropActive
-                      ? qsTr("Windows accepted the Mica backdrop request")
-                      : qsTr("Opaque fallback is active")
-                opacity: 0.8
+            pushEnter: Transition {
+                enabled: stackView.settingsPageTransitionsEnabled
+
+                ParallelAnimation {
+                    NumberAnimation {
+                        property: "opacity"
+                        from: 0
+                        to: 1
+                        duration: stackView.settingsPageFadeDuration
+                        easing.type: Easing.InQuint
+                    }
+                    NumberAnimation {
+                        property: "x"
+                        from: (stackView.mirrored ? -1 : 1) * stackView.settingsPageSlideDistance
+                        to: 0
+                        duration: stackView.settingsPageSlideDuration
+                        easing.type: Easing.OutCubic
+                    }
+                }
             }
 
+            popExit: Transition {
+                enabled: stackView.settingsPageTransitionsEnabled
+
+                NumberAnimation {
+                    property: "opacity"
+                    from: 1
+                    to: 0
+                    duration: stackView.settingsPageFadeDuration
+                    easing.type: Easing.OutQuint
+                }
+            }
+
+            pushExit: Transition {
+                enabled: stackView.settingsPageTransitionsEnabled
+
+                NumberAnimation {
+                    property: "opacity"
+                    from: 1
+                    to: 0
+                    duration: stackView.settingsPageFadeDuration
+                    easing.type: Easing.OutQuint
+                }
+            }
+
+            replaceEnter: Transition {
+                enabled: stackView.settingsPageTransitionsEnabled
+
+                ParallelAnimation {
+                    NumberAnimation {
+                        property: "opacity"
+                        from: 0
+                        to: 1
+                        duration: stackView.settingsPageFadeDuration
+                        easing.type: Easing.InQuint
+                    }
+                    NumberAnimation {
+                        property: "x"
+                        from: (stackView.mirrored ? -1 : 1) * stackView.settingsPageSlideDistance
+                        to: 0
+                        duration: stackView.settingsPageSlideDuration
+                        easing.type: Easing.OutCubic
+                    }
+                }
+            }
+
+            replaceExit: Transition {
+                enabled: stackView.settingsPageTransitionsEnabled
+
+                ParallelAnimation {
+                    NumberAnimation {
+                        property: "opacity"
+                        from: 1
+                        to: 0
+                        duration: stackView.settingsPageFadeDuration
+                        easing.type: Easing.OutQuint
+                    }
+                    NumberAnimation {
+                        property: "x"
+                        from: 0
+                        to: (stackView.mirrored ? 1 : -1) * stackView.settingsPageSlideDistance
+                        duration: stackView.settingsPageSlideDuration
+                        easing.type: Easing.InCubic
+                    }
+                }
+            }
+
+            Component {
+                id: generalPaneComponent
+                GeneralPane {}
+            }
+
+            Component {
+                id: componentsPaneComponent
+                ComponentsPane {}
+            }
+
+            Component {
+                id: languagePaneComponent
+                LanguagePane {}
+            }
+
+            Component {
+                id: commAppsPaneComponent
+                CommAppsPane {}
+            }
+
+            Component {
+                id: shortcutsPaneComponent
+                ShortcutsPane {}
+            }
+
+            Component {
+                id: appHotkeysPaneComponent
+                AppHotkeysPane {}
+            }
+
+            Component {
+                id: appearancePaneComponent
+                AppearancePane {}
+            }
+
+            Component {
+                id: mediaOverlayPaneComponent
+                MediaOverlayPane {}
+            }
+
+            Component {
+                id: headsetControlPaneComponent
+                HeadsetControlPane {}
+            }
+
+            Component {
+                id: deviceRenamingPaneComponent
+                DeviceRenamingPane {}
+            }
+
+            Component {
+                id: updatePaneComponent
+                UpdatePane {}
+            }
+
+            Component {
+                id: debugPaneComponent
+                DebugPane {}
+            }
         }
     }
 }

--- a/qml/SettingsWindow.qml
+++ b/qml/SettingsWindow.qml
@@ -37,15 +37,10 @@ ApplicationWindow {
         target: Qt.application.styleHints
 
         function onColorSchemeChanged() {
-            // DWM coalesces an immediate Mica reset and reapply, leaving the
-            // old light material behind when Qt switches back to dark mode.
-            // Keep the client readable with the new opaque fallback for one
-            // event-loop turn, then create a fresh native material instance.
+            // The native theme handler rebuilds the material. Keep the client
+            // opaque until that compositor refresh has completed.
             root.nativeBackdropActive = false
-            Qt.callLater(function () {
-                WindowsBackdrop.removeBackdrop(root)
-                Qt.callLater(root.updateNativeBackdrop)
-            })
+            Qt.callLater(root.updateNativeBackdrop)
         }
     }
 

--- a/resources/icons/icons.qrc
+++ b/resources/icons/icons.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/icons">
+        <file>icon.png</file>
         <file>tray_light_0.png</file>
         <file>tray_dark_0.png</file>
         <file>tray_light_33.png</file>

--- a/src/windowchrome.cpp
+++ b/src/windowchrome.cpp
@@ -340,6 +340,30 @@ bool WindowChrome::nativeEventFilter(
     case WM_NCLBUTTONDOWN:
         if (msg->wParam == HTMAXBUTTON) {
             setMaximizeButtonPressed(true);
+            if (trackedWindow.window->visibility() == QWindow::Maximized) {
+                trackedWindow.window->showNormal();
+            } else {
+                trackedWindow.window->showMaximized();
+            }
+            setMaximizeButtonPressed(false);
+            *result = 0;
+            return true;
+        }
+        if (msg->wParam == HTCAPTION) {
+            trackedWindow.window->startSystemMove();
+            *result = 0;
+            return true;
+        }
+        return false;
+    case WM_NCLBUTTONDBLCLK:
+        if (msg->wParam == HTCAPTION) {
+            if (trackedWindow.window->visibility() == QWindow::Maximized) {
+                trackedWindow.window->showNormal();
+            } else {
+                trackedWindow.window->showMaximized();
+            }
+            *result = 0;
+            return true;
         }
         return false;
     case WM_NCLBUTTONUP:

--- a/src/windowchrome.cpp
+++ b/src/windowchrome.cpp
@@ -1,0 +1,396 @@
+#include "windowchrome.h"
+
+#include "logmanager.h"
+
+#include <QCoreApplication>
+#include <QPointer>
+#include <QQuickItem>
+#include <QQuickWindow>
+
+#include <windows.h>
+#include <windowsx.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <unordered_map>
+
+namespace {
+constexpr char LogCategory[] = "WindowChrome";
+
+QQuickWindow* windowFromObject(QObject* object)
+{
+    return qobject_cast<QQuickWindow*>(object);
+}
+
+QQuickItem* itemFromObject(QObject* object)
+{
+    return qobject_cast<QQuickItem*>(object);
+}
+
+bool itemContainsNativePoint(
+    const QQuickItem* item,
+    const QQuickWindow* window,
+    const POINT& clientPoint)
+{
+    if (!item || !window || !item->isVisible() || !item->isEnabled()) {
+        return false;
+    }
+
+    const qreal devicePixelRatio = window->devicePixelRatio();
+    const QPointF scenePoint(
+        clientPoint.x / devicePixelRatio,
+        clientPoint.y / devicePixelRatio);
+    return item->contains(item->mapFromScene(scenePoint));
+}
+
+int resizeBorderThickness(HWND hwnd, int metric)
+{
+    const UINT dpi = GetDpiForWindow(hwnd);
+    return GetSystemMetricsForDpi(metric, dpi)
+        + GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi);
+}
+
+LRESULT resizeHitTest(HWND hwnd, const POINT& clientPoint)
+{
+    if (IsZoomed(hwnd)) {
+        return HTNOWHERE;
+    }
+
+    RECT clientRect{};
+    if (!GetClientRect(hwnd, &clientRect)) {
+        return HTNOWHERE;
+    }
+
+    const int horizontalBorder = resizeBorderThickness(hwnd, SM_CXSIZEFRAME);
+    const int verticalBorder = resizeBorderThickness(hwnd, SM_CYSIZEFRAME);
+    const bool left = clientPoint.x < horizontalBorder;
+    const bool right = clientPoint.x >= clientRect.right - horizontalBorder;
+    const bool top = clientPoint.y < verticalBorder;
+    const bool bottom = clientPoint.y >= clientRect.bottom - verticalBorder;
+
+    if (top && left) {
+        return HTTOPLEFT;
+    }
+    if (top && right) {
+        return HTTOPRIGHT;
+    }
+    if (bottom && left) {
+        return HTBOTTOMLEFT;
+    }
+    if (bottom && right) {
+        return HTBOTTOMRIGHT;
+    }
+    if (left) {
+        return HTLEFT;
+    }
+    if (right) {
+        return HTRIGHT;
+    }
+    if (top) {
+        return HTTOP;
+    }
+    if (bottom) {
+        return HTBOTTOM;
+    }
+    return HTNOWHERE;
+}
+}
+
+struct WindowChrome::Impl
+{
+    struct TrackedWindow
+    {
+        QPointer<QQuickWindow> window;
+        QPointer<QQuickItem> titleBar;
+        QPointer<QQuickItem> systemMenu;
+        QPointer<QQuickItem> minimizeButton;
+        QPointer<QQuickItem> maximizeButton;
+        QPointer<QQuickItem> closeButton;
+        QMetaObject::Connection destroyedConnection;
+    };
+
+    std::unordered_map<HWND, std::unique_ptr<TrackedWindow>> windows;
+};
+
+WindowChrome* WindowChrome::m_instance = nullptr;
+
+WindowChrome::WindowChrome(QObject* parent)
+    : QObject(parent)
+    , m_impl(std::make_unique<Impl>())
+{
+    QCoreApplication::instance()->installNativeEventFilter(this);
+}
+
+WindowChrome::~WindowChrome()
+{
+    QCoreApplication::instance()->removeNativeEventFilter(this);
+    for (const auto& [hwnd, trackedWindow] : m_impl->windows) {
+        Q_UNUSED(hwnd)
+        QObject::disconnect(trackedWindow->destroyedConnection);
+    }
+    m_impl->windows.clear();
+    if (m_instance == this) {
+        m_instance = nullptr;
+    }
+}
+
+WindowChrome* WindowChrome::create(QQmlEngine* qmlEngine, QJSEngine* jsEngine)
+{
+    Q_UNUSED(qmlEngine)
+    Q_UNUSED(jsEngine)
+
+    if (!m_instance) {
+        m_instance = new WindowChrome();
+    }
+    return m_instance;
+}
+
+WindowChrome* WindowChrome::instance()
+{
+    return m_instance;
+}
+
+bool WindowChrome::maximizeButtonHovered() const
+{
+    return m_maximizeButtonHovered;
+}
+
+bool WindowChrome::maximizeButtonPressed() const
+{
+    return m_maximizeButtonPressed;
+}
+
+bool WindowChrome::installWindowChrome(
+    QObject* windowObject,
+    QObject* titleBarObject,
+    QObject* systemMenuObject,
+    QObject* minimizeButtonObject,
+    QObject* maximizeButtonObject,
+    QObject* closeButtonObject)
+{
+    QQuickWindow* window = windowFromObject(windowObject);
+    QQuickItem* titleBar = itemFromObject(titleBarObject);
+    QQuickItem* systemMenu = itemFromObject(systemMenuObject);
+    QQuickItem* minimizeButton = itemFromObject(minimizeButtonObject);
+    QQuickItem* maximizeButton = itemFromObject(maximizeButtonObject);
+    QQuickItem* closeButton = itemFromObject(closeButtonObject);
+    if (!window || !titleBar || !systemMenu || !minimizeButton
+        || !maximizeButton || !closeButton) {
+        LOG_WARN(LogCategory, "Cannot install window chrome: invalid window item");
+        return false;
+    }
+
+    const HWND hwnd = reinterpret_cast<HWND>(window->winId());
+    if (!hwnd) {
+        LOG_WARN(LogCategory, "Cannot install window chrome: native window is unavailable");
+        return false;
+    }
+
+    LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+    style |= WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU;
+    style &= ~WS_CAPTION;
+    SetWindowLongPtrW(hwnd, GWL_STYLE, style);
+    SetWindowPos(
+        hwnd,
+        nullptr,
+        0,
+        0,
+        0,
+        0,
+        SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER
+            | SWP_NOACTIVATE);
+
+    auto existingWindow = m_impl->windows.find(hwnd);
+    if (existingWindow != m_impl->windows.end()) {
+        existingWindow->second->titleBar = titleBar;
+        existingWindow->second->systemMenu = systemMenu;
+        existingWindow->second->minimizeButton = minimizeButton;
+        existingWindow->second->maximizeButton = maximizeButton;
+        existingWindow->second->closeButton = closeButton;
+        return true;
+    }
+
+    auto trackedWindow = std::make_unique<Impl::TrackedWindow>();
+    trackedWindow->window = window;
+    trackedWindow->titleBar = titleBar;
+    trackedWindow->systemMenu = systemMenu;
+    trackedWindow->minimizeButton = minimizeButton;
+    trackedWindow->maximizeButton = maximizeButton;
+    trackedWindow->closeButton = closeButton;
+    trackedWindow->destroyedConnection = connect(
+        window,
+        &QObject::destroyed,
+        this,
+        [this, hwnd]() {
+            m_impl->windows.erase(hwnd);
+            setMaximizeButtonHovered(false);
+            setMaximizeButtonPressed(false);
+        });
+    m_impl->windows.emplace(hwnd, std::move(trackedWindow));
+
+    LOG_INFO(LogCategory, "Installed native Settings window chrome");
+    return true;
+}
+
+void WindowChrome::removeWindowChrome(QObject* windowObject)
+{
+    QQuickWindow* window = windowFromObject(windowObject);
+    if (!window) {
+        return;
+    }
+
+    for (auto iterator = m_impl->windows.begin(); iterator != m_impl->windows.end(); ++iterator) {
+        if (iterator->second->window == window) {
+            QObject::disconnect(iterator->second->destroyedConnection);
+            m_impl->windows.erase(iterator);
+            setMaximizeButtonHovered(false);
+            setMaximizeButtonPressed(false);
+            return;
+        }
+    }
+}
+
+bool WindowChrome::nativeEventFilter(
+    const QByteArray& eventType,
+    void* message,
+    qintptr* result)
+{
+    if (eventType != "windows_generic_MSG"
+        && eventType != "windows_dispatcher_MSG") {
+        return false;
+    }
+
+    MSG* msg = static_cast<MSG*>(message);
+    const auto trackedWindowIterator = m_impl->windows.find(msg->hwnd);
+    if (trackedWindowIterator == m_impl->windows.end()) {
+        return false;
+    }
+
+    const Impl::TrackedWindow& trackedWindow = *trackedWindowIterator->second;
+    if (!trackedWindow.window) {
+        return false;
+    }
+
+    switch (msg->message) {
+    case WM_NCHITTEST: {
+        POINT clientPoint{GET_X_LPARAM(msg->lParam), GET_Y_LPARAM(msg->lParam)};
+        if (!ScreenToClient(msg->hwnd, &clientPoint)) {
+            return false;
+        }
+
+        const LRESULT resizeResult = resizeHitTest(msg->hwnd, clientPoint);
+        if (resizeResult != HTNOWHERE) {
+            setMaximizeButtonHovered(false);
+            *result = resizeResult;
+            return true;
+        }
+
+        if (itemContainsNativePoint(
+                trackedWindow.maximizeButton,
+                trackedWindow.window,
+                clientPoint)) {
+            setMaximizeButtonHovered(true);
+            TRACKMOUSEEVENT tracking{
+                sizeof(TRACKMOUSEEVENT),
+                TME_LEAVE | TME_NONCLIENT,
+                msg->hwnd,
+                0,
+            };
+            TrackMouseEvent(&tracking);
+            *result = HTMAXBUTTON;
+            return true;
+        }
+
+        setMaximizeButtonHovered(false);
+        if (itemContainsNativePoint(
+                trackedWindow.minimizeButton,
+                trackedWindow.window,
+                clientPoint)
+            || itemContainsNativePoint(
+                trackedWindow.closeButton,
+                trackedWindow.window,
+                clientPoint)) {
+            *result = HTCLIENT;
+            return true;
+        }
+        if (itemContainsNativePoint(
+                trackedWindow.systemMenu,
+                trackedWindow.window,
+                clientPoint)) {
+            *result = HTSYSMENU;
+            return true;
+        }
+        if (itemContainsNativePoint(
+                trackedWindow.titleBar,
+                trackedWindow.window,
+                clientPoint)) {
+            *result = HTCAPTION;
+            return true;
+        }
+        return false;
+    }
+    case WM_NCMOUSEMOVE:
+        setMaximizeButtonHovered(msg->wParam == HTMAXBUTTON);
+        return false;
+    case WM_NCMOUSELEAVE:
+        setMaximizeButtonHovered(false);
+        setMaximizeButtonPressed(false);
+        return false;
+    case WM_NCLBUTTONDOWN:
+        if (msg->wParam == HTMAXBUTTON) {
+            setMaximizeButtonPressed(true);
+        }
+        return false;
+    case WM_NCLBUTTONUP:
+        setMaximizeButtonPressed(false);
+        return false;
+    case WM_CAPTURECHANGED:
+        setMaximizeButtonPressed(false);
+        return false;
+    case WM_GETMINMAXINFO: {
+        auto* minMaxInfo = reinterpret_cast<MINMAXINFO*>(msg->lParam);
+        const HMONITOR monitor = MonitorFromWindow(msg->hwnd, MONITOR_DEFAULTTONEAREST);
+        MONITORINFO monitorInfo{sizeof(MONITORINFO)};
+        if (!GetMonitorInfoW(monitor, &monitorInfo)) {
+            return false;
+        }
+
+        minMaxInfo->ptMaxPosition.x = monitorInfo.rcWork.left - monitorInfo.rcMonitor.left;
+        minMaxInfo->ptMaxPosition.y = monitorInfo.rcWork.top - monitorInfo.rcMonitor.top;
+        minMaxInfo->ptMaxSize.x = monitorInfo.rcWork.right - monitorInfo.rcWork.left;
+        minMaxInfo->ptMaxSize.y = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top;
+        const qreal devicePixelRatio = trackedWindow.window->devicePixelRatio();
+        minMaxInfo->ptMinTrackSize.x = std::max(
+            minMaxInfo->ptMinTrackSize.x,
+            static_cast<LONG>(std::lround(
+                trackedWindow.window->minimumWidth() * devicePixelRatio)));
+        minMaxInfo->ptMinTrackSize.y = std::max(
+            minMaxInfo->ptMinTrackSize.y,
+            static_cast<LONG>(std::lround(
+                trackedWindow.window->minimumHeight() * devicePixelRatio)));
+        *result = 0;
+        return true;
+    }
+    default:
+        return false;
+    }
+}
+
+void WindowChrome::setMaximizeButtonHovered(bool hovered)
+{
+    if (m_maximizeButtonHovered == hovered) {
+        return;
+    }
+    m_maximizeButtonHovered = hovered;
+    emit maximizeButtonHoveredChanged();
+}
+
+void WindowChrome::setMaximizeButtonPressed(bool pressed)
+{
+    if (m_maximizeButtonPressed == pressed) {
+        return;
+    }
+    m_maximizeButtonPressed = pressed;
+    emit maximizeButtonPressedChanged();
+}

--- a/src/windowchrome.cpp
+++ b/src/windowchrome.cpp
@@ -108,6 +108,7 @@ struct WindowChrome::Impl
         QPointer<QQuickItem> maximizeButton;
         QPointer<QQuickItem> closeButton;
         QMetaObject::Connection destroyedConnection;
+        bool maximizeButtonTracking = false;
     };
 
     std::unordered_map<HWND, std::unique_ptr<TrackedWindow>> windows;
@@ -267,13 +268,33 @@ bool WindowChrome::nativeEventFilter(
         return false;
     }
 
-    const Impl::TrackedWindow& trackedWindow = *trackedWindowIterator->second;
+    Impl::TrackedWindow& trackedWindow = *trackedWindowIterator->second;
     if (!trackedWindow.window) {
         return false;
     }
     const auto setResult = [result](qintptr value) {
         if (result) {
             *result = value;
+        }
+    };
+    const auto toggleMaximized = [&trackedWindow]() {
+        if (trackedWindow.window->visibility() == QWindow::Maximized) {
+            trackedWindow.window->showNormal();
+        } else {
+            trackedWindow.window->showMaximized();
+        }
+    };
+    const HWND hwnd = msg->hwnd;
+    const auto finishMaximizeClick = [this, &trackedWindow, &toggleMaximized, hwnd](
+                                         bool pointerInside) {
+        trackedWindow.maximizeButtonTracking = false;
+        if (GetCapture() == hwnd) {
+            ReleaseCapture();
+        }
+        setMaximizeButtonPressed(false);
+        setMaximizeButtonHovered(pointerInside);
+        if (pointerInside) {
+            toggleMaximized();
         }
     };
 
@@ -340,17 +361,15 @@ bool WindowChrome::nativeEventFilter(
         return false;
     case WM_NCMOUSELEAVE:
         setMaximizeButtonHovered(false);
-        setMaximizeButtonPressed(false);
+        if (!trackedWindow.maximizeButtonTracking) {
+            setMaximizeButtonPressed(false);
+        }
         return false;
     case WM_NCLBUTTONDOWN:
         if (msg->wParam == HTMAXBUTTON) {
+            trackedWindow.maximizeButtonTracking = true;
+            SetCapture(msg->hwnd);
             setMaximizeButtonPressed(true);
-            if (trackedWindow.window->visibility() == QWindow::Maximized) {
-                trackedWindow.window->showNormal();
-            } else {
-                trackedWindow.window->showMaximized();
-            }
-            setMaximizeButtonPressed(false);
             setResult(0);
             return true;
         }
@@ -362,19 +381,52 @@ bool WindowChrome::nativeEventFilter(
         return false;
     case WM_NCLBUTTONDBLCLK:
         if (msg->wParam == HTCAPTION) {
-            if (trackedWindow.window->visibility() == QWindow::Maximized) {
-                trackedWindow.window->showNormal();
-            } else {
-                trackedWindow.window->showMaximized();
-            }
+            toggleMaximized();
+            setResult(0);
+            return true;
+        }
+        return false;
+    case WM_MOUSEMOVE:
+        if (trackedWindow.maximizeButtonTracking) {
+            const POINT clientPoint{GET_X_LPARAM(msg->lParam), GET_Y_LPARAM(msg->lParam)};
+            const bool pointerInside = itemContainsNativePoint(
+                trackedWindow.maximizeButton,
+                trackedWindow.window,
+                clientPoint);
+            setMaximizeButtonHovered(pointerInside);
+            setMaximizeButtonPressed(pointerInside);
+            setResult(0);
+            return true;
+        }
+        return false;
+    case WM_LBUTTONUP:
+        if (trackedWindow.maximizeButtonTracking) {
+            const POINT clientPoint{GET_X_LPARAM(msg->lParam), GET_Y_LPARAM(msg->lParam)};
+            finishMaximizeClick(itemContainsNativePoint(
+                trackedWindow.maximizeButton,
+                trackedWindow.window,
+                clientPoint));
             setResult(0);
             return true;
         }
         return false;
     case WM_NCLBUTTONUP:
+        if (trackedWindow.maximizeButtonTracking) {
+            POINT clientPoint{GET_X_LPARAM(msg->lParam), GET_Y_LPARAM(msg->lParam)};
+            const bool pointAvailable = ScreenToClient(msg->hwnd, &clientPoint) != FALSE;
+            finishMaximizeClick(
+                pointAvailable
+                && itemContainsNativePoint(
+                    trackedWindow.maximizeButton,
+                    trackedWindow.window,
+                    clientPoint));
+            setResult(0);
+            return true;
+        }
         setMaximizeButtonPressed(false);
         return false;
     case WM_CAPTURECHANGED:
+        trackedWindow.maximizeButtonTracking = false;
         setMaximizeButtonPressed(false);
         return false;
     case WM_GETMINMAXINFO: {

--- a/src/windowchrome.cpp
+++ b/src/windowchrome.cpp
@@ -271,6 +271,11 @@ bool WindowChrome::nativeEventFilter(
     if (!trackedWindow.window) {
         return false;
     }
+    const auto setResult = [result](qintptr value) {
+        if (result) {
+            *result = value;
+        }
+    };
 
     switch (msg->message) {
     case WM_NCHITTEST: {
@@ -282,7 +287,7 @@ bool WindowChrome::nativeEventFilter(
         const LRESULT resizeResult = resizeHitTest(msg->hwnd, clientPoint);
         if (resizeResult != HTNOWHERE) {
             setMaximizeButtonHovered(false);
-            *result = resizeResult;
+            setResult(resizeResult);
             return true;
         }
 
@@ -298,7 +303,7 @@ bool WindowChrome::nativeEventFilter(
                 0,
             };
             TrackMouseEvent(&tracking);
-            *result = HTMAXBUTTON;
+            setResult(HTMAXBUTTON);
             return true;
         }
 
@@ -311,21 +316,21 @@ bool WindowChrome::nativeEventFilter(
                 trackedWindow.closeButton,
                 trackedWindow.window,
                 clientPoint)) {
-            *result = HTCLIENT;
+            setResult(HTCLIENT);
             return true;
         }
         if (itemContainsNativePoint(
                 trackedWindow.systemMenu,
                 trackedWindow.window,
                 clientPoint)) {
-            *result = HTSYSMENU;
+            setResult(HTSYSMENU);
             return true;
         }
         if (itemContainsNativePoint(
                 trackedWindow.titleBar,
                 trackedWindow.window,
                 clientPoint)) {
-            *result = HTCAPTION;
+            setResult(HTCAPTION);
             return true;
         }
         return false;
@@ -346,12 +351,12 @@ bool WindowChrome::nativeEventFilter(
                 trackedWindow.window->showMaximized();
             }
             setMaximizeButtonPressed(false);
-            *result = 0;
+            setResult(0);
             return true;
         }
         if (msg->wParam == HTCAPTION) {
             trackedWindow.window->startSystemMove();
-            *result = 0;
+            setResult(0);
             return true;
         }
         return false;
@@ -362,7 +367,7 @@ bool WindowChrome::nativeEventFilter(
             } else {
                 trackedWindow.window->showMaximized();
             }
-            *result = 0;
+            setResult(0);
             return true;
         }
         return false;
@@ -393,7 +398,7 @@ bool WindowChrome::nativeEventFilter(
             minMaxInfo->ptMinTrackSize.y,
             static_cast<LONG>(std::lround(
                 trackedWindow.window->minimumHeight() * devicePixelRatio)));
-        *result = 0;
+        setResult(0);
         return true;
     }
     default:

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -203,18 +203,29 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     return applyDwmBackdrop(hwnd, DWMSBT_TRANSIENTWINDOW);
 }
 
-void refreshMaterialForTheme(QWindow* window, BackdropKind kind)
+bool refreshMaterialForTheme(QWindow* window, BackdropKind kind)
 {
     const HWND hwnd = reinterpret_cast<HWND>(window->winId());
     if (!hwnd) {
-        return;
+        return false;
     }
 
+    BOOL cloaked = FALSE;
     if (kind == BackdropKind::MainWindow) {
-        // DWM can coalesce back-to-back NONE and MAINWINDOW attribute changes,
-        // preserving the previous Mica theme until the window is restored.
-        // Present the cleared material first so the following application
-        // creates a new backdrop using the current color scheme.
+        // Recreate DWM's composed surface without changing QWindow visibility,
+        // activation, placement, or maximized state. This follows the native
+        // lifecycle that refreshes Mica when a minimized window is restored.
+        cloaked = TRUE;
+        const HRESULT cloakResult = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_CLOAK,
+            &cloaked,
+            sizeof(cloaked));
+        if (FAILED(cloakResult)) {
+            LOG_WARN(LogCategory,
+                     QString("Failed to cloak window for Mica theme refresh: %1")
+                         .arg(formatHresult(cloakResult)));
+        }
         clearDwmBackdrop(hwnd);
         const HRESULT flushResult = DwmFlush();
         if (FAILED(flushResult)) {
@@ -224,7 +235,26 @@ void refreshMaterialForTheme(QWindow* window, BackdropKind kind)
         }
     }
 
-    applyMaterial(window, kind);
+    const bool materialActive = applyMaterial(window, kind);
+    if (cloaked) {
+        const HRESULT materialFlushResult = DwmFlush();
+        if (FAILED(materialFlushResult)) {
+            LOG_WARN(LogCategory,
+                     QString("Failed to present refreshed Mica material: %1")
+                         .arg(formatHresult(materialFlushResult)));
+        }
+        const BOOL uncloak = FALSE;
+        const HRESULT uncloakResult = DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_CLOAK,
+            &uncloak,
+            sizeof(uncloak));
+        if (FAILED(uncloakResult)) {
+            LOG_WARN(LogCategory,
+                     QString("Failed to uncloak window after Mica theme refresh: %1")
+                         .arg(formatHresult(uncloakResult)));
+        }
+    }
     SetWindowPos(
         hwnd,
         nullptr,
@@ -239,6 +269,7 @@ void refreshMaterialForTheme(QWindow* window, BackdropKind kind)
         nullptr,
         nullptr,
         RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+    return materialActive;
 }
 
 void clearMaterial(QWindow* window)
@@ -295,10 +326,9 @@ WindowsBackdrop::WindowsBackdrop(QObject* parent)
         [this]() {
             for (const auto& [window, trackedWindow] : m_impl->windows) {
                 Q_UNUSED(window)
-                if (trackedWindow->window) {
-                    refreshMaterialForTheme(
-                        trackedWindow->window,
-                        trackedWindow->kind);
+                if (trackedWindow->window
+                    && trackedWindow->kind == BackdropKind::Transient) {
+                    applyMaterial(trackedWindow->window, trackedWindow->kind);
                 }
             }
         });
@@ -339,6 +369,22 @@ bool WindowsBackdrop::applyTransientBackdrop(QObject* windowObject)
 bool WindowsBackdrop::applyMainWindowBackdrop(QObject* windowObject)
 {
     return applyBackdrop(windowObject, true);
+}
+
+bool WindowsBackdrop::refreshMainWindowBackdrop(QObject* windowObject)
+{
+    QWindow* window = windowFromObject(windowObject);
+    if (!window) {
+        LOG_WARN(LogCategory, "Cannot refresh backdrop: object is not a window");
+        return false;
+    }
+
+    const auto trackedWindow = m_impl->windows.find(window);
+    if (trackedWindow == m_impl->windows.end()
+        || trackedWindow->second->kind != BackdropKind::MainWindow) {
+        return applyBackdrop(windowObject, true);
+    }
+    return refreshMaterialForTheme(window, BackdropKind::MainWindow);
 }
 
 bool WindowsBackdrop::applyBackdrop(QObject* windowObject, bool mainWindow)

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -203,75 +203,6 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     return applyDwmBackdrop(hwnd, DWMSBT_TRANSIENTWINDOW);
 }
 
-bool refreshMaterialForTheme(QWindow* window, BackdropKind kind)
-{
-    const HWND hwnd = reinterpret_cast<HWND>(window->winId());
-    if (!hwnd) {
-        return false;
-    }
-
-    BOOL cloaked = FALSE;
-    if (kind == BackdropKind::MainWindow) {
-        // Recreate DWM's composed surface without changing QWindow visibility,
-        // activation, placement, or maximized state. This follows the native
-        // lifecycle that refreshes Mica when a minimized window is restored.
-        cloaked = TRUE;
-        const HRESULT cloakResult = DwmSetWindowAttribute(
-            hwnd,
-            DWMWA_CLOAK,
-            &cloaked,
-            sizeof(cloaked));
-        if (FAILED(cloakResult)) {
-            LOG_WARN(LogCategory,
-                     QString("Failed to cloak window for Mica theme refresh: %1")
-                         .arg(formatHresult(cloakResult)));
-        }
-        clearDwmBackdrop(hwnd);
-        const HRESULT flushResult = DwmFlush();
-        if (FAILED(flushResult)) {
-            LOG_WARN(LogCategory,
-                     QString("Failed to synchronize Mica theme refresh: %1")
-                         .arg(formatHresult(flushResult)));
-        }
-    }
-
-    const bool materialActive = applyMaterial(window, kind);
-    if (cloaked) {
-        const HRESULT materialFlushResult = DwmFlush();
-        if (FAILED(materialFlushResult)) {
-            LOG_WARN(LogCategory,
-                     QString("Failed to present refreshed Mica material: %1")
-                         .arg(formatHresult(materialFlushResult)));
-        }
-        const BOOL uncloak = FALSE;
-        const HRESULT uncloakResult = DwmSetWindowAttribute(
-            hwnd,
-            DWMWA_CLOAK,
-            &uncloak,
-            sizeof(uncloak));
-        if (FAILED(uncloakResult)) {
-            LOG_WARN(LogCategory,
-                     QString("Failed to uncloak window after Mica theme refresh: %1")
-                         .arg(formatHresult(uncloakResult)));
-        }
-    }
-    SetWindowPos(
-        hwnd,
-        nullptr,
-        0,
-        0,
-        0,
-        0,
-        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE
-            | SWP_FRAMECHANGED);
-    RedrawWindow(
-        hwnd,
-        nullptr,
-        nullptr,
-        RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
-    return materialActive;
-}
-
 void clearMaterial(QWindow* window)
 {
     const HWND hwnd = reinterpret_cast<HWND>(window->winId());
@@ -369,22 +300,6 @@ bool WindowsBackdrop::applyTransientBackdrop(QObject* windowObject)
 bool WindowsBackdrop::applyMainWindowBackdrop(QObject* windowObject)
 {
     return applyBackdrop(windowObject, true);
-}
-
-bool WindowsBackdrop::refreshMainWindowBackdrop(QObject* windowObject)
-{
-    QWindow* window = windowFromObject(windowObject);
-    if (!window) {
-        LOG_WARN(LogCategory, "Cannot refresh backdrop: object is not a window");
-        return false;
-    }
-
-    const auto trackedWindow = m_impl->windows.find(window);
-    if (trackedWindow == m_impl->windows.end()
-        || trackedWindow->second->kind != BackdropKind::MainWindow) {
-        return applyBackdrop(windowObject, true);
-    }
-    return refreshMaterialForTheme(window, BackdropKind::MainWindow);
 }
 
 bool WindowsBackdrop::applyBackdrop(QObject* windowObject, bool mainWindow)

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -203,6 +203,29 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     return applyDwmBackdrop(hwnd, DWMSBT_TRANSIENTWINDOW);
 }
 
+void refreshMaterialForTheme(QWindow* window, BackdropKind kind)
+{
+    const HWND hwnd = reinterpret_cast<HWND>(window->winId());
+    if (!hwnd) {
+        return;
+    }
+
+    if (kind == BackdropKind::MainWindow) {
+        // Reapplying the same backdrop type is not enough to make DWM rebuild
+        // an existing light Mica surface after Qt switches back to dark mode.
+        // Reset only this long-lived material so the new theme takes effect
+        // immediately, matching the refresh Windows performs on restore.
+        clearDwmBackdrop(hwnd);
+    }
+
+    applyMaterial(window, kind);
+    RedrawWindow(
+        hwnd,
+        nullptr,
+        nullptr,
+        RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN);
+}
+
 void clearMaterial(QWindow* window)
 {
     const HWND hwnd = reinterpret_cast<HWND>(window->winId());
@@ -258,7 +281,9 @@ WindowsBackdrop::WindowsBackdrop(QObject* parent)
             for (const auto& [window, trackedWindow] : m_impl->windows) {
                 Q_UNUSED(window)
                 if (trackedWindow->window) {
-                    applyMaterial(trackedWindow->window, trackedWindow->kind);
+                    refreshMaterialForTheme(
+                        trackedWindow->window,
+                        trackedWindow->kind);
                 }
             }
         });

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -203,29 +203,6 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     return applyDwmBackdrop(hwnd, DWMSBT_TRANSIENTWINDOW);
 }
 
-void refreshMaterialForTheme(QWindow* window, BackdropKind kind)
-{
-    const HWND hwnd = reinterpret_cast<HWND>(window->winId());
-    if (!hwnd) {
-        return;
-    }
-
-    if (kind == BackdropKind::MainWindow) {
-        // Reapplying the same backdrop type is not enough to make DWM rebuild
-        // an existing light Mica surface after Qt switches back to dark mode.
-        // Reset only this long-lived material so the new theme takes effect
-        // immediately, matching the refresh Windows performs on restore.
-        clearDwmBackdrop(hwnd);
-    }
-
-    applyMaterial(window, kind);
-    RedrawWindow(
-        hwnd,
-        nullptr,
-        nullptr,
-        RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN);
-}
-
 void clearMaterial(QWindow* window)
 {
     const HWND hwnd = reinterpret_cast<HWND>(window->winId());
@@ -281,9 +258,7 @@ WindowsBackdrop::WindowsBackdrop(QObject* parent)
             for (const auto& [window, trackedWindow] : m_impl->windows) {
                 Q_UNUSED(window)
                 if (trackedWindow->window) {
-                    refreshMaterialForTheme(
-                        trackedWindow->window,
-                        trackedWindow->kind);
+                    applyMaterial(trackedWindow->window, trackedWindow->kind);
                 }
             }
         });

--- a/src/windowsbackdrop.cpp
+++ b/src/windowsbackdrop.cpp
@@ -203,6 +203,44 @@ bool applyMaterial(QWindow* window, BackdropKind kind)
     return applyDwmBackdrop(hwnd, DWMSBT_TRANSIENTWINDOW);
 }
 
+void refreshMaterialForTheme(QWindow* window, BackdropKind kind)
+{
+    const HWND hwnd = reinterpret_cast<HWND>(window->winId());
+    if (!hwnd) {
+        return;
+    }
+
+    if (kind == BackdropKind::MainWindow) {
+        // DWM can coalesce back-to-back NONE and MAINWINDOW attribute changes,
+        // preserving the previous Mica theme until the window is restored.
+        // Present the cleared material first so the following application
+        // creates a new backdrop using the current color scheme.
+        clearDwmBackdrop(hwnd);
+        const HRESULT flushResult = DwmFlush();
+        if (FAILED(flushResult)) {
+            LOG_WARN(LogCategory,
+                     QString("Failed to synchronize Mica theme refresh: %1")
+                         .arg(formatHresult(flushResult)));
+        }
+    }
+
+    applyMaterial(window, kind);
+    SetWindowPos(
+        hwnd,
+        nullptr,
+        0,
+        0,
+        0,
+        0,
+        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE
+            | SWP_FRAMECHANGED);
+    RedrawWindow(
+        hwnd,
+        nullptr,
+        nullptr,
+        RDW_INVALIDATE | RDW_FRAME | RDW_ALLCHILDREN | RDW_UPDATENOW);
+}
+
 void clearMaterial(QWindow* window)
 {
     const HWND hwnd = reinterpret_cast<HWND>(window->winId());
@@ -258,7 +296,9 @@ WindowsBackdrop::WindowsBackdrop(QObject* parent)
             for (const auto& [window, trackedWindow] : m_impl->windows) {
                 Q_UNUSED(window)
                 if (trackedWindow->window) {
-                    applyMaterial(trackedWindow->window, trackedWindow->kind);
+                    refreshMaterialForTheme(
+                        trackedWindow->window,
+                        trackedWindow->kind);
                 }
             }
         });


### PR DESCRIPTION
## Summary

- replace the standard Settings frame with native-aware frameless window chrome
- use the Windows main-window Mica backdrop when available while retaining the opaque accessibility and compatibility fallback
- preserve native move, resize, minimize, maximize, system-menu, and Snap Layout behavior
- keep live theme changes readable with an opaque fallback, then retry Mica after Settings is closed and reopened

## Validation

- built and installed the Debug configuration on the Windows 11 VM with Qt 6.11.2
- verified navigation, links, move, resize, minimize, maximize, repeated maximize/restore, and title-bar double-click in the VM
- verified the opaque live-theme fallback and Mica restoration after close/reopen in the VM without 3D acceleration
- repeated the window-chrome and dark/light theme tests successfully on a hardware-accelerated Windows 11 notebook