### PR TITLE
feat(ui): Adapt device list background for native backdrop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 CMakeLists.txt.user
 .qmlls.ini
 .cache/*
+.vs/*

--- a/qml/Common/DevicesListView.qml
+++ b/qml/Common/DevicesListView.qml
@@ -10,6 +10,7 @@ Rectangle {
 
     property alias model: devicesList.model
     property bool expanded: false
+    property bool nativeBackdropActive: false
     property real expandedNeededHeight: devicesList.contentHeight + 20
 
     signal deviceClicked(string name, int index)
@@ -18,7 +19,7 @@ Rectangle {
     Layout.preferredHeight: expanded ? expandedNeededHeight : 0
     Layout.leftMargin: -14
     Layout.rightMargin: -14
-    color: Constants.footerColor
+    color: nativeBackdropActive ? "transparent" : Constants.footerColor
 
     function closeContextMenus() {
         if (deviceRenameContextMenu.visible) {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -804,6 +804,7 @@ ApplicationWindow {
                         DevicesListView {
                             id: outputDevicesRect
                             model: AudioBridge.outputDevices
+                            nativeBackdropActive: panel.nativeBackdropActive
                             onDeviceClicked: function(name, index) {
                                 AudioBridge.setOutputDevice(index)
                                 expanded = false
@@ -877,6 +878,7 @@ ApplicationWindow {
                         DevicesListView {
                             id: inputDevicesRect
                             model: AudioBridge.inputDevices
+                            nativeBackdropActive: panel.nativeBackdropActive
                             onDeviceClicked: function(name, index) {
                                 AudioBridge.setInputDevice(index)
                                 expanded = false


### PR DESCRIPTION
Updates `DevicesListView` to support transparent backgrounds when `nativeBackdropActive` is true, enhancing UI integration with native system effects. The list's background dynamically adjusts based on the main panel's backdrop state. Also, adds `.vs/*` to `.gitignore` for Visual Studio build artifacts.

### Breaking Changes
None.

### Review Focus
Verify visual consistency and correct transparency behavior of the device lists when the native backdrop is active. Ensure `nativeBackdropActive` property propagation functions as intended.