### PR TITLE
Show media source identity in media controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 2.1.0 LANGUAGES C CXX)
+project(QontrolPanel VERSION 2.2.0 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/include/mediasessionbridge.h
+++ b/include/mediasessionbridge.h
@@ -14,6 +14,9 @@ class MediaSessionBridge : public QObject
     Q_PROPERTY(QString mediaArtist READ mediaArtist NOTIFY mediaInfoChanged)
     Q_PROPERTY(bool isMediaPlaying READ isMediaPlaying NOTIFY mediaInfoChanged)
     Q_PROPERTY(QString mediaArt READ mediaArt NOTIFY mediaInfoChanged)
+    Q_PROPERTY(QString sourceName READ sourceName NOTIFY mediaInfoChanged)
+    Q_PROPERTY(QString sourceIcon READ sourceIcon NOTIFY mediaInfoChanged)
+    Q_PROPERTY(int sourceCount READ sourceCount NOTIFY mediaInfoChanged)
 
 public:
     explicit MediaSessionBridge(QObject* parent = nullptr);
@@ -26,10 +29,14 @@ public:
     QString mediaArtist() const;
     bool isMediaPlaying() const;
     QString mediaArt() const;
+    QString sourceName() const;
+    QString sourceIcon() const;
+    int sourceCount() const;
 
     Q_INVOKABLE void playPause();
     Q_INVOKABLE void nextTrack();
     Q_INVOKABLE void previousTrack();
+    Q_INVOKABLE void nextSource();
     Q_INVOKABLE void startMediaMonitoring();
     Q_INVOKABLE void stopMediaMonitoring();
 
@@ -43,5 +50,8 @@ private:
     QString m_mediaArtist;
     bool m_isMediaPlaying = false;
     QString m_mediaArt;
+    QString m_sourceName;
+    QString m_sourceIcon;
+    int m_sourceCount = 0;
 };
 

--- a/include/mediasessionbridge.h
+++ b/include/mediasessionbridge.h
@@ -42,6 +42,7 @@ public:
 
 signals:
     void mediaInfoChanged();
+    void mediaSourceSwitchRequested();
 
 private:
     static MediaSessionBridge* m_instance;

--- a/include/mediasessionmanager.h
+++ b/include/mediasessionmanager.h
@@ -19,6 +19,9 @@ struct MediaInfo {
     QString album;
     bool isPlaying = false;
     QString albumArt;
+    QString sourceName;
+    QString sourceIcon;
+    int sourceCount = 0;
 };
 
 class MediaWorker : public QObject
@@ -32,6 +35,7 @@ public slots:
     void playPause();
     void nextTrack();
     void previousTrack();
+    void nextSource();
 
 signals:
     void mediaInfoChanged(const MediaInfo& info);
@@ -39,6 +43,7 @@ signals:
 private:
     GlobalSystemMediaTransportControlsSessionManager m_sessionManager{ nullptr };
     GlobalSystemMediaTransportControlsSession m_currentSession{ nullptr };
+    bool m_sourceSelectedManually = false;
 
     // Event tokens for cleanup
     event_token m_sessionsChangedToken{};
@@ -68,5 +73,6 @@ void stopMonitoringAsync();
 void playPauseAsync();
 void nextTrackAsync();
 void previousTrackAsync();
+void nextSourceAsync();
 MediaWorker* getWorker();
 }

--- a/include/mediasessionmanager.h
+++ b/include/mediasessionmanager.h
@@ -47,6 +47,7 @@ private:
 
     // Event tokens for cleanup
     event_token m_sessionsChangedToken{};
+    event_token m_currentSessionChangedToken{};
     event_token m_propertiesChangedToken{};
     event_token m_playbackInfoChangedToken{};
 

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -56,11 +56,13 @@ ColumnLayout {
             Layout.preferredHeight: 24
             visible: MediaSessionBridge.sourceCount > 1
 
-            contentItem: IconImage {
-                source: "qrc:/icons/arrow.svg"
-                sourceSize.width: 12
-                sourceSize.height: 12
+            contentItem: Text {
+                text: "\uE76C"
+                font.family: "Segoe Fluent Icons"
+                font.pixelSize: 12
                 color: sourceSwitchButton.palette.buttonText
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
             }
 
             onClicked: MediaSessionBridge.nextSource()

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -51,13 +51,18 @@ ColumnLayout {
         }
 
         ToolButton {
+            id: sourceSwitchButton
             Layout.preferredWidth: 24
             Layout.preferredHeight: 24
             visible: MediaSessionBridge.sourceCount > 1
-            icon.source: "qrc:/icons/arrow.svg"
-            icon.color: palette.text
-            icon.width: 12
-            icon.height: 12
+
+            contentItem: IconImage {
+                source: "qrc:/icons/arrow.svg"
+                sourceSize.width: 12
+                sourceSize.height: 12
+                color: sourceSwitchButton.palette.buttonText
+            }
+
             onClicked: MediaSessionBridge.nextSource()
         }
     }

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -55,6 +55,7 @@ ColumnLayout {
             Layout.preferredHeight: 24
             visible: MediaSessionBridge.sourceCount > 1
             icon.source: "qrc:/icons/arrow.svg"
+            icon.color: palette.text
             icon.width: 12
             icon.height: 12
             onClicked: MediaSessionBridge.nextSource()

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -16,6 +16,51 @@ ColumnLayout {
         }
     }
 
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.preferredHeight: 24
+        spacing: 8
+
+        Item {
+            Layout.preferredWidth: 18
+            Layout.preferredHeight: 18
+
+            Image {
+                anchors.fill: parent
+                source: MediaSessionBridge.sourceIcon || ""
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                visible: MediaSessionBridge.sourceIcon !== ""
+            }
+
+            IconImage {
+                anchors.fill: parent
+                source: "qrc:/icons/music.svg"
+                color: palette.text
+                opacity: 0.7
+                visible: MediaSessionBridge.sourceIcon === ""
+            }
+        }
+
+        Label {
+            text: MediaSessionBridge.sourceName || ""
+            font.pixelSize: 12
+            font.bold: true
+            elide: Text.ElideRight
+            Layout.fillWidth: true
+        }
+
+        ToolButton {
+            Layout.preferredWidth: 24
+            Layout.preferredHeight: 24
+            visible: MediaSessionBridge.sourceCount > 1
+            icon.source: "qrc:/icons/arrow.svg"
+            icon.width: 12
+            icon.height: 12
+            onClicked: MediaSessionBridge.nextSource()
+        }
+    }
+
     ColumnLayout {
         Layout.fillWidth: true
 

--- a/qml/MediaOverlay.qml
+++ b/qml/MediaOverlay.qml
@@ -34,7 +34,7 @@ ApplicationWindow {
     function calculateHeight() {
         const sizeMultipliers = [0.8, 1.0, 1.2]
         const multiplier = sizeMultipliers[UserSettings.mediaOverlaySize] || 1.0
-        return Math.round(80 * multiplier)
+        return Math.round(80 * multiplier) + 24
     }
 
     Component.onCompleted: {
@@ -380,63 +380,104 @@ ApplicationWindow {
             opacity: 0.15
         }
 
-        RowLayout {
+        ColumnLayout {
             anchors.fill: parent
             anchors.margins: 10
-            spacing: 10
+            spacing: 6
 
-            // Album art - span 2
-            Rectangle {
-                Layout.preferredWidth: parent.height
-                Layout.preferredHeight: parent.height
-                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-                color: "#2a2a2a"
-                radius: 3
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 18
+                spacing: 7
 
-                Image {
-                    anchors.fill: parent
-                    anchors.margins: 2
-                    source: MediaSessionBridge.mediaArt || ""
-                    fillMode: Image.PreserveAspectCrop
-                    visible: MediaSessionBridge.mediaArt !== ""
-                    smooth: true
+                Item {
+                    Layout.preferredWidth: 16
+                    Layout.preferredHeight: 16
+
+                    Image {
+                        anchors.fill: parent
+                        source: MediaSessionBridge.sourceIcon || ""
+                        fillMode: Image.PreserveAspectFit
+                        smooth: true
+                        visible: MediaSessionBridge.sourceIcon !== ""
+                    }
+
+                    IconImage {
+                        anchors.fill: parent
+                        source: "qrc:/icons/music.svg"
+                        color: palette.text
+                        opacity: 0.7
+                        visible: MediaSessionBridge.sourceIcon === ""
+                    }
                 }
 
-                IconImage {
-                    anchors.centerIn: parent
-                    source: "qrc:/icons/headset.svg"
-                    sourceSize.width: 24
-                    sourceSize.height: 24
-                    color: palette.text
-                    opacity: 0.3
-                    visible: MediaSessionBridge.mediaArt === ""
+                Label {
+                    text: MediaSessionBridge.sourceName || ""
+                    font.pixelSize: 11
+                    font.bold: true
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
                 }
             }
 
-            // Title and Artist - span 1
-            ColumnLayout {
+            RowLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 spacing: 10
 
-                Label {
-                    text: MediaSessionBridge.mediaTitle || qsTr("No media playing")
-                    font.pixelSize: 13
-                    font.bold: true
-                    Layout.fillWidth: true
-                    wrapMode: Text.Wrap
-                    elide: Text.ElideRight
-                    maximumLineCount: 2
+                // Album art - span 2
+                Rectangle {
+                    Layout.preferredWidth: parent.height
+                    Layout.preferredHeight: parent.height
+                    Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                    color: "#2a2a2a"
+                    radius: 3
+
+                    Image {
+                        anchors.fill: parent
+                        anchors.margins: 2
+                        source: MediaSessionBridge.mediaArt || ""
+                        fillMode: Image.PreserveAspectCrop
+                        visible: MediaSessionBridge.mediaArt !== ""
+                        smooth: true
+                    }
+
+                    IconImage {
+                        anchors.centerIn: parent
+                        source: "qrc:/icons/headset.svg"
+                        sourceSize.width: 24
+                        sourceSize.height: 24
+                        color: palette.text
+                        opacity: 0.3
+                        visible: MediaSessionBridge.mediaArt === ""
+                    }
                 }
 
-                Label {
-                    text: MediaSessionBridge.mediaArtist || ""
-                    font.pixelSize: 11
-                    opacity: 0.7
+                // Title and Artist - span 1
+                ColumnLayout {
                     Layout.fillWidth: true
-                    elide: Text.ElideRight
-                    maximumLineCount: 1
-                    visible: MediaSessionBridge.mediaArtist !== ""
+                    Layout.fillHeight: true
+                    spacing: 10
+
+                    Label {
+                        text: MediaSessionBridge.mediaTitle || qsTr("No media playing")
+                        font.pixelSize: 13
+                        font.bold: true
+                        Layout.fillWidth: true
+                        wrapMode: Text.Wrap
+                        elide: Text.ElideRight
+                        maximumLineCount: 2
+                    }
+
+                    Label {
+                        text: MediaSessionBridge.mediaArtist || ""
+                        font.pixelSize: 11
+                        opacity: 0.7
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        maximumLineCount: 1
+                        visible: MediaSessionBridge.mediaArtist !== ""
+                    }
                 }
             }
         }

--- a/qml/MediaOverlay.qml
+++ b/qml/MediaOverlay.qml
@@ -10,7 +10,7 @@ ApplicationWindow {
     width: calculateWidth()
     height: calculateHeight()
     visible: false
-    flags: Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint
+    flags: Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint | Qt.WindowDoesNotAcceptFocus
     color: "#00000000"
 
     property bool isAnimatingIn: false
@@ -18,6 +18,7 @@ ApplicationWindow {
     property string previousTitle: ""
     property string previousArtist: ""
     property bool hasReceivedFirstUpdate: false
+    property bool suppressNextMediaInfoOverlay: false
     property bool nativeBackdropActive: false
     property real restingX: 0
     property real restingY: 0
@@ -71,6 +72,11 @@ ApplicationWindow {
     Connections {
         target: MediaSessionBridge
 
+        function onMediaSourceSwitchRequested() {
+            suppressNextMediaInfoOverlay = true
+            sourceSwitchSuppressionTimer.restart()
+        }
+
         function onMediaInfoChanged() {
             if (!UserSettings.enableMediaOverlay || !UserSettings.enableMediaSessionManager) {
                 return
@@ -78,6 +84,14 @@ ApplicationWindow {
 
             const newTitle = MediaSessionBridge.mediaTitle || ""
             const newArtist = MediaSessionBridge.mediaArtist || ""
+
+            if (suppressNextMediaInfoOverlay) {
+                previousTitle = newTitle
+                previousArtist = newArtist
+                suppressNextMediaInfoOverlay = false
+                sourceSwitchSuppressionTimer.stop()
+                return
+            }
 
             // First update after component creation - just store the values, don't show overlay
             if (!hasReceivedFirstUpdate) {
@@ -94,6 +108,13 @@ ApplicationWindow {
                 showOverlay()
             }
         }
+    }
+
+    Timer {
+        id: sourceSwitchSuppressionTimer
+        interval: 2000
+        repeat: false
+        onTriggered: suppressNextMediaInfoOverlay = false
     }
 
     Timer {

--- a/src/mediasessionbridge.cpp
+++ b/src/mediasessionbridge.cpp
@@ -14,6 +14,9 @@ MediaSessionBridge::MediaSessionBridge(QObject* parent)
                     m_mediaArtist = info.artist;
                     m_mediaArt = info.albumArt;
                     m_isMediaPlaying = info.isPlaying;
+                    m_sourceName = info.sourceName;
+                    m_sourceIcon = info.sourceIcon;
+                    m_sourceCount = info.sourceCount;
                     emit mediaInfoChanged();
                 });
     }
@@ -62,6 +65,18 @@ QString MediaSessionBridge::mediaArt() const {
     return m_mediaArt;
 }
 
+QString MediaSessionBridge::sourceName() const {
+    return m_sourceName;
+}
+
+QString MediaSessionBridge::sourceIcon() const {
+    return m_sourceIcon;
+}
+
+int MediaSessionBridge::sourceCount() const {
+    return m_sourceCount;
+}
+
 void MediaSessionBridge::playPause() {
     MediaSessionManager::playPauseAsync();
 }
@@ -72,6 +87,10 @@ void MediaSessionBridge::nextTrack() {
 
 void MediaSessionBridge::previousTrack() {
     MediaSessionManager::previousTrackAsync();
+}
+
+void MediaSessionBridge::nextSource() {
+    MediaSessionManager::nextSourceAsync();
 }
 
 void MediaSessionBridge::startMediaMonitoring() {

--- a/src/mediasessionbridge.cpp
+++ b/src/mediasessionbridge.cpp
@@ -90,6 +90,7 @@ void MediaSessionBridge::previousTrack() {
 }
 
 void MediaSessionBridge::nextSource() {
+    emit mediaSourceSwitchRequested();
     MediaSessionManager::nextSourceAsync();
 }
 

--- a/src/mediasessionmanager.cpp
+++ b/src/mediasessionmanager.cpp
@@ -1,5 +1,6 @@
 #include <windows.h>
 #include <shobjidl.h>
+#include <shlobj.h>
 #include <shellapi.h>
 #include "mediasessionmanager.h"
 #include "logmanager.h"
@@ -14,6 +15,7 @@
 #include <QFileInfo>
 #include <QSettings>
 #include <winver.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <cstring>
 #include <vector>

--- a/src/mediasessionmanager.cpp
+++ b/src/mediasessionmanager.cpp
@@ -8,7 +8,14 @@
 #include <QImage>
 #include <QPainter>
 #include <QPainterPath>
+#include <QFileInfo>
+#include <QSettings>
+#include <shobjidl.h>
+#include <shellapi.h>
+#include <winver.h>
 #include <winrt/Windows.Storage.Streams.h>
+#include <cstring>
+#include <vector>
 
 using namespace winrt;
 using namespace Windows::Media::Control;
@@ -18,6 +25,204 @@ using namespace Windows::Storage::Streams;
 static QThread* g_mediaWorkerThread = nullptr;
 static MediaWorker* g_mediaWorker = nullptr;
 static QMutex g_mediaInitMutex;
+
+namespace {
+
+QString imageToDataUri(const QImage& image)
+{
+    if (image.isNull()) {
+        return {};
+    }
+
+    QByteArray imageData;
+    QBuffer buffer(&imageData);
+    buffer.open(QIODevice::WriteOnly);
+    image.save(&buffer, "PNG");
+    return QStringLiteral("data:image/png;base64,") + imageData.toBase64();
+}
+
+QImage bitmapToImage(HBITMAP bitmap)
+{
+    BITMAP bitmapInfo{};
+    if (!bitmap || GetObject(bitmap, sizeof(bitmapInfo), &bitmapInfo) == 0) {
+        return {};
+    }
+
+    BITMAPINFO dibInfo{};
+    dibInfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    dibInfo.bmiHeader.biWidth = bitmapInfo.bmWidth;
+    dibInfo.bmiHeader.biHeight = -bitmapInfo.bmHeight;
+    dibInfo.bmiHeader.biPlanes = 1;
+    dibInfo.bmiHeader.biBitCount = 32;
+    dibInfo.bmiHeader.biCompression = BI_RGB;
+
+    QImage image(bitmapInfo.bmWidth, bitmapInfo.bmHeight, QImage::Format_ARGB32);
+    HDC deviceContext = GetDC(nullptr);
+    const int copiedLines = GetDIBits(deviceContext, bitmap, 0, bitmapInfo.bmHeight,
+                                      image.bits(), &dibInfo, DIB_RGB_COLORS);
+    ReleaseDC(nullptr, deviceContext);
+
+    return copiedLines == bitmapInfo.bmHeight ? image : QImage{};
+}
+
+QImage iconToImage(HICON icon, int size)
+{
+    if (!icon) {
+        return {};
+    }
+
+    BITMAPINFO bitmapInfo{};
+    bitmapInfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bitmapInfo.bmiHeader.biWidth = size;
+    bitmapInfo.bmiHeader.biHeight = -size;
+    bitmapInfo.bmiHeader.biPlanes = 1;
+    bitmapInfo.bmiHeader.biBitCount = 32;
+    bitmapInfo.bmiHeader.biCompression = BI_RGB;
+
+    void* pixels = nullptr;
+    HDC screenContext = GetDC(nullptr);
+    HBITMAP bitmap = CreateDIBSection(screenContext, &bitmapInfo, DIB_RGB_COLORS,
+                                      &pixels, nullptr, 0);
+    HDC drawContext = CreateCompatibleDC(screenContext);
+    if (!screenContext || !bitmap || !pixels || !drawContext) {
+        if (drawContext) {
+            DeleteDC(drawContext);
+        }
+        if (bitmap) {
+            DeleteObject(bitmap);
+        }
+        if (screenContext) {
+            ReleaseDC(nullptr, screenContext);
+        }
+        return {};
+    }
+
+    HGDIOBJ oldBitmap = SelectObject(drawContext, bitmap);
+    memset(pixels, 0, static_cast<size_t>(size * size * 4));
+    DrawIconEx(drawContext, 0, 0, icon, size, size, 0, nullptr, DI_NORMAL);
+
+    QImage image(static_cast<uchar*>(pixels), size, size, QImage::Format_ARGB32);
+    QImage result = image.copy();
+
+    SelectObject(drawContext, oldBitmap);
+    DeleteDC(drawContext);
+    DeleteObject(bitmap);
+    ReleaseDC(nullptr, screenContext);
+    return result;
+}
+
+QString executableDisplayName(const QString& executablePath)
+{
+    const std::wstring nativePath = executablePath.toStdWString();
+    const DWORD dataSize = GetFileVersionInfoSize(nativePath.c_str(), nullptr);
+    if (dataSize == 0) {
+        return {};
+    }
+
+    std::vector<BYTE> versionData(dataSize);
+    if (!GetFileVersionInfo(nativePath.c_str(), 0, dataSize, versionData.data())) {
+        return {};
+    }
+
+    void* value = nullptr;
+    UINT valueLength = 0;
+    for (const wchar_t* key : {L"\\StringFileInfo\\040904b0\\ProductName",
+                               L"\\StringFileInfo\\040904b0\\FileDescription"}) {
+        if (VerQueryValue(versionData.data(), key, &value, &valueLength) && valueLength > 1) {
+            return QString::fromWCharArray(static_cast<const wchar_t*>(value));
+        }
+    }
+    return {};
+}
+
+QString executablePathForSource(const QString& sourceId)
+{
+    QString executableName = QFileInfo(sourceId).fileName();
+    if (!executableName.endsWith(QStringLiteral(".exe"), Qt::CaseInsensitive)) {
+        return {};
+    }
+
+    if (QFileInfo::exists(sourceId)) {
+        return sourceId;
+    }
+
+    const QStringList registryRoots = {
+        QStringLiteral("HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\"),
+        QStringLiteral("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\")
+    };
+    for (const QString& root : registryRoots) {
+        QSettings registry(root + executableName, QSettings::NativeFormat);
+        QString path = registry.value(QStringLiteral(".")).toString();
+        path.remove(u'\"');
+        if (QFileInfo::exists(path)) {
+            return path;
+        }
+    }
+
+    std::wstring nativeName = executableName.toStdWString();
+    std::vector<wchar_t> pathBuffer(32768);
+    const DWORD length = SearchPathW(nullptr, nativeName.c_str(), nullptr,
+                                     static_cast<DWORD>(pathBuffer.size()), pathBuffer.data(), nullptr);
+    if (length > 0 && length < pathBuffer.size()) {
+        return QString::fromWCharArray(pathBuffer.data(), static_cast<qsizetype>(length));
+    }
+    return {};
+}
+
+void resolveSourceIdentity(const QString& sourceId, QString& sourceName, QString& sourceIcon)
+{
+    const std::wstring nativeId = sourceId.toStdWString();
+    IShellItem* shellItem = nullptr;
+    if (SUCCEEDED(SHCreateItemInKnownFolder(FOLDERID_AppsFolder, KF_FLAG_DEFAULT,
+                                             nativeId.c_str(), IID_PPV_ARGS(&shellItem)))) {
+        PWSTR displayName = nullptr;
+        if (SUCCEEDED(shellItem->GetDisplayName(SIGDN_NORMALDISPLAY, &displayName))) {
+            sourceName = QString::fromWCharArray(displayName);
+            CoTaskMemFree(displayName);
+        }
+
+        IShellItemImageFactory* imageFactory = nullptr;
+        if (SUCCEEDED(shellItem->QueryInterface(IID_PPV_ARGS(&imageFactory)))) {
+            HBITMAP iconBitmap = nullptr;
+            const SIZE iconSize{32, 32};
+            if (SUCCEEDED(imageFactory->GetImage(iconSize,
+                                                 static_cast<SIIGBF>(SIIGBF_ICONONLY | SIIGBF_BIGGERSIZEOK),
+                                                 &iconBitmap))) {
+                sourceIcon = imageToDataUri(bitmapToImage(iconBitmap));
+                DeleteObject(iconBitmap);
+            }
+            imageFactory->Release();
+        }
+        shellItem->Release();
+    }
+
+    const QString executablePath = executablePathForSource(sourceId);
+    if (!executablePath.isEmpty()) {
+        if (sourceName.isEmpty()) {
+            sourceName = executableDisplayName(executablePath);
+        }
+        if (sourceIcon.isEmpty()) {
+            SHFILEINFO fileInfo{};
+            if (SHGetFileInfo(executablePath.toStdWString().c_str(), 0, &fileInfo, sizeof(fileInfo),
+                              SHGFI_ICON | SHGFI_LARGEICON)) {
+                sourceIcon = imageToDataUri(iconToImage(fileInfo.hIcon, 32));
+                DestroyIcon(fileInfo.hIcon);
+            }
+        }
+    }
+
+    if (sourceName.isEmpty()) {
+        sourceName = QFileInfo(sourceId).completeBaseName();
+        if (sourceName.contains(u'!')) {
+            sourceName = sourceName.section(u'!', -1);
+        }
+        if (!sourceName.isEmpty()) {
+            sourceName[0] = sourceName[0].toUpper();
+        }
+    }
+}
+
+} // namespace
 
 QPixmap createRoundedPixmap(const QPixmap& source, int targetSize, int radius) {
     // Scale the source to target size while maintaining aspect ratio
@@ -53,10 +258,19 @@ MediaInfo queryMediaInfoImpl(MediaWorker* worker) {
 
     try {
         init_apartment();
-        auto sessionManager = GlobalSystemMediaTransportControlsSessionManager::RequestAsync().get();
-        auto currentSession = sessionManager.GetCurrentSession();
+        if (!worker || !worker->ensureCurrentSession()) {
+            LOG_INFO("MediaSessionManager", "No active media session found");
+            return info;
+        }
+
+        auto currentSession = worker->m_currentSession;
+        auto sessions = worker->m_sessionManager.GetSessions();
+        info.sourceCount = static_cast<int>(sessions.Size());
 
         if (currentSession) {
+            const QString sourceId = QString::fromWCharArray(currentSession.SourceAppUserModelId().c_str());
+            resolveSourceIdentity(sourceId, info.sourceName, info.sourceIcon);
+
             auto properties = currentSession.TryGetMediaPropertiesAsync().get();
             if (properties) {
                 info.title = QString::fromWCharArray(properties.Title().c_str());
@@ -182,7 +396,22 @@ bool MediaWorker::ensureCurrentSession() {
             m_sessionManager = GlobalSystemMediaTransportControlsSessionManager::RequestAsync().get();
         }
 
-        auto currentSession = m_sessionManager.GetCurrentSession();
+        auto sessions = m_sessionManager.GetSessions();
+        bool currentSessionStillExists = false;
+        for (const auto& session : sessions) {
+            if (session == m_currentSession) {
+                currentSessionStillExists = true;
+                break;
+            }
+        }
+
+        if (m_sourceSelectedManually && !currentSessionStillExists) {
+            m_sourceSelectedManually = false;
+        }
+
+        auto currentSession = m_sourceSelectedManually
+            ? m_currentSession
+            : m_sessionManager.GetCurrentSession();
 
         // If session changed, update notifications
         if (m_currentSession != currentSession) {
@@ -288,6 +517,7 @@ void MediaWorker::stopMonitoring() {
     cleanupSessionManagerNotifications();
     m_currentSession = nullptr;
     m_sessionManager = nullptr;
+    m_sourceSelectedManually = false;
 
     // Clear cache on stop
     m_cachedRawAlbumArt.clear();
@@ -341,6 +571,39 @@ void MediaWorker::previousTrack() {
         }
     } catch (...) {
         LOG_CRITICAL("MediaSessionManager", "Failed to skip to previous track");
+    }
+}
+
+void MediaWorker::nextSource() {
+    LOG_INFO("MediaSessionManager", "Switching to next media source");
+
+    try {
+        if (!ensureCurrentSession()) {
+            return;
+        }
+
+        const auto sessions = m_sessionManager.GetSessions();
+        if (sessions.Size() < 2) {
+            return;
+        }
+
+        uint32_t currentIndex = 0;
+        for (uint32_t index = 0; index < sessions.Size(); ++index) {
+            if (sessions.GetAt(index) == m_currentSession) {
+                currentIndex = index;
+                break;
+            }
+        }
+
+        cleanupSessionNotifications();
+        m_currentSession = sessions.GetAt((currentIndex + 1) % sessions.Size());
+        m_sourceSelectedManually = true;
+        m_cachedRawAlbumArt.clear();
+        m_cachedProcessedAlbumArt.clear();
+        setupSessionNotifications();
+        queryMediaInfo();
+    } catch (...) {
+        LOG_CRITICAL("MediaSessionManager", "Failed to switch media source");
     }
 }
 
@@ -421,6 +684,12 @@ void MediaSessionManager::nextTrackAsync() {
 void MediaSessionManager::previousTrackAsync() {
     if (g_mediaWorker) {
         QMetaObject::invokeMethod(g_mediaWorker, "previousTrack", Qt::QueuedConnection);
+    }
+}
+
+void MediaSessionManager::nextSourceAsync() {
+    if (g_mediaWorker) {
+        QMetaObject::invokeMethod(g_mediaWorker, "nextSource", Qt::QueuedConnection);
     }
 }
 

--- a/src/mediasessionmanager.cpp
+++ b/src/mediasessionmanager.cpp
@@ -374,6 +374,19 @@ void MediaWorker::setupSessionManagerNotifications() {
                 }, Qt::QueuedConnection);
             });
 
+        // Follow the source Windows considers most relevant, matching Quick Settings.
+        m_currentSessionChangedToken = m_sessionManager.CurrentSessionChanged(
+            [this](GlobalSystemMediaTransportControlsSessionManager const& sender,
+                   CurrentSessionChangedEventArgs const& args) {
+                Q_UNUSED(sender)
+                Q_UNUSED(args)
+                QMetaObject::invokeMethod(this, [this]() {
+                    LOG_INFO("MediaSessionManager", "Current media session changed");
+                    m_sourceSelectedManually = false;
+                    queryMediaInfo();
+                }, Qt::QueuedConnection);
+            });
+
         LOG_INFO("MediaSessionManager", "Session manager notifications registered");
     } catch (...) {
         LOG_CRITICAL("MediaSessionManager", "Failed to setup session manager notifications");
@@ -381,10 +394,16 @@ void MediaWorker::setupSessionManagerNotifications() {
 }
 
 void MediaWorker::cleanupSessionManagerNotifications() {
-    if (m_sessionManager && m_sessionsChangedToken.value != 0) {
+    if (m_sessionManager) {
         try {
-            m_sessionManager.SessionsChanged(m_sessionsChangedToken);
-            m_sessionsChangedToken = {};
+            if (m_sessionsChangedToken.value != 0) {
+                m_sessionManager.SessionsChanged(m_sessionsChangedToken);
+                m_sessionsChangedToken = {};
+            }
+            if (m_currentSessionChangedToken.value != 0) {
+                m_sessionManager.CurrentSessionChanged(m_currentSessionChangedToken);
+                m_currentSessionChangedToken = {};
+            }
             LOG_INFO("MediaSessionManager", "Session manager notifications cleaned up");
         } catch (...) {
             LOG_WARN("MediaSessionManager", "Error cleaning up session manager notifications");
@@ -466,7 +485,19 @@ void MediaWorker::setupSessionNotifications() {
                    PlaybackInfoChangedEventArgs const& args) {
                 Q_UNUSED(session)
                 Q_UNUSED(args)
-                QMetaObject::invokeMethod(this, "queryMediaInfo", Qt::QueuedConnection);
+                QMetaObject::invokeMethod(this, [this]() {
+                    if (m_sourceSelectedManually && m_currentSession) {
+                        const auto playbackInfo = m_currentSession.GetPlaybackInfo();
+                        if (playbackInfo) {
+                            const auto status = playbackInfo.PlaybackStatus();
+                            if (status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Stopped
+                                || status == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Closed) {
+                                m_sourceSelectedManually = false;
+                            }
+                        }
+                    }
+                    queryMediaInfo();
+                }, Qt::QueuedConnection);
             });
 
         LOG_INFO("MediaSessionManager", "Session event notifications registered successfully");

--- a/src/mediasessionmanager.cpp
+++ b/src/mediasessionmanager.cpp
@@ -1,3 +1,6 @@
+#include <windows.h>
+#include <shobjidl.h>
+#include <shellapi.h>
 #include "mediasessionmanager.h"
 #include "logmanager.h"
 #include <QMetaObject>
@@ -10,8 +13,6 @@
 #include <QPainterPath>
 #include <QFileInfo>
 #include <QSettings>
-#include <shobjidl.h>
-#include <shellapi.h>
 #include <winver.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <cstring>


### PR DESCRIPTION
## Summary

- show the active application icon and name above media details in the main media flyout and media overlay
- add a Windows-style source switch control when multiple media sessions are available
- follow the Windows current-session priority when a newer source starts and fall back to another active source when it stops
- keep the panel open while switching sources and suppress the redundant media overlay popup
- bump the application version to 2.2.0

## Validation

- Windows 11 manual validation with multiple simultaneous media sources
- verified source cycling, automatic current-source selection, and fallback after stopping the selected source
- verified the panel remains open when switching sources
- Release build completed successfully on Windows with Qt 6.11.2
- `git diff --check origin/main...HEAD` passed