### PR TITLE
fix: restore mixer interaction after reopening panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 2.2.2 LANGUAGES C CXX)
+project(QontrolPanel VERSION 2.2.3 LANGUAGES C CXX)
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)
 set(CMAKE_CXX_STANDARD 20)

--- a/include/audiomodels.h
+++ b/include/audiomodels.h
@@ -106,11 +106,11 @@ struct ApplicationGroup {
     QString displayName;
     QString iconPath;
     QList<AudioApplication> sessions;
-    int averageVolume;
-    bool anyMuted;
-    bool allMuted;
-    int sessionCount;
-    int averageAudioLevel;
+    int averageVolume = 0;
+    bool anyMuted = false;
+    bool allMuted = false;
+    int sessionCount = 0;
+    int averageAudioLevel = 0;
     bool isSystemSounds = false;
 };
 

--- a/qml/ChatMixNotification.qml
+++ b/qml/ChatMixNotification.qml
@@ -58,7 +58,15 @@ ApplicationWindow {
         target: KeyboardShortcutManager
 
         function onChatMixToggleRequested() {
-            UserSettings.chatMixEnabled = !UserSettings.chatMixEnabled
+            if (UserSettings.activateChatmix) {
+                UserSettings.chatMixEnabled = !UserSettings.chatMixEnabled
+
+                if (UserSettings.chatMixEnabled) {
+                    AudioBridge.applyChatMixToApplications(UserSettings.chatMixValue)
+                } else {
+                    AudioBridge.restoreOriginalVolumes()
+                }
+            }
 
             if (UserSettings.chatMixShortcutNotification) {
                 notificationType = "chatmix"

--- a/qml/Common/ApplicationsListView.qml
+++ b/qml/Common/ApplicationsListView.qml
@@ -12,6 +12,7 @@ Rectangle {
     property bool expanded: false
     property string executableName: ""
     property bool nativeBackdropActive: false
+    readonly property bool chatMixEffectiveEnabled: UserSettings.activateChatmix && UserSettings.chatMixEnabled
 
     // Export the height needed when fully expanded
     property real expandedNeededHeight: {
@@ -112,7 +113,7 @@ Rectangle {
                 spacing: -4
 
                 Label {
-                    opacity: UserSettings.chatMixEnabled ? 0.3 : 0.5
+                    opacity: root.chatMixEffectiveEnabled ? 0.3 : 0.5
                     elide: Text.ElideRight
                     Layout.preferredWidth: 200
                     Layout.leftMargin: 18
@@ -154,7 +155,7 @@ Rectangle {
                     id: volumeSlider
                     from: 0
                     to: 100
-                    enabled: !UserSettings.chatMixEnabled && !muteButton.highlighted
+                    enabled: !root.chatMixEffectiveEnabled && !muteButton.highlighted
                     audioLevel: {
                         AudioBridge.applicationAudioLevels
                         return AudioBridge.getApplicationAudioLevel(individualAppLayout.model.appId)
@@ -168,7 +169,7 @@ Rectangle {
                         if (pressed) {
                             return value
                         }
-                        if (!UserSettings.chatMixEnabled) {
+                        if (!root.chatMixEffectiveEnabled) {
                             return individualAppLayout.model.volume
                         }
                         let appName = individualAppLayout.model.name
@@ -181,12 +182,12 @@ Rectangle {
                         text: Math.round(volumeSlider.value).toString()
                     }
                     onValueChanged: {
-                        if (!UserSettings.chatMixEnabled && pressed) {
+                        if (!root.chatMixEffectiveEnabled && pressed) {
                             root.applicationVolumeChanged(individualAppLayout.model.appId, value)
                         }
                     }
                     onPressedChanged: {
-                        if (!pressed && !UserSettings.chatMixEnabled) {
+                        if (!pressed && !root.chatMixEffectiveEnabled) {
                             root.applicationVolumeChanged(individualAppLayout.model.appId, value)
                         }
                         if (!UserSettings.showAudioLevel) return
@@ -197,7 +198,7 @@ Rectangle {
                         }
                     }
                     onWheelChanged: {
-                        if (!UserSettings.chatMixEnabled) {
+                        if (!root.chatMixEffectiveEnabled) {
                             root.applicationVolumeChanged(individualAppLayout.model.appId, value)
                         }
                     }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -291,6 +291,8 @@ ApplicationWindow {
         }
         onFinished: {
             panel.isAnimatingIn = false
+            // Moving a hidden OpenGL window on-screen does not always schedule a frame.
+            panel.update()
         }
     }
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -24,6 +24,7 @@ ApplicationWindow {
     property real mediaRestingX: 0
     property real mediaRestingY: 0
     property alias mediaSurfaceWindow: mediaPanelWindow
+    readonly property bool chatMixEffectiveEnabled: UserSettings.activateChatmix && UserSettings.chatMixEnabled
     // Preserve the original 24px spacer after the media content's 15px outer inset.
     readonly property real panelGap: 9
     property string taskbarPos: {
@@ -941,7 +942,7 @@ ApplicationWindow {
                                         spacing: -4
 
                                         Label {
-                                            opacity: UserSettings.chatMixEnabled ? 0.3 : 1
+                                            opacity: panel.chatMixEffectiveEnabled ? 0.3 : 1
                                             elide: Text.ElideRight
                                             Layout.preferredWidth: 200
                                             Layout.leftMargin: 18
@@ -952,7 +953,7 @@ ApplicationWindow {
                                                     name = qsTr("System sounds")
                                                 }
 
-                                                if (UserSettings.chatMixEnabled && AudioBridge.isCommApp(name) && !appDelegateRoot.model.isSystemSounds) {
+                                                if (panel.chatMixEffectiveEnabled && AudioBridge.isCommApp(name) && !appDelegateRoot.model.isSystemSounds) {
                                                     name += " (Comm)"
                                                 }
                                                 return name
@@ -977,25 +978,29 @@ ApplicationWindow {
                                             from: 0
                                             to: 100
                                             value: pressed ? value : appDelegateRoot.model.averageVolume
-                                            enabled: !UserSettings.chatMixEnabled && !executableMuteButton.highlighted
+                                            enabled: !panel.chatMixEffectiveEnabled && !executableMuteButton.highlighted
                                             opacity: enabled ? 1 : 0.5
                                             Layout.fillWidth: true
                                             displayProgress: !appDelegateRoot.model.isSystemSounds
-                                            audioLevel: !appDelegateRoot.model.isSystemSounds
-                                                        ? (appDelegateRoot.model.averageAudioLevel || 0)
-                                                        : 0
+                                            audioLevel: {
+                                                // Keep this binding subscribed even while the session list is collapsed.
+                                                AudioBridge.applicationAudioLevels
+                                                return !appDelegateRoot.model.isSystemSounds
+                                                    ? (appDelegateRoot.model.averageAudioLevel || 0)
+                                                    : 0
+                                            }
                                             onValueChanged: {
-                                                if (!UserSettings.chatMixEnabled && pressed) {
+                                                if (!panel.chatMixEffectiveEnabled && pressed) {
                                                     AudioBridge.setExecutableVolume(appDelegateRoot.model.executableName, value)
                                                 }
                                             }
                                             onPressedChanged: {
-                                                if (!pressed && !UserSettings.chatMixEnabled) {
+                                                if (!pressed && !panel.chatMixEffectiveEnabled) {
                                                     AudioBridge.setExecutableVolume(appDelegateRoot.model.executableName, value)
                                                 }
                                             }
                                             onWheelChanged: {
-                                                if (!UserSettings.chatMixEnabled) {
+                                                if (!panel.chatMixEffectiveEnabled) {
                                                     AudioBridge.setExecutableVolume(appDelegateRoot.model.executableName, value)
                                                 }
                                             }

--- a/src/panelengine.cpp
+++ b/src/panelengine.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QScreen>
 #include <QRect>
+#include <QQuickWindow>
 #include <QWindow>
 #include <QQmlContext>
 #include <QTimer>
@@ -65,6 +66,14 @@ void PanelEngine::initializeQMLEngine()
     if (!engine->rootObjects().isEmpty()) {
         panelWindow = qobject_cast<QWindow*>(engine->rootObjects().constFirst());
         if (panelWindow) {
+            if (auto* quickWindow = qobject_cast<QQuickWindow*>(panelWindow)) {
+                // The main panel is animated fully off-screen before it is hidden.
+                // Recreate its OpenGL scene graph on the next show so Windows/DWM
+                // cannot retain a stale backing surface that only repaints on resize.
+                quickWindow->setPersistentGraphics(false);
+                quickWindow->setPersistentSceneGraph(false);
+            }
+
             QObject* mediaWindowObject = panelWindow->property("mediaSurfaceWindow").value<QObject*>();
             mediaPanelWindow = qobject_cast<QWindow*>(mediaWindowObject);
             if (!mediaPanelWindow) {
@@ -82,6 +91,9 @@ void PanelEngine::onPanelVisibilityChanged(bool visible)
 
     if (visible) {
         startFocusMonitoring();
+        if (auto* quickWindow = qobject_cast<QQuickWindow*>(panelWindow)) {
+            QTimer::singleShot(0, quickWindow, &QQuickWindow::update);
+        }
     } else {
         stopFocusMonitoring();
     }


### PR DESCRIPTION
## Summary

- Keep mixer state consistent when ChatMix is configured but currently disabled.
- Initialize application-group audio state to avoid a stale disabled appearance.
- Recreate the main panel scene graph after hiding and force a repaint when it is shown again.
- Bump the application version to 2.2.3.

## Problem

After the first successful panel display, later hide/show cycles could leave the lower audio controls visually frozen under the OpenGL renderer. Clicks still changed the volume, but hover feedback, dragging, and level animations were not rendered until opening a submenu forced a refresh.

## Validation

- Built the Release `INSTALL` target with Visual Studio 2026 and Qt 6.11.2.
- Manually verified repeated main-panel hide/show cycles.
- Confirmed slider hover, drag feedback, and audio-level animations remain responsive.
- Confirmed the installed build launches with its deployed runtime files.