### PR TITLE
feat(ui): Adapt applications list background for native backdrop

### DIFF
--- a/qml/Common/ApplicationsListView.qml
+++ b/qml/Common/ApplicationsListView.qml
@@ -11,6 +11,7 @@ Rectangle {
     property alias model: applicationsList.model
     property bool expanded: false
     property string executableName: ""
+    property bool nativeBackdropActive: false
 
     // Export the height needed when fully expanded
     property real expandedNeededHeight: {
@@ -28,7 +29,7 @@ Rectangle {
     Layout.preferredHeight: expanded ? expandedNeededHeight : 0
     Layout.leftMargin: -14
     Layout.rightMargin: -14
-    color: Constants.footerColor
+    color: nativeBackdropActive ? "transparent" : Constants.footerColor
 
     function closeContextMenus() {
         if (renameContextMenu.visible) {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -1024,6 +1024,7 @@ ApplicationWindow {
                                     id: individualAppsRect
                                     model: AudioBridge.getSessionsForExecutable(appDelegateRoot.model.executableName)
                                     executableName: appDelegateRoot.model.executableName
+                                    nativeBackdropActive: panel.nativeBackdropActive
 
                                     onApplicationVolumeChanged: function(appId, volume) {
                                         AudioBridge.setApplicationVolume(appId, volume)


### PR DESCRIPTION
Introduces a `nativeBackdropActive` property to dynamically set the `ApplicationsListView` background to transparent, enabling better integration with a native backdrop. This ensures a consistent visual experience when such a backdrop is active.

**Review Focus**
Verify the visual rendering of the applications list background when the native backdrop is both active and inactive.