### PR TITLE
fix(tray): show headset badge on app icon

### DIFF
--- a/qml/Singletons/Constants.qml
+++ b/qml/Singletons/Constants.qml
@@ -52,6 +52,10 @@ Item {
 
     function getTrayIcon(volume, muted) {
         if (UserSettings.iconStyle === 3) {
+            if (HeadsetControlBridge.anyDeviceFound) {
+                return "image://trayicon/icon.png"
+            }
+
             return "qrc:/icons/icon.png"
         }
 


### PR DESCRIPTION
## Summary

- show the connected-headset badge on the AppIcon tray style
- keep the Battery tray style unchanged
- preserve the plain AppIcon when no headset is connected

## Validation

- Windows Visual Studio 2026 Release `INSTALL` target succeeded
- Windows test suite passed (confirmed on the build machine)
- Linux portable `nightlight_data` and `release_provenance` tests passed