### PR TITLE
Add media timeline and seek controls

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,7 +19,7 @@ Tick `Desktop development with C++`
 
 Tick the following:
 
-![image](../.assets/msvc_setup.png)
+![image](.assets/msvc_setup.png)
 
 Wait for installation to complete and close visual studio editor.
 
@@ -42,11 +42,11 @@ You can then start the install
 Open QtCreator, open project, and load QontrolPanel CMakeLists.txt.  
 In the kit configuration, you can just leave it to default and click on configure project.
 
-![image](../.assets/qt_kit.png)
+![image](.assets/qt_kit.png)
 
 In QtCrator, bottom left, you can click the Run button.
 
-![image](../.assets/build_run.png)
+![image](.assets/build_run.png)
 
 Be sure to have closed any previous instance of QontrolPanel, or the new one will refuse to open.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(WIN32 AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         CACHE STRING "Vcpkg toolchain file")
 endif()
 
-project(QontrolPanel VERSION 2.3.1 LANGUAGES C CXX)
+project(QontrolPanel VERSION 2.4.0 LANGUAGES C CXX)
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "Installation directory" FORCE)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ When changing user-visible text:
 3. Review changed `.ts` files for accidental churn.
 4. Do not hand-edit translations unless you are intentionally translating.
 
-Translator-specific notes live in `.github/TRANSLATIONS.md`.
+Translator-specific notes live in [`TRANSLATIONS.md`](TRANSLATIONS.md).
 
 ## HeadsetControl Changes
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Default section of settings pane is configurable in General section.
 
 ## Translations
 
-Translators should have a look [here](.github/TRANSLATIONS.md).
+Translators should have a look [here](TRANSLATIONS.md).
 
 ## Installation / Upgrade
 
@@ -74,7 +74,7 @@ Use the provided installer or download the archive, extract it, and run `bin/Qon
 
 ## Build the project
 
-See [here](.github/BUILDING.md).
+See [here](BUILDING.md).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ Click anywhere or left again on the tray icon to close the panel.<br>
 Double click on tray icon will open the settings pane.<br>
 Default section of settings pane is configurable in General section.
 
+## Highlights
+
+- **Tray-first controls:** Open the compact panel instantly from the Windows system tray.
+- **Output audio:** Adjust volume, mute audio, and switch between playback devices.
+- **Input audio:** Control microphone volume, mute state, and the active recording device.
+- **Per-application mixer:** Manage individual app volumes, names, icons, locks, and background muting.
+- **ChatMix:** Keep communication apps at a dedicated volume and restore their original levels afterward.
+- **Media controls:** View artwork and track details, switch media sources, control playback, and seek through supported media.
+- **Display controls:** Adjust internal and external monitor brightness and control Windows Night Light.
+- **HeadsetControl integration:** Monitor supported headsets and configure battery alerts, sidetone, lighting, equalizer presets, and more.
+- **Keyboard shortcuts:** Configure global controls and per-application volume hotkeys.
+- **Power and personalization:** Access Windows power actions and customize the panel layout, appearance, language, and behavior.
+
 ## Translations
 
 Translators should have a look [here](TRANSLATIONS.md).

--- a/TRANSLATIONS.md
+++ b/TRANSLATIONS.md
@@ -8,7 +8,7 @@ More information can be found here: [Qt linguist](https://doc.qt.io/qt-6/linguis
 
 ### New languages
 
-For new languages we also need to add a new line in [cmake/languages.cmake](../cmake/languages.cmake).
+For new languages we also need to add a new line in [cmake/languages.cmake](cmake/languages.cmake).
 
 ### Testing your changes
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,7 +73,7 @@ Audio runs in a COM MTA. Native callback targets are invalidated before callback
 
 ### Media Sessions
 
-`MediaSessionManager` handles Windows media session monitoring and transport control. `MediaSessionBridge` exposes title, artist, art, playback state, and play/pause/next/previous commands to QML. Media monitoring is gated by user settings because it uses Windows media-session APIs and may not be needed by every user.
+`MediaSessionManager` handles Windows media session monitoring and transport control. `MediaSessionBridge` exposes title, artist, art, playback state, source-reported transport capabilities, timeline state, and play/pause/next/previous/seek commands to QML. Timeline positions are normalized to the start of the current media item; seeking is limited to the source-reported seek range. Media monitoring is gated by user settings because it uses Windows media-session APIs and may not be needed by every user.
 
 ### Display and Brightness
 

--- a/include/mediasessionbridge.h
+++ b/include/mediasessionbridge.h
@@ -17,6 +17,14 @@ class MediaSessionBridge : public QObject
     Q_PROPERTY(QString sourceName READ sourceName NOTIFY mediaInfoChanged)
     Q_PROPERTY(QString sourceIcon READ sourceIcon NOTIFY mediaInfoChanged)
     Q_PROPERTY(int sourceCount READ sourceCount NOTIFY mediaInfoChanged)
+    Q_PROPERTY(bool canPreviousTrack READ canPreviousTrack NOTIFY mediaInfoChanged)
+    Q_PROPERTY(bool hasMediaTimeline READ hasMediaTimeline NOTIFY mediaInfoChanged)
+    Q_PROPERTY(bool canSeek READ canSeek NOTIFY mediaInfoChanged)
+    Q_PROPERTY(qint64 mediaPositionMs READ mediaPositionMs NOTIFY mediaInfoChanged)
+    Q_PROPERTY(qint64 mediaDurationMs READ mediaDurationMs NOTIFY mediaInfoChanged)
+    Q_PROPERTY(qint64 mediaMinimumSeekMs READ mediaMinimumSeekMs NOTIFY mediaInfoChanged)
+    Q_PROPERTY(qint64 mediaMaximumSeekMs READ mediaMaximumSeekMs NOTIFY mediaInfoChanged)
+    Q_PROPERTY(double mediaPlaybackRate READ mediaPlaybackRate NOTIFY mediaInfoChanged)
 
 private:
     explicit MediaSessionBridge(QObject* parent = nullptr);
@@ -34,10 +42,19 @@ public:
     QString sourceName() const;
     QString sourceIcon() const;
     int sourceCount() const;
+    bool canPreviousTrack() const;
+    bool hasMediaTimeline() const;
+    bool canSeek() const;
+    qint64 mediaPositionMs() const;
+    qint64 mediaDurationMs() const;
+    qint64 mediaMinimumSeekMs() const;
+    qint64 mediaMaximumSeekMs() const;
+    double mediaPlaybackRate() const;
 
     Q_INVOKABLE void playPause();
     Q_INVOKABLE void nextTrack();
     Q_INVOKABLE void previousTrack();
+    Q_INVOKABLE void seekTo(qint64 positionMs);
     Q_INVOKABLE void nextSource();
     Q_INVOKABLE void startMediaMonitoring();
     Q_INVOKABLE void stopMediaMonitoring();
@@ -56,4 +73,12 @@ private:
     QString m_sourceName;
     QString m_sourceIcon;
     int m_sourceCount = 0;
+    bool m_canPreviousTrack = false;
+    bool m_hasMediaTimeline = false;
+    bool m_canSeek = false;
+    qint64 m_mediaPositionMs = 0;
+    qint64 m_mediaDurationMs = 0;
+    qint64 m_mediaMinimumSeekMs = 0;
+    qint64 m_mediaMaximumSeekMs = 0;
+    double m_mediaPlaybackRate = 1.0;
 };

--- a/include/mediasessionmanager.h
+++ b/include/mediasessionmanager.h
@@ -88,8 +88,15 @@ private:
     // Cache for album art to avoid reprocessing
     QByteArray m_cachedRawAlbumArt;
     QString m_cachedProcessedAlbumArt;
+    bool m_mediaIdentityLogged = false;
+    QString m_lastLoggedTitle;
+    QString m_lastLoggedArtist;
+    QString m_lastLoggedAlbum;
+    bool m_playbackStatusLogged = false;
+    bool m_lastLoggedPlaying = false;
 
     void resetSessionManager();
+    void resetRoutineLogState();
     void setupSessionManagerNotifications();
     void cleanupSessionManagerNotifications();
     void setupSessionNotifications();

--- a/include/mediasessionmanager.h
+++ b/include/mediasessionmanager.h
@@ -41,6 +41,7 @@ struct MediaCallbackTarget
 {
     QMutex mutex;
     MediaWorker* worker = nullptr;
+    bool timelineRefreshPending = false;
 };
 
 class MediaWorker : public QObject

--- a/include/mediasessionmanager.h
+++ b/include/mediasessionmanager.h
@@ -20,6 +20,14 @@ struct MediaInfo {
     QString artist;
     QString album;
     bool isPlaying = false;
+    bool canPreviousTrack = false;
+    bool hasMediaTimeline = false;
+    bool canSeek = false;
+    qint64 mediaPositionMs = 0;
+    qint64 mediaDurationMs = 0;
+    qint64 mediaMinimumSeekMs = 0;
+    qint64 mediaMaximumSeekMs = 0;
+    double mediaPlaybackRate = 1.0;
     QString albumArt;
     QString sourceName;
     QString sourceIcon;
@@ -52,6 +60,7 @@ public slots:
     void playPause();
     void nextTrack();
     void previousTrack();
+    void seekTo(qint64 positionMs);
     void nextSource();
 
 signals:
@@ -73,6 +82,7 @@ private:
     event_token m_currentSessionChangedToken{};
     event_token m_propertiesChangedToken{};
     event_token m_playbackInfoChangedToken{};
+    event_token m_timelinePropertiesChangedToken{};
 
     // Cache for album art to avoid reprocessing
     QByteArray m_cachedRawAlbumArt;
@@ -98,6 +108,7 @@ void stopMonitoringAsync();
 void playPauseAsync();
 void nextTrackAsync();
 void previousTrackAsync();
+void seekToAsync(qint64 positionMs);
 void nextSourceAsync();
 MediaWorker* getWorker();
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -244,6 +244,11 @@ ApplicationWindow {
         transientParent: panel
 
         onAvailableChanged: panel.handleMediaAvailabilityChanged()
+        onHeightChanged: {
+            if (visible && panel.visible) {
+                panel.repositionWindows()
+            }
+        }
         onHideRequested: panel.hidePanel()
     }
 

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -13,6 +13,14 @@ ColumnLayout {
     property real displayedPositionMs: 0
     property real positionBaselineMs: 0
     property real positionBaselineTimestampMs: 0
+    property bool positionBaselinePlaying: false
+    property real positionBaselinePlaybackRate: 1
+    property bool timelineIdentityValid: false
+    property string timelineSourceName: ""
+    property string timelineTitle: ""
+    property string timelineArtist: ""
+    property real timelineDurationMs: 0
+    readonly property real timelineCorrectionToleranceMs: 1500
     property bool seekGestureActive: false
     property string seekSourceName: ""
     property string seekTitle: ""
@@ -44,12 +52,48 @@ ColumnLayout {
         return totalMinutes + ":" + paddedSeconds
     }
 
+    function projectedPosition(timestampMs) {
+        let projectedPosition = positionBaselineMs
+        if (positionBaselinePlaying) {
+            projectedPosition += (timestampMs - positionBaselineTimestampMs)
+                * positionBaselinePlaybackRate
+        }
+        return clampPosition(projectedPosition)
+    }
+
     function synchronizeTimeline() {
         if (seekGestureActive) {
             return
         }
-        positionBaselineMs = clampPosition(MediaSessionBridge.mediaPositionMs)
-        positionBaselineTimestampMs = Date.now()
+
+        const timestampMs = Date.now()
+        const nativePositionMs = clampPosition(MediaSessionBridge.mediaPositionMs)
+        const sameTimeline = timelineIdentityValid
+            && MediaSessionBridge.hasMediaTimeline
+            && MediaSessionBridge.sourceName === timelineSourceName
+            && MediaSessionBridge.mediaTitle === timelineTitle
+            && MediaSessionBridge.mediaArtist === timelineArtist
+            && MediaSessionBridge.mediaDurationMs === timelineDurationMs
+
+        let synchronizedPositionMs = nativePositionMs
+        if (sameTimeline && positionBaselinePlaying && MediaSessionBridge.isMediaPlaying) {
+            const projectedPositionMs = projectedPosition(timestampMs)
+            if (Math.abs(nativePositionMs - projectedPositionMs)
+                    <= timelineCorrectionToleranceMs) {
+                synchronizedPositionMs = projectedPositionMs
+            }
+        }
+
+        timelineIdentityValid = MediaSessionBridge.hasMediaTimeline
+        timelineSourceName = MediaSessionBridge.sourceName
+        timelineTitle = MediaSessionBridge.mediaTitle
+        timelineArtist = MediaSessionBridge.mediaArtist
+        timelineDurationMs = MediaSessionBridge.mediaDurationMs
+        positionBaselineMs = synchronizedPositionMs
+        positionBaselineTimestampMs = timestampMs
+        positionBaselinePlaying = MediaSessionBridge.isMediaPlaying
+        positionBaselinePlaybackRate = Number.isFinite(MediaSessionBridge.mediaPlaybackRate)
+            ? MediaSessionBridge.mediaPlaybackRate : 1
         setDisplayedPosition(positionBaselineMs)
     }
 
@@ -57,13 +101,7 @@ ColumnLayout {
         if (!MediaSessionBridge.hasMediaTimeline || seekGestureActive) {
             return
         }
-        let projectedPosition = positionBaselineMs
-        if (MediaSessionBridge.isMediaPlaying) {
-            const rate = Number.isFinite(MediaSessionBridge.mediaPlaybackRate)
-                ? MediaSessionBridge.mediaPlaybackRate : 1
-            projectedPosition += (Date.now() - positionBaselineTimestampMs) * rate
-        }
-        setDisplayedPosition(projectedPosition)
+        setDisplayedPosition(projectedPosition(Date.now()))
     }
 
     function beginSeek() {
@@ -95,6 +133,9 @@ ColumnLayout {
             Math.min(MediaSessionBridge.mediaMaximumSeekMs, positionMs))
         positionBaselineMs = targetPosition
         positionBaselineTimestampMs = Date.now()
+        positionBaselinePlaying = MediaSessionBridge.isMediaPlaying
+        positionBaselinePlaybackRate = Number.isFinite(MediaSessionBridge.mediaPlaybackRate)
+            ? MediaSessionBridge.mediaPlaybackRate : 1
         setDisplayedPosition(targetPosition)
         MediaSessionBridge.seekTo(Math.round(targetPosition))
     }

--- a/qml/MediaFlyoutContent.qml
+++ b/qml/MediaFlyoutContent.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Window
 import QtQuick.Controls.FluentWinUI3
 import QtQuick.Controls.impl
 import ChrisLauinger77.QontrolPanel
@@ -9,9 +10,119 @@ ColumnLayout {
     opacity: 0
     spacing: 10
 
+    property real displayedPositionMs: 0
+    property real positionBaselineMs: 0
+    property real positionBaselineTimestampMs: 0
+    property bool seekGestureActive: false
+    property string seekSourceName: ""
+    property string seekTitle: ""
+    property string seekArtist: ""
+    property real seekDurationMs: 0
+
+    function clampPosition(positionMs) {
+        return Math.max(0, Math.min(MediaSessionBridge.mediaDurationMs, positionMs))
+    }
+
+    function setDisplayedPosition(positionMs) {
+        displayedPositionMs = clampPosition(positionMs)
+        if (!timelineSlider.pressed) {
+            timelineSlider.value = displayedPositionMs
+        }
+    }
+
+    function formatMediaTime(positionMs) {
+        const totalSeconds = Math.floor(Math.max(0, positionMs) / 1000)
+        const seconds = totalSeconds % 60
+        const totalMinutes = Math.floor(totalSeconds / 60)
+        const minutes = totalMinutes % 60
+        const hours = Math.floor(totalMinutes / 60)
+        const paddedSeconds = seconds < 10 ? "0" + seconds : seconds.toString()
+        if (hours > 0) {
+            const paddedMinutes = minutes < 10 ? "0" + minutes : minutes.toString()
+            return hours + ":" + paddedMinutes + ":" + paddedSeconds
+        }
+        return totalMinutes + ":" + paddedSeconds
+    }
+
+    function synchronizeTimeline() {
+        if (seekGestureActive) {
+            return
+        }
+        positionBaselineMs = clampPosition(MediaSessionBridge.mediaPositionMs)
+        positionBaselineTimestampMs = Date.now()
+        setDisplayedPosition(positionBaselineMs)
+    }
+
+    function updateDisplayedPosition() {
+        if (!MediaSessionBridge.hasMediaTimeline || seekGestureActive) {
+            return
+        }
+        let projectedPosition = positionBaselineMs
+        if (MediaSessionBridge.isMediaPlaying) {
+            const rate = Number.isFinite(MediaSessionBridge.mediaPlaybackRate)
+                ? MediaSessionBridge.mediaPlaybackRate : 1
+            projectedPosition += (Date.now() - positionBaselineTimestampMs) * rate
+        }
+        setDisplayedPosition(projectedPosition)
+    }
+
+    function beginSeek() {
+        seekGestureActive = true
+        seekSourceName = MediaSessionBridge.sourceName
+        seekTitle = MediaSessionBridge.mediaTitle
+        seekArtist = MediaSessionBridge.mediaArtist
+        seekDurationMs = MediaSessionBridge.mediaDurationMs
+    }
+
+    function finishSeek(positionMs) {
+        if (!seekGestureActive) {
+            return
+        }
+        seekGestureActive = false
+
+        const timelineUnchanged = MediaSessionBridge.hasMediaTimeline
+            && MediaSessionBridge.canSeek
+            && MediaSessionBridge.sourceName === seekSourceName
+            && MediaSessionBridge.mediaTitle === seekTitle
+            && MediaSessionBridge.mediaArtist === seekArtist
+            && MediaSessionBridge.mediaDurationMs === seekDurationMs
+        if (!timelineUnchanged) {
+            synchronizeTimeline()
+            return
+        }
+
+        const targetPosition = Math.max(MediaSessionBridge.mediaMinimumSeekMs,
+            Math.min(MediaSessionBridge.mediaMaximumSeekMs, positionMs))
+        positionBaselineMs = targetPosition
+        positionBaselineTimestampMs = Date.now()
+        setDisplayedPosition(targetPosition)
+        MediaSessionBridge.seekTo(Math.round(targetPosition))
+    }
+
     function finishOpacityAnimation() {
         opacityAnimation.stop()
         opacity = 1
+    }
+
+    Component.onCompleted: synchronizeTimeline()
+
+    Connections {
+        target: MediaSessionBridge
+
+        function onMediaInfoChanged() {
+            mediaLayout.synchronizeTimeline()
+        }
+    }
+
+    Timer {
+        interval: 250
+        repeat: true
+        running: mediaLayout.Window.window !== null
+            && mediaLayout.Window.window.visible
+            && MediaSessionBridge.hasMediaTimeline
+            && MediaSessionBridge.isMediaPlaying
+            && !mediaLayout.seekGestureActive
+        onTriggered: mediaLayout.updateDisplayedPosition()
     }
 
     Behavior on opacity {
@@ -134,12 +245,59 @@ ColumnLayout {
         }
 
         RowLayout {
+            id: timelineRow
+            objectName: "mediaTimelineRow"
+            Layout.fillWidth: true
+            visible: MediaSessionBridge.hasMediaTimeline
+                && MediaSessionBridge.mediaDurationMs > 0
+            spacing: 8
+
+            Label {
+                objectName: "mediaElapsedTime"
+                text: mediaLayout.formatMediaTime(mediaLayout.displayedPositionMs)
+                font.pixelSize: 11
+                horizontalAlignment: Text.AlignRight
+                Layout.minimumWidth: 36
+            }
+
+            Slider {
+                id: timelineSlider
+                objectName: "mediaTimelineSlider"
+                focusPolicy: Qt.NoFocus
+                enabled: MediaSessionBridge.canSeek
+                from: enabled ? MediaSessionBridge.mediaMinimumSeekMs : 0
+                to: enabled ? MediaSessionBridge.mediaMaximumSeekMs
+                            : MediaSessionBridge.mediaDurationMs
+                Layout.fillWidth: true
+
+                onMoved: mediaLayout.displayedPositionMs = value
+                onPressedChanged: {
+                    if (pressed) {
+                        mediaLayout.beginSeek()
+                    } else {
+                        mediaLayout.finishSeek(value)
+                    }
+                }
+            }
+
+            Label {
+                objectName: "mediaRemainingTime"
+                text: "-" + mediaLayout.formatMediaTime(
+                    MediaSessionBridge.mediaDurationMs - mediaLayout.displayedPositionMs)
+                font.pixelSize: 11
+                Layout.minimumWidth: 42
+            }
+        }
+
+        RowLayout {
             Item {
                 Layout.fillWidth: true
             }
 
             ToolButton {
+                objectName: "mediaPreviousButton"
                 icon.source: "qrc:/icons/prev.png"
+                enabled: MediaSessionBridge.canPreviousTrack
                 onClicked: MediaSessionBridge.previousTrack()
                 Layout.preferredWidth: 40
                 Layout.preferredHeight: 40

--- a/src/mediasessionbridge.cpp
+++ b/src/mediasessionbridge.cpp
@@ -19,6 +19,14 @@ MediaSessionBridge::MediaSessionBridge(QObject* parent)
                     m_sourceName = info.sourceName;
                     m_sourceIcon = info.sourceIcon;
                     m_sourceCount = info.sourceCount;
+                    m_canPreviousTrack = info.canPreviousTrack;
+                    m_hasMediaTimeline = info.hasMediaTimeline;
+                    m_canSeek = info.canSeek;
+                    m_mediaPositionMs = info.mediaPositionMs;
+                    m_mediaDurationMs = info.mediaDurationMs;
+                    m_mediaMinimumSeekMs = info.mediaMinimumSeekMs;
+                    m_mediaMaximumSeekMs = info.mediaMaximumSeekMs;
+                    m_mediaPlaybackRate = info.mediaPlaybackRate;
                     emit mediaInfoChanged();
                 });
     }
@@ -85,6 +93,38 @@ int MediaSessionBridge::sourceCount() const {
     return m_sourceCount;
 }
 
+bool MediaSessionBridge::canPreviousTrack() const {
+    return m_canPreviousTrack;
+}
+
+bool MediaSessionBridge::hasMediaTimeline() const {
+    return m_hasMediaTimeline;
+}
+
+bool MediaSessionBridge::canSeek() const {
+    return m_canSeek;
+}
+
+qint64 MediaSessionBridge::mediaPositionMs() const {
+    return m_mediaPositionMs;
+}
+
+qint64 MediaSessionBridge::mediaDurationMs() const {
+    return m_mediaDurationMs;
+}
+
+qint64 MediaSessionBridge::mediaMinimumSeekMs() const {
+    return m_mediaMinimumSeekMs;
+}
+
+qint64 MediaSessionBridge::mediaMaximumSeekMs() const {
+    return m_mediaMaximumSeekMs;
+}
+
+double MediaSessionBridge::mediaPlaybackRate() const {
+    return m_mediaPlaybackRate;
+}
+
 void MediaSessionBridge::playPause() {
     MediaSessionManager::playPauseAsync();
 }
@@ -95,6 +135,10 @@ void MediaSessionBridge::nextTrack() {
 
 void MediaSessionBridge::previousTrack() {
     MediaSessionManager::previousTrackAsync();
+}
+
+void MediaSessionBridge::seekTo(qint64 positionMs) {
+    MediaSessionManager::seekToAsync(positionMs);
 }
 
 void MediaSessionBridge::nextSource() {

--- a/src/mediasessionmanager.cpp
+++ b/src/mediasessionmanager.cpp
@@ -277,8 +277,17 @@ MediaInfo queryMediaInfoImpl(MediaWorker* worker) {
                 info.artist = QString::fromWCharArray(properties.Artist().c_str());
                 info.album = QString::fromWCharArray(properties.AlbumTitle().c_str());
 
-                LOG_INFO("MediaSessionManager",
-                                                QString("Retrieved media info: %1 - %2").arg(info.artist, info.title));
+                if (!worker->m_mediaIdentityLogged
+                    || worker->m_lastLoggedTitle != info.title
+                    || worker->m_lastLoggedArtist != info.artist
+                    || worker->m_lastLoggedAlbum != info.album) {
+                    LOG_INFO("MediaSessionManager",
+                             QString("Retrieved media info: %1 - %2").arg(info.artist, info.title));
+                    worker->m_mediaIdentityLogged = true;
+                    worker->m_lastLoggedTitle = info.title;
+                    worker->m_lastLoggedArtist = info.artist;
+                    worker->m_lastLoggedAlbum = info.album;
+                }
 
                 // Fetch album art
                 try {
@@ -341,7 +350,6 @@ MediaInfo queryMediaInfoImpl(MediaWorker* worker) {
                                     } else if (worker) {
                                         // Use cached processed album art
                                         info.albumArt = worker->m_cachedProcessedAlbumArt;
-                                        LOG_INFO("MediaSessionManager", "Using cached album art");
                                     }
                                 }
                             }
@@ -370,8 +378,14 @@ MediaInfo queryMediaInfoImpl(MediaWorker* worker) {
                 if (playbackRate && std::isfinite(playbackRate.Value())) {
                     info.mediaPlaybackRate = playbackRate.Value();
                 }
-                LOG_INFO("MediaSessionManager",
-                                                QString("Playback status: %1").arg(info.isPlaying ? "Playing" : "Paused/Stopped"));
+                if (!worker->m_playbackStatusLogged
+                    || worker->m_lastLoggedPlaying != info.isPlaying) {
+                    LOG_INFO("MediaSessionManager",
+                             QString("Playback status: %1")
+                                 .arg(info.isPlaying ? "Playing" : "Paused/Stopped"));
+                    worker->m_playbackStatusLogged = true;
+                    worker->m_lastLoggedPlaying = info.isPlaying;
+                }
             }
 
             auto timeline = currentSession.GetTimelineProperties();
@@ -497,6 +511,7 @@ bool MediaWorker::ensureCurrentSession() {
             // Clear cache when session changes
             m_cachedRawAlbumArt.clear();
             m_cachedProcessedAlbumArt.clear();
+            resetRoutineLogState();
             LOG_INFO("MediaSessionManager", "Album art cache cleared due to session change");
 
             cleanupSessionNotifications();
@@ -629,6 +644,7 @@ void MediaWorker::startMonitoring() {
     // Clear cache on start
     m_cachedRawAlbumArt.clear();
     m_cachedProcessedAlbumArt.clear();
+    resetRoutineLogState();
 
     setupSessionManagerNotifications();
     ensureCurrentSession();
@@ -944,4 +960,15 @@ void MediaWorker::resetSessionManager()
     m_currentSession = nullptr;
     m_sessionManager = nullptr;
     m_sourceSelectedManually = false;
+    resetRoutineLogState();
+}
+
+void MediaWorker::resetRoutineLogState()
+{
+    m_mediaIdentityLogged = false;
+    m_lastLoggedTitle.clear();
+    m_lastLoggedArtist.clear();
+    m_lastLoggedAlbum.clear();
+    m_playbackStatusLogged = false;
+    m_lastLoggedPlaying = false;
 }

--- a/src/mediasessionmanager.cpp
+++ b/src/mediasessionmanager.cpp
@@ -2,6 +2,7 @@
 #include <shobjidl.h>
 #include <shlobj.h>
 #include <shellapi.h>
+#include <algorithm>
 #include "mediasessionmanager.h"
 #include "logmanager.h"
 #include "workerthreads.h"
@@ -23,6 +24,7 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <cstring>
+#include <cmath>
 #include <vector>
 
 using namespace winrt;
@@ -192,6 +194,11 @@ void resolveSourceIdentity(const QString& sourceId, QString& sourceName, QString
     }
 }
 
+qint64 timeSpanToMilliseconds(const TimeSpan& value)
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(value).count();
+}
+
 } // namespace
 
 QImage createRoundedImage(const QImage& source, int targetSize, int radius)
@@ -327,11 +334,52 @@ MediaInfo queryMediaInfoImpl(MediaWorker* worker) {
                 }
             }
 
+            bool playbackPositionEnabled = false;
             auto playbackInfo = currentSession.GetPlaybackInfo();
             if (playbackInfo) {
                 info.isPlaying = (playbackInfo.PlaybackStatus() == GlobalSystemMediaTransportControlsSessionPlaybackStatus::Playing);
+                auto controls = playbackInfo.Controls();
+                if (controls) {
+                    info.canPreviousTrack = controls.IsPreviousEnabled();
+                    playbackPositionEnabled = controls.IsPlaybackPositionEnabled();
+                }
+                auto playbackRate = playbackInfo.PlaybackRate();
+                if (playbackRate && std::isfinite(playbackRate.Value())) {
+                    info.mediaPlaybackRate = playbackRate.Value();
+                }
                 LOG_INFO("MediaSessionManager",
                                                 QString("Playback status: %1").arg(info.isPlaying ? "Playing" : "Paused/Stopped"));
+            }
+
+            auto timeline = currentSession.GetTimelineProperties();
+            if (timeline) {
+                const qint64 startMs = timeSpanToMilliseconds(timeline.StartTime());
+                const qint64 endMs = timeSpanToMilliseconds(timeline.EndTime());
+                if (endMs > startMs) {
+                    info.hasMediaTimeline = true;
+                    info.mediaDurationMs = endMs - startMs;
+
+                    long double positionMs = timeSpanToMilliseconds(timeline.Position()) - startMs;
+                    const auto lastUpdatedTime = timeline.LastUpdatedTime();
+                    if (info.isPlaying && lastUpdatedTime.time_since_epoch().count() > 0) {
+                        const auto sinceUpdate = winrt::clock::now() - lastUpdatedTime;
+                        const qint64 sinceUpdateMs = qMax<qint64>(
+                            0, std::chrono::duration_cast<std::chrono::milliseconds>(sinceUpdate).count());
+                        positionMs += static_cast<long double>(sinceUpdateMs)
+                            * info.mediaPlaybackRate;
+                    }
+                    info.mediaPositionMs = static_cast<qint64>(std::clamp(
+                        positionMs, static_cast<long double>(0),
+                        static_cast<long double>(info.mediaDurationMs)));
+                    info.mediaMinimumSeekMs = std::clamp(
+                        timeSpanToMilliseconds(timeline.MinSeekTime()) - startMs,
+                        qint64{0}, info.mediaDurationMs);
+                    info.mediaMaximumSeekMs = std::clamp(
+                        timeSpanToMilliseconds(timeline.MaxSeekTime()) - startMs,
+                        qint64{0}, info.mediaDurationMs);
+                    info.canSeek = playbackPositionEnabled
+                        && info.mediaMaximumSeekMs > info.mediaMinimumSeekMs;
+                }
             }
         } else {
             LOG_INFO("MediaSessionManager", "No active media session found");
@@ -457,6 +505,8 @@ void MediaWorker::setupSessionNotifications() {
             [target = m_callbackTarget](auto const&, auto const&) { queueMediaRefresh(target); });
         m_playbackInfoChangedToken = m_currentSession.PlaybackInfoChanged(
             [target = m_callbackTarget](auto const&, auto const&) { queueMediaRefresh(target, false, true); });
+        m_timelinePropertiesChangedToken = m_currentSession.TimelinePropertiesChanged(
+            [target = m_callbackTarget](auto const&, auto const&) { queueMediaRefresh(target); });
     }
     catch (const hresult_error& error)
     {
@@ -484,6 +534,8 @@ void MediaWorker::cleanupSessionNotifications() {
     };
     revoke(m_propertiesChangedToken, [&](auto token) { m_currentSession.MediaPropertiesChanged(token); });
     revoke(m_playbackInfoChangedToken, [&](auto token) { m_currentSession.PlaybackInfoChanged(token); });
+    revoke(m_timelinePropertiesChangedToken,
+           [&](auto token) { m_currentSession.TimelinePropertiesChanged(token); });
         }
 
 MediaWorker::MediaWorker()
@@ -637,6 +689,12 @@ void MediaWorker::previousTrack() {
 
     try {
         if (ensureCurrentSession() && m_currentSession) {
+            const auto playbackInfo = m_currentSession.GetPlaybackInfo();
+            if (!playbackInfo || !playbackInfo.Controls()
+                || !playbackInfo.Controls().IsPreviousEnabled()) {
+                LOG_WARN("MediaSessionManager", "Previous track is not available for the active session");
+                return;
+            }
             if (!awaitResult(m_currentSession.TrySkipPreviousAsync(), m_stopRequested))
             {
                 LOG_WARN("MediaSessionManager", "Media source rejected transport command");
@@ -654,6 +712,61 @@ void MediaWorker::previousTrack() {
                                             .arg(static_cast<qint32>(error.code()), 0, 16)
                                             .arg(QString::fromWCharArray(error.message().c_str())));
         LOG_CRITICAL("MediaSessionManager", "Failed to skip to previous track");
+    }
+}
+
+void MediaWorker::seekTo(qint64 positionMs) {
+    LOG_INFO("MediaSessionManager", QString("Seeking to %1ms").arg(positionMs));
+
+    bool refreshMediaInfo = false;
+    try {
+        if (ensureCurrentSession() && m_currentSession) {
+            const auto playbackInfo = m_currentSession.GetPlaybackInfo();
+            if (!playbackInfo || !playbackInfo.Controls()
+                || !playbackInfo.Controls().IsPlaybackPositionEnabled()) {
+                LOG_WARN("MediaSessionManager", "Seeking is not available for the active session");
+                return;
+            }
+
+            const auto timeline = m_currentSession.GetTimelineProperties();
+            if (!timeline || timeline.EndTime() <= timeline.StartTime()) {
+                LOG_WARN("MediaSessionManager", "Active session has no valid seekable timeline");
+                return;
+            }
+
+            const auto minimumSeekTime = std::max(timeline.StartTime(), timeline.MinSeekTime());
+            const auto maximumSeekTime = std::min(timeline.EndTime(), timeline.MaxSeekTime());
+            if (maximumSeekTime <= minimumSeekTime) {
+                LOG_WARN("MediaSessionManager", "Active session has no valid seekable range");
+                return;
+            }
+
+            const auto requestedOffset = std::chrono::duration_cast<TimeSpan>(
+                std::chrono::milliseconds(qMax<qint64>(0, positionMs)));
+            const auto requestedPosition = std::clamp(
+                timeline.StartTime() + requestedOffset,
+                minimumSeekTime, maximumSeekTime);
+            refreshMediaInfo = true;
+            if (awaitResult(m_currentSession.TryChangePlaybackPositionAsync(requestedPosition.count()),
+                            m_stopRequested)) {
+                LOG_INFO("MediaSessionManager", "Playback position changed successfully");
+            } else {
+                LOG_WARN("MediaSessionManager", "Media source rejected playback position change");
+            }
+        } else {
+            LOG_WARN("MediaSessionManager", "No active session for playback position change");
+        }
+    }
+    catch (const hresult_error& error)
+    {
+        LOG_WARN("MediaSessionManager", QString("WinRT error %1: %2")
+                                            .arg(static_cast<qint32>(error.code()), 0, 16)
+                                            .arg(QString::fromWCharArray(error.message().c_str())));
+        LOG_CRITICAL("MediaSessionManager", "Failed to change playback position");
+    }
+
+    if (refreshMediaInfo && m_running && !m_stopRequested.load()) {
+        queryMediaInfo();
     }
 }
 
@@ -756,6 +869,13 @@ void MediaSessionManager::nextTrackAsync() {
 void MediaSessionManager::previousTrackAsync() {
     if (g_mediaWorker) {
         QMetaObject::invokeMethod(g_mediaWorker, "previousTrack", Qt::QueuedConnection);
+    }
+}
+
+void MediaSessionManager::seekToAsync(qint64 positionMs) {
+    if (g_mediaWorker) {
+        QMetaObject::invokeMethod(g_mediaWorker, "seekTo", Qt::QueuedConnection,
+                                  Q_ARG(qint64, positionMs));
     }
 }
 

--- a/src/mediasessionmanager.cpp
+++ b/src/mediasessionmanager.cpp
@@ -77,6 +77,29 @@ namespace {
             Qt::QueuedConnection);
 }
 
+    void queueMediaTimelineRefresh(const std::shared_ptr<MediaCallbackTarget>& target)
+    {
+        QMutexLocker guard(&target->mutex);
+        auto* worker = target->worker;
+        if (!worker || target->timelineRefreshPending)
+            return;
+        target->timelineRefreshPending = true;
+        const bool queued = QMetaObject::invokeMethod(
+            worker,
+            [target, worker] {
+                {
+                    QMutexLocker guard(&target->mutex);
+                    target->timelineRefreshPending = false;
+                    if (target->worker != worker)
+                        return;
+                }
+                worker->handleMediaEvent(false, false);
+            },
+            Qt::QueuedConnection);
+        if (!queued)
+            target->timelineRefreshPending = false;
+    }
+
     using namespace NativeImage;
 
 QString executableDisplayName(const QString& executablePath)
@@ -506,7 +529,7 @@ void MediaWorker::setupSessionNotifications() {
         m_playbackInfoChangedToken = m_currentSession.PlaybackInfoChanged(
             [target = m_callbackTarget](auto const&, auto const&) { queueMediaRefresh(target, false, true); });
         m_timelinePropertiesChangedToken = m_currentSession.TimelinePropertiesChanged(
-            [target = m_callbackTarget](auto const&, auto const&) { queueMediaRefresh(target); });
+            [target = m_callbackTarget](auto const&, auto const&) { queueMediaTimelineRefresh(target); });
     }
     catch (const hresult_error& error)
     {

--- a/tests/qml/SettingsUiStubs.qml
+++ b/tests/qml/SettingsUiStubs.qml
@@ -42,4 +42,29 @@ QtObject {
     function setTestModeEnabled(value) { testModeEnabled = value }
     function setTestProfile(value) { testProfile = value }
     function refreshNow() {}
+
+    property string mediaTitle: "Test title"
+    property string mediaArtist: "Test artist"
+    property bool isMediaPlaying: false
+    property string mediaArt: ""
+    property string sourceName: "Test player"
+    property string sourceIcon: ""
+    property int sourceCount: 1
+    property bool canPreviousTrack: false
+    property bool hasMediaTimeline: false
+    property bool canSeek: false
+    property real mediaPositionMs: 0
+    property real mediaDurationMs: 0
+    property real mediaMinimumSeekMs: 0
+    property real mediaMaximumSeekMs: 0
+    property real mediaPlaybackRate: 1
+    property int previousTrackCount: 0
+    property int seekCount: 0
+    property real lastSeekPositionMs: -1
+    signal mediaInfoChanged()
+    function previousTrack() { previousTrackCount++ }
+    function playPause() {}
+    function nextTrack() {}
+    function nextSource() {}
+    function seekTo(positionMs) { seekCount++; lastSeekPositionMs = positionMs }
 }

--- a/tests/settings_ui_tests.cpp
+++ b/tests/settings_ui_tests.cpp
@@ -74,6 +74,7 @@ class SettingsUiTests : public QObject
     std::unique_ptr<QQuickWindow> m_window;
     std::unique_ptr<QObject> m_pane;
     int m_audioType = -1;
+    int m_mediaType = -1;
 
     QObject* loadPane(const QString& name)
     {
@@ -93,6 +94,24 @@ class SettingsUiTests : public QObject
         return m_pane.get();
     }
 
+    QObject* loadMediaFlyout()
+    {
+        m_window = std::make_unique<QQuickWindow>();
+        m_window->resize(360, 220);
+        m_engine = std::make_unique<QQmlEngine>();
+        QQmlComponent component(m_engine.get(), sourceUrl("qml/MediaFlyoutContent.qml"));
+        if (component.isError())
+            qWarning().noquote() << component.errorString();
+        m_pane.reset(component.create());
+        if (auto* item = qobject_cast<QQuickItem*>(m_pane.get())) {
+            item->setParentItem(m_window->contentItem());
+            item->setSize(m_window->size());
+        }
+        m_window->show();
+        QCoreApplication::processEvents();
+        return m_pane.get();
+    }
+
     HANDLE lockPreferences()
     {
         return CreateFileW(reinterpret_cast<LPCWSTR>(m_preferencesPath.utf16()), GENERIC_READ,
@@ -100,6 +119,13 @@ class SettingsUiTests : public QObject
     }
 
     QObject* audio() { return m_engine->singletonInstance<QObject*>(m_audioType); }
+    QObject* media() { return m_engine->singletonInstance<QObject*>(m_mediaType); }
+
+    void publishMediaInfo()
+    {
+        QVERIFY(QMetaObject::invokeMethod(media(), "mediaInfoChanged"));
+        QCoreApplication::processEvents();
+    }
 
 private slots:
     void initTestCase()
@@ -125,6 +151,7 @@ private slots:
             qmlRegisterSingletonType(sourceUrl("tests/qml/SettingsUiStubs.qml"), Module, 1, 0, name);
         qmlRegisterSingletonType(sourceUrl("qml/Singletons/Context.qml"), Module, 1, 0, "Context");
         m_audioType = qmlRegisterSingletonType(sourceUrl("tests/qml/SettingsUiStubs.qml"), Module, 1, 0, "AudioBridge");
+        m_mediaType = qmlRegisterSingletonType(sourceUrl("tests/qml/SettingsUiStubs.qml"), Module, 1, 0, "MediaSessionBridge");
     }
 
     void init()
@@ -266,6 +293,109 @@ private slots:
         QVERIFY(!settings->settingsAnimationsEnabled());
         QCOMPARE(panelChanged.size(), 1);
         QCOMPARE(settingsChanged.size(), 1);
+    }
+
+    void mediaPreviousCapabilityControlsButton()
+    {
+        QVERIFY(loadMediaFlyout());
+        auto* previousButton = m_pane->findChild<QObject*>("mediaPreviousButton");
+        QVERIFY(previousButton);
+        QVERIFY(!previousButton->property("enabled").toBool());
+
+        media()->setProperty("canPreviousTrack", true);
+        QTRY_VERIFY(previousButton->property("enabled").toBool());
+        QVERIFY(QMetaObject::invokeMethod(previousButton, "click"));
+        QCOMPARE(media()->property("previousTrackCount").toInt(), 1);
+    }
+
+    void mediaTimelinePresentation()
+    {
+        QVERIFY(loadMediaFlyout());
+        auto* timelineRow = m_pane->findChild<QObject*>("mediaTimelineRow");
+        auto* slider = m_pane->findChild<QObject*>("mediaTimelineSlider");
+        auto* elapsed = m_pane->findChild<QObject*>("mediaElapsedTime");
+        auto* remaining = m_pane->findChild<QObject*>("mediaRemainingTime");
+        QVERIFY(timelineRow);
+        QVERIFY(slider);
+        QVERIFY(elapsed);
+        QVERIFY(remaining);
+        QVERIFY(!timelineRow->property("visible").toBool());
+
+        media()->setProperty("hasMediaTimeline", true);
+        media()->setProperty("canSeek", false);
+        media()->setProperty("mediaPositionMs", 65000);
+        media()->setProperty("mediaDurationMs", 200000);
+        publishMediaInfo();
+        QTRY_VERIFY(timelineRow->property("visible").toBool());
+        QVERIFY(!slider->property("enabled").toBool());
+        QCOMPARE(elapsed->property("text").toString(), QStringLiteral("1:05"));
+        QCOMPARE(remaining->property("text").toString(), QStringLiteral("-2:15"));
+
+        media()->setProperty("mediaPositionMs", 3661000);
+        media()->setProperty("mediaDurationMs", 7322000);
+        publishMediaInfo();
+        QCOMPARE(elapsed->property("text").toString(), QStringLiteral("1:01:01"));
+        QCOMPARE(remaining->property("text").toString(), QStringLiteral("-1:01:01"));
+
+        media()->setProperty("mediaDurationMs", 0);
+        publishMediaInfo();
+        QTRY_VERIFY(!timelineRow->property("visible").toBool());
+    }
+
+    void mediaTimelineClockFollowsPlayback()
+    {
+        QVERIFY(loadMediaFlyout());
+        media()->setProperty("hasMediaTimeline", true);
+        media()->setProperty("mediaPositionMs", 1000);
+        media()->setProperty("mediaDurationMs", 10000);
+        media()->setProperty("mediaPlaybackRate", 4.0);
+        media()->setProperty("isMediaPlaying", true);
+        publishMediaInfo();
+        QTRY_VERIFY(m_pane->property("displayedPositionMs").toDouble() > 1500);
+
+        media()->setProperty("isMediaPlaying", false);
+        publishMediaInfo();
+        const double pausedPosition = m_pane->property("displayedPositionMs").toDouble();
+        QTest::qWait(350);
+        QVERIFY(qAbs(m_pane->property("displayedPositionMs").toDouble() - pausedPosition) < 1.0);
+
+        media()->setProperty("mediaPositionMs", 9500);
+        media()->setProperty("mediaPlaybackRate", 100.0);
+        media()->setProperty("isMediaPlaying", true);
+        publishMediaInfo();
+        QTRY_COMPARE(m_pane->property("displayedPositionMs").toDouble(), 10000.0);
+    }
+
+    void mediaSeekCommitsOnceOnRelease()
+    {
+        QVERIFY(loadMediaFlyout());
+        media()->setProperty("hasMediaTimeline", true);
+        media()->setProperty("canSeek", true);
+        media()->setProperty("mediaPositionMs", 1000);
+        media()->setProperty("mediaDurationMs", 10000);
+        media()->setProperty("mediaMinimumSeekMs", 0);
+        media()->setProperty("mediaMaximumSeekMs", 10000);
+        publishMediaInfo();
+
+        auto* slider = qobject_cast<QQuickItem*>(m_pane->findChild<QObject*>("mediaTimelineSlider"));
+        QVERIFY(slider);
+        QVERIFY(slider->width() > 0);
+        QVERIFY(slider->height() > 0);
+        const QPoint pressPoint = slider->mapToScene(
+            QPointF(slider->width() * 0.1, slider->height() * 0.5)).toPoint();
+        const QPoint movePoint = slider->mapToScene(
+            QPointF(slider->width() * 0.75, slider->height() * 0.5)).toPoint();
+
+        QTest::mousePress(m_window.get(), Qt::LeftButton, Qt::NoModifier, pressPoint);
+        QTRY_VERIFY(slider->property("pressed").toBool());
+        QTest::mouseMove(m_window.get(), movePoint, 50);
+        QCOMPARE(media()->property("seekCount").toInt(), 0);
+        QTRY_VERIFY(m_pane->property("displayedPositionMs").toDouble() > 1000);
+        QTest::mouseRelease(m_window.get(), Qt::LeftButton, Qt::NoModifier, movePoint);
+        QTRY_COMPARE(media()->property("seekCount").toInt(), 1);
+        QVERIFY(media()->property("lastSeekPositionMs").toDouble() > 1000);
+        QTest::qWait(300);
+        QCOMPARE(media()->property("seekCount").toInt(), 1);
     }
 
     void rejectedEditor_data()

--- a/tests/settings_ui_tests.cpp
+++ b/tests/settings_ui_tests.cpp
@@ -366,6 +366,32 @@ private slots:
         QTRY_COMPARE(m_pane->property("displayedPositionMs").toDouble(), 10000.0);
     }
 
+    void mediaTimelineSuppressesSmallPlayingCorrections()
+    {
+        QVERIFY(loadMediaFlyout());
+        media()->setProperty("hasMediaTimeline", true);
+        media()->setProperty("mediaPositionMs", 1000);
+        media()->setProperty("mediaDurationMs", 10000);
+        media()->setProperty("mediaPlaybackRate", 1.0);
+        media()->setProperty("isMediaPlaying", true);
+        publishMediaInfo();
+        QTRY_VERIFY(m_pane->property("displayedPositionMs").toDouble() >= 1200.0);
+
+        const double beforeCorrection = m_pane->property("displayedPositionMs").toDouble();
+        media()->setProperty("mediaPositionMs", beforeCorrection - 500.0);
+        publishMediaInfo();
+        QVERIFY(m_pane->property("displayedPositionMs").toDouble() >= beforeCorrection);
+
+        media()->setProperty("mediaPositionMs", 7000);
+        publishMediaInfo();
+        QCOMPARE(m_pane->property("displayedPositionMs").toDouble(), 7000.0);
+
+        media()->setProperty("mediaPositionMs", 4000);
+        media()->setProperty("isMediaPlaying", false);
+        publishMediaInfo();
+        QCOMPARE(m_pane->property("displayedPositionMs").toDouble(), 4000.0);
+    }
+
     void mediaSeekCommitsOnceOnRelease()
     {
         QVERIFY(loadMediaFlyout());


### PR DESCRIPTION
## Summary

- disable the previous-track button when the active media source reports no previous item
- show elapsed and remaining time with a live timeline in the media flyout
- seek once on slider release when the source supports playback-position changes
- keep timeline movement smooth when players such as Apple Music publish frequent position corrections
- prevent media debug-log flooding by logging metadata and playback status only when they change
- add Windows QML fixture coverage and document the expanded media bridge
- move the BUILDING and TRANSLATIONS guides to the repository root and update their links
- bump the application version to 2.4.0 and update the pinned HeadsetControl revision

## Verification

- Windows Release configuration and build succeeded with MSVC and Qt 6.11.2
- Release CTest: 4/4 passed
  - `nightlight_data`
  - `release_provenance`
  - `qt_reliability`
  - `settings_ui`
- install target and Qt runtime deployment succeeded
- installed-runtime validation completed:
  - YouTube timeline moves smoothly and supports seeking
  - slider dragging sends one seek request on release
  - Apple Music timeline moves smoothly
  - Apple Music remains non-seekable when it reports no usable playback-position capability
  - media timeline updates no longer flood the debug log
- documentation links verified locally
- `git diff --check` passed